### PR TITLE
eval: run real100 v2 reranker budget screening

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -100,6 +100,7 @@ ALLOWED_PATTERNS=(
   '^reports/real100_v2/baseline\.aggregate\.json$'
   '^reports/real100_v2/benchmark_tiers\.aggregate\.json$'
   '^reports/real100_v2/latency_cost_budget\.aggregate\.json$'
+  '^reports/real100_v2/reranker_candidate_budget\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.md$'
   '^reports/real100_v2/retrieval_diagnostics\.aggregate\.json$'

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ reports/real100_v2/*
 !reports/real100_v2/benchmark_tiers.aggregate.json
 !reports/real100_v2/baseline.aggregate.json
 !reports/real100_v2/latency_cost_budget.aggregate.json
+!reports/real100_v2/reranker_candidate_budget.aggregate.json
 !reports/real100_v2/metric_suite.aggregate.json
 !reports/real100_v2/metric_suite.md
 !reports/real100_v2/retrieval_diagnostics.aggregate.json

--- a/docs/evaluation/real100_v2-reranker-candidate-budget.md
+++ b/docs/evaluation/real100_v2-reranker-candidate-budget.md
@@ -1,0 +1,30 @@
+# real100_v2 Reranker Candidate-Budget Sweep
+
+This report is aggregate-only. It contains no raw questions, answers, evidence text, filenames, local paths, document identifiers, chunk identifiers, or per-case rows. Legacy `real100`, v1, 221, and kordoc evidence is not used.
+
+## Decision
+
+- Overall classification: `latency_regression`
+- Selected variant: `-`
+- Paired delta valid: `False`
+- Subset run: `True`
+- Latency hard ceiling ms: `4799.0000`
+- Cost status: `not_observable_from_committed_aggregate`
+
+## Control
+
+| Variant | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | p50 ms | p95 ms |
+|---|---:|---:|---:|---:|---:|---:|
+| control_no_cross_encoder_top20 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 13700.6600 | 16842.9560 |
+
+## Candidate Variants
+
+| Variant | Pool | top_n | preR@N | postR@N | dMRR | dNDCG@10 | fallback | p95 ms | Classification |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| reranker_budget_pool30_topn10_top20 | 30.0000 | 10.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 149369.5710 | latency_regression |
+
+## Notes
+
+- Candidate-pool recall is measured before cross-encoder reranking; reranker precision is measured as MRR/nDCG movement after reranking.
+- `winner` requires material retrieval or reranker-precision gain with no ranking, citation, latency, or fallback regression.
+- `paired_delta_valid=false` means this artifact is screening evidence only and must not be used as a headline private eval improvement claim.

--- a/docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
+++ b/docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
@@ -1,9 +1,9 @@
 # Plan: T-2026-0032 reranker candidate-budget experiment
 
-- Status: proposed
+- Status: review
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0032`
-- Related issue / PR: [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624)
+- Related issue / PR: plan [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624); implementation [#1629](https://github.com/hskim-solv/BidMate-DocAgent/issues/1629) / PR TBD
 - Related ADR: [ADR 0001](../adr/0001-preserve-naive-baseline.md), [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0026](../adr/0026-cross-encoder-reranker-deferral.md)
 - Created: 2026-05-28
 - Last updated: 2026-05-28
@@ -34,6 +34,9 @@ The repo already has a cross-encoder reranker surface:
   v2 diagnostic trigger: dominant exclusive retrieval status is
   `not_observable_limited_depth`, page metadata coverage is 0.0, and
   `T-2026-0032` is preferred while `T-2026-0031` is blocked.
+- `reports/real100_v2/latency_cost_budget.aggregate.json` sets the current
+  baseline hard no-go latency ceiling at 4799 ms and marks cost telemetry as
+  not observable from the committed aggregate.
 
 ## Desired Behavior
 
@@ -105,13 +108,13 @@ or failed experiment.
 
 ## Acceptance Criteria
 
-- [ ] Sweep output classifies winner, recall-only gain, ranking regression,
+- [x] Sweep output classifies winner, recall-only gain, ranking regression,
   citation regression, latency regression, or failed experiment.
-- [ ] Candidate-pool recall and reranker precision are reported separately.
-- [ ] Reranker provenance is present in aggregate output.
-- [ ] Latency/cost guardrail from `T-2026-0030` is present or this task remains
+- [x] Candidate-pool recall and reranker precision are reported separately.
+- [x] Reranker provenance is present in aggregate output.
+- [x] Latency/cost guardrail from `T-2026-0030` is present or this task remains
   blocked.
-- [ ] No legacy `real100`/v1/221/kordoc evidence is used.
+- [x] No legacy `real100`/v1/221/kordoc evidence is used.
 
 ## Validation Strategy
 
@@ -119,7 +122,7 @@ Commands that must be run by the implementation PR:
 
 ```bash
 python3 -m pytest -q tests/test_reranker*.py <focused-new-tests>
-python3 <reranker-sweep-script> --config <local-v2-config> --out <aggregate-output>
+python3 scripts/run_real100_v2_reranker_budget_sweep.py --config <local-v2-config> --index-dir <local-v2-index> --cases-subset-n 3 --candidate-pools 30 --reranker-top-ns 10 --reranker-backend bge_ko
 python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <real100_v2-variant-aggregate>
 make real-eval-v2-guard
 python3 scripts/agent_loop.py privacy-audit-output
@@ -163,7 +166,8 @@ private `real100_v2` raw run artifacts or indexes during rollback.
 ## Observability
 
 - `reports/real100_v2/retrieval_diagnostics.aggregate.json`
-- Future sweep aggregate and Markdown report
+- `reports/real100_v2/reranker_candidate_budget.aggregate.json`
+- `docs/evaluation/real100_v2-reranker-candidate-budget.md`
 - `rerank_delta_mrr`, `rerank_delta_ndcg_at_10`, `retrieval_metrics`, and
   `stage_latency`
 - `make real-eval-v2-guard`
@@ -177,6 +181,23 @@ wins only by hiding candidate-pool recall, regresses citation behavior, or
 exceeds the latency/cost envelope.
 
 ## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 12:30 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1629-run-real100-v2-reranker-candidate-budget-experim / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1629 / PR TBD
+- Task: T-2026-0032
+- Current status: runner/report implemented; 3-case `real100_v2` BGE-KO screening classifies `latency_regression`.
+- Files touched: scripts/run_real100_v2_reranker_budget_sweep.py, tests/test_real100_v2_reranker_budget_sweep.py, reports/real100_v2/reranker_candidate_budget.aggregate.json, docs/evaluation/real100_v2-reranker-candidate-budget.md, reports/real100_v2/README.md, .gitignore, .githooks/pre-commit, scripts/check_real100_v2_only.py, docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md, tasks/queue.md
+- Decisions made: no winner and no headline improvement claim; paired_delta_valid=false because this was a 3-case screening run; local BGE-KO reranker latency exceeds the 4799 ms hard no-go ceiling by a large margin.
+- Commands run: make ship-start TITLE="Run real100 v2 reranker candidate budget experiment" TYPE=eval; make check-branch; python3 -m py_compile scripts/run_real100_v2_reranker_budget_sweep.py; python3 -m pytest -q tests/test_real100_v2_reranker_budget_sweep.py; python3 scripts/run_real100_v2_reranker_budget_sweep.py --config <external_private_real100_v2_config> --index-dir <external_private_real100_v2_index> --cases-subset-n 3 --candidate-pools 30 --reranker-top-ns 10 --reranker-backend bge_ko.
+- Results: aggregate/report written; candidate-pool recall and reranker precision separated; reranker provenance captured as backend bge_ko and model safe label dragonkue__bge-reranker-v2-m3-ko.
+- Next safe command: make real-eval-v2-guard && python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md docs/evaluation/real100_v2-reranker-candidate-budget.md reports/real100_v2/README.md
+- Open questions: whether to run any further reranker backend requires a GPU or explicit latency budget exception; current CPU local backend is no-go.
+- Risks: subset run is screening evidence only, not paired full private eval delta.
+```
 
 ```markdown
 ## Session Handoff - 2026-05-28 09:55 KST

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -9,6 +9,7 @@ Allowed files:
 - `benchmark_tiers.aggregate.json`
 - `baseline.aggregate.json`
 - `latency_cost_budget.aggregate.json`
+- `reranker_candidate_budget.aggregate.json`
 - `metric_suite.aggregate.json`
 - `metric_suite.md`
 - `retrieval_diagnostics.aggregate.json`

--- a/reports/real100_v2/reranker_candidate_budget.aggregate.json
+++ b/reports/real100_v2/reranker_candidate_budget.aggregate.json
@@ -1,0 +1,195 @@
+{
+  "decision": {
+    "overall_classification": "latency_regression",
+    "selected_variant": null,
+    "variants": [
+      {
+        "classifications": [
+          "latency_regression"
+        ],
+        "deltas_vs_control": {
+          "latency_p95_ms": 132526.61500000002,
+          "mrr_at_5": 0.0,
+          "ndcg_at_5": 0.0,
+          "recall_at_10": 0.0,
+          "recall_at_5": 0.0
+        },
+        "missing_metrics": [],
+        "name": "reranker_budget_pool30_topn10_top20",
+        "primary_classification": "latency_regression"
+      }
+    ]
+  },
+  "generated_at_utc": "2026-05-28T03:24:55.699186+00:00",
+  "known_limits": [
+    "This is aggregate-only private-local measurement, not a global reranker improvement claim.",
+    "Legacy real100, v1, 221, and kordoc evidence is not used.",
+    "BGE or other local reranker model availability is environment-dependent."
+  ],
+  "latency_budget": {
+    "cost_status": "not_observable_from_committed_aggregate",
+    "hard_no_go_ceiling_ms": 4799.0,
+    "present": true
+  },
+  "privacy_boundary": "aggregate_only_no_raw_questions_answers_evidence_ids_paths_or_filenames",
+  "profile_type": "private_real100_v2_reranker_candidate_budget",
+  "provenance": {
+    "eval_config_sha256": "168147eb51a599161733524bd11d515f15a4d2fe2085c81a4c68a4da133687ef",
+    "git_commit": "6aa92343b012",
+    "git_dirty": true,
+    "index_fingerprint_sha256": "7ddb84e3cf430e4de3dcb994fa3c5f3b10622d5d77780d32d23a5ee7e761a277",
+    "input_labels": {
+      "config": "external_private_real100_v2_config",
+      "index": "external_private_real100_v2_index",
+      "latency_budget": "reports_real100_v2_latency_cost_budget_aggregate"
+    }
+  },
+  "run_scope": {
+    "cases_evaluated": 3,
+    "cases_requested": 300,
+    "paired_delta_valid": false,
+    "subset_run": true,
+    "surface": "real100_v2"
+  },
+  "schema_version": 1,
+  "sweep": {
+    "candidate_count": 1,
+    "candidate_pool_values": [
+      30
+    ],
+    "classification_policy": [
+      "citation_regression",
+      "failed_experiment",
+      "latency_regression",
+      "ranking_regression",
+      "recall_only_gain",
+      "winner"
+    ],
+    "control": "control_no_cross_encoder_top20",
+    "reranker_top_n_values": [
+      10
+    ]
+  },
+  "variants": [
+    {
+      "metrics": {
+        "candidate_pool": {
+          "post_rerank_mrr_at_topn": null,
+          "post_rerank_ndcg_at_topn": null,
+          "post_rerank_recall_at_topn": null,
+          "pre_rerank_mrr_at_topn": null,
+          "pre_rerank_ndcg_at_topn": null,
+          "pre_rerank_recall_at_topn": null
+        },
+        "citation_guardrail": {
+          "citation_or_page_metadata_issue": {
+            "count": 0,
+            "denominator": 3,
+            "rate": 0.0
+          }
+        },
+        "final_retrieval": {
+          "mrr_at_5": 0.0,
+          "ndcg_at_5": 0.0,
+          "recall_at_10": 0.0,
+          "recall_at_5": 0.0
+        },
+        "latency_ms": {
+          "count": 3,
+          "p50": 13700.66,
+          "p95": 16842.956
+        },
+        "reranker_precision": {
+          "rerank_delta_mrr": null,
+          "rerank_delta_ndcg_at_10": null
+        }
+      },
+      "name": "control_no_cross_encoder_top20",
+      "num_cases": 3,
+      "parameters": {
+        "bm25_pool": null,
+        "dense_pool": null,
+        "rerank_cross_encoder": false,
+        "reranker_top_n": null,
+        "retrieval_backend": "hybrid",
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "reranker_provenance": {
+        "backend": "disabled",
+        "candidates_scored_mean": null,
+        "fallback": {
+          "count": 0,
+          "denominator": 3,
+          "rate": 0.0
+        },
+        "latency_ms": {
+          "count": 0,
+          "p50": null,
+          "p95": null
+        },
+        "model": "disabled"
+      }
+    },
+    {
+      "metrics": {
+        "candidate_pool": {
+          "post_rerank_mrr_at_topn": 0.0,
+          "post_rerank_ndcg_at_topn": 0.0,
+          "post_rerank_recall_at_topn": 0.0,
+          "pre_rerank_mrr_at_topn": 0.0,
+          "pre_rerank_ndcg_at_topn": 0.0,
+          "pre_rerank_recall_at_topn": 0.0
+        },
+        "citation_guardrail": {
+          "citation_or_page_metadata_issue": {
+            "count": 0,
+            "denominator": 3,
+            "rate": 0.0
+          }
+        },
+        "final_retrieval": {
+          "mrr_at_5": 0.0,
+          "ndcg_at_5": 0.0,
+          "recall_at_10": 0.0,
+          "recall_at_5": 0.0
+        },
+        "latency_ms": {
+          "count": 3,
+          "p50": 71655.66,
+          "p95": 149369.57100000003
+        },
+        "reranker_precision": {
+          "rerank_delta_mrr": 0.0,
+          "rerank_delta_ndcg_at_10": 0.0
+        }
+      },
+      "name": "reranker_budget_pool30_topn10_top20",
+      "num_cases": 3,
+      "parameters": {
+        "bm25_pool": 30,
+        "dense_pool": 30,
+        "rerank_cross_encoder": true,
+        "reranker_top_n": 10,
+        "retrieval_backend": "hybrid",
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "reranker_provenance": {
+        "backend": "bge_ko",
+        "candidates_scored_mean": 10.0,
+        "fallback": {
+          "count": 0,
+          "denominator": 3,
+          "rate": 0.0
+        },
+        "latency_ms": {
+          "count": 3,
+          "p50": 24875.84,
+          "p95": 132087.09799999997
+        },
+        "model": "dragonkue__bge-reranker-v2-m3-ko"
+      }
+    }
+  ]
+}

--- a/scripts/check_real100_v2_only.py
+++ b/scripts/check_real100_v2_only.py
@@ -19,6 +19,7 @@ DEFAULT_PATHS = (
     Path("docs/evaluation/private_real_eval_workflow.md"),
     Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
     Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
+    Path("docs/evaluation/real100_v2-reranker-candidate-budget.md"),
     Path("reports/real100_v2/README.md"),
 )
 
@@ -117,6 +118,7 @@ def check_path(path: Path) -> list[str]:
         Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
         Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
         Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
+        Path("docs/evaluation/real100_v2-reranker-candidate-budget.md"),
     }:
         for lineno, line in enumerate(scoped.splitlines(), start=1):
             if _is_ban_context(line):

--- a/scripts/run_real100_v2_reranker_budget_sweep.py
+++ b/scripts/run_real100_v2_reranker_budget_sweep.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Run an aggregate-only real100_v2 reranker candidate-budget sweep.
+
+This is a private/local measurement harness. It changes no default runtime
+behavior: candidate-pool and reranker ``top_n`` variants are injected only from
+this script and the committed outputs are aggregate-only.
+"""
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Iterator
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.run_eval import load_config, normalize_run_config  # noqa: E402
+from eval.scorers import derive_gold_evidence, score_case  # noqa: E402
+from eval.scorers.chunk_metrics import chunk_mrr_at_k, chunk_ndcg_at_k, chunk_recall_at_k  # noqa: E402
+from eval.scorers.failure_classifier import classify_failure  # noqa: E402
+from rag_core import DEFAULT_RAG_PIPELINE_NAME, _run_rag_query_with_plan_overrides, load_index, percentile, rate  # noqa: E402
+from scripts.run_private_hybrid_sweep import (  # noqa: E402
+    assert_aggregate_privacy_safe,
+    assert_rendered_output_privacy_safe,
+    render_output_path,
+)
+
+
+DEFAULT_CONFIG = ROOT / "data" / "private" / "real100_v2" / "real_config_v2.local.yaml"
+DEFAULT_INDEX_DIR = ROOT / "data" / "index" / "real100_v2"
+DEFAULT_LATENCY_BUDGET = ROOT / "reports" / "real100_v2" / "latency_cost_budget.aggregate.json"
+DEFAULT_OUT_JSON = ROOT / "reports" / "real100_v2" / "reranker_candidate_budget.aggregate.json"
+DEFAULT_OUT_MD = ROOT / "docs" / "evaluation" / "real100_v2-reranker-candidate-budget.md"
+ALLOWED_CLASSIFICATIONS = {
+    "winner",
+    "recall_only_gain",
+    "ranking_regression",
+    "citation_regression",
+    "latency_regression",
+    "failed_experiment",
+}
+MATERIAL_RECALL_DELTA = 0.005
+RANKING_REGRESSION_TOLERANCE = 0.001
+RERANK_PRECISION_DELTA = 0.001
+LATENCY_REGRESSION_RATIO = 0.05
+LATENCY_REGRESSION_MS = 10.0
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    retrieval_backend: str
+    top_k: int
+    rerank_cross_encoder: bool
+    reranker_top_n: int | None
+    dense_pool: int | None = None
+    bm25_pool: int | None = None
+    rrf_k: int = 60
+
+    @property
+    def plan_overrides(self) -> dict[str, Any]:
+        if self.retrieval_backend != "hybrid" or self.dense_pool is None or self.bm25_pool is None:
+            return {}
+        return {
+            "rrf_channel_pools": {
+                "dense": int(self.dense_pool),
+                "bm25": int(self.bm25_pool),
+            }
+        }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Private real100_v2 eval config.")
+    parser.add_argument("--index-dir", default=str(DEFAULT_INDEX_DIR), help="Private real100_v2 index directory.")
+    parser.add_argument("--latency-budget", default=str(DEFAULT_LATENCY_BUDGET))
+    parser.add_argument("--out-json", default=str(DEFAULT_OUT_JSON))
+    parser.add_argument("--out-md", default=str(DEFAULT_OUT_MD))
+    parser.add_argument("--cases-subset-n", type=int, default=None)
+    parser.add_argument("--top-k", type=int, default=20)
+    parser.add_argument("--reranker-top-ns", default="10,20,30")
+    parser.add_argument("--candidate-pools", default="30")
+    parser.add_argument("--rrf-k", type=int, default=60)
+    parser.add_argument("--reranker-backend", default=None, help="Override BIDMATE_RERANK_BACKEND.")
+    parser.add_argument("--reranker-model", default=None, help="Override BIDMATE_RERANK_MODEL.")
+    return parser.parse_args(argv)
+
+
+def _csv_ints(value: str) -> tuple[int, ...]:
+    out = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not out or any(item < 1 for item in out):
+        raise ValueError("integer lists must contain positive values")
+    return out
+
+
+def _require_real100_v2(path: Path, *, label: str) -> None:
+    path_text = path.as_posix()
+    if "real100_v2" not in path_text:
+        raise ValueError(f"{label} must be under a real100_v2 path")
+    lowered = {part.lower() for part in path.parts}
+    if "real100" in lowered and "real100_v2" not in lowered:
+        raise ValueError(f"{label} must not use legacy real100 paths")
+
+
+def _base_run_config(config: dict[str, Any], *, top_k: int) -> dict[str, Any]:
+    for run in config.get("ablation_runs") or []:
+        if isinstance(run, dict) and str(run.get("name") or "") == "full":
+            base = normalize_run_config(run)
+            break
+    else:
+        base = normalize_run_config(
+            {
+                "name": "full",
+                "pipeline": DEFAULT_RAG_PIPELINE_NAME,
+                "metadata_first": True,
+                "rerank": True,
+                "rerank_cross_encoder": False,
+                "verifier_retry": True,
+                "retrieval_mode": "flat",
+                "retrieval_backend": "hybrid",
+                "query_expansion": "identity",
+            }
+        )
+    base["top_k"] = int(top_k)
+    base["rerank"] = True
+    base["rerank_cross_encoder"] = False
+    return base
+
+
+def resolve_specs(*, top_k: int, reranker_top_ns: tuple[int, ...], candidate_pools: tuple[int, ...], rrf_k: int) -> list[VariantSpec]:
+    specs = [
+        VariantSpec(
+            name=f"control_no_cross_encoder_top{top_k}",
+            retrieval_backend="hybrid",
+            top_k=top_k,
+            rerank_cross_encoder=False,
+            reranker_top_n=None,
+            dense_pool=None,
+            bm25_pool=None,
+            rrf_k=rrf_k,
+        )
+    ]
+    for pool in candidate_pools:
+        for top_n in reranker_top_ns:
+            specs.append(
+                VariantSpec(
+                    name=f"reranker_budget_pool{pool}_topn{top_n}_top{top_k}",
+                    retrieval_backend="hybrid",
+                    top_k=top_k,
+                    rerank_cross_encoder=True,
+                    reranker_top_n=top_n,
+                    dense_pool=pool,
+                    bm25_pool=pool,
+                    rrf_k=rrf_k,
+                )
+            )
+    return specs
+
+
+def _config_for_variant(base: dict[str, Any], spec: VariantSpec) -> dict[str, Any]:
+    run_config = dict(base)
+    run_config["name"] = spec.name
+    run_config["top_k"] = spec.top_k
+    run_config["retrieval_backend"] = spec.retrieval_backend
+    run_config["rerank_cross_encoder"] = spec.rerank_cross_encoder
+    run_config["rrf_k"] = spec.rrf_k
+    return run_config
+
+
+def _query_kwargs(run_config: dict[str, Any], *, context_entities: list[str] | None = None, conversation_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "pipeline": str(run_config.get("pipeline") or DEFAULT_RAG_PIPELINE_NAME),
+        "top_k": run_config.get("top_k"),
+        "context_entities": context_entities or [],
+        "metadata_first": bool(run_config.get("metadata_first", True)),
+        "rerank": bool(run_config.get("rerank", True)),
+        "rerank_cross_encoder": bool(run_config.get("rerank_cross_encoder", False)),
+        "verifier_retry": bool(run_config.get("verifier_retry", True)),
+        "retrieval_mode": str(run_config.get("retrieval_mode", "flat")),
+        "retrieval_backend": str(run_config.get("retrieval_backend", "hybrid")),
+        "prompt_profile": str(run_config.get("prompt_profile") or ""),
+        "conversation_state": conversation_state,
+        "rrf_k": int(run_config.get("rrf_k") or 60),
+        "bm25_stopword_profile": str(run_config.get("bm25_stopword_profile", "shared")),
+        "bm25_tokenizer": str(run_config.get("bm25_tokenizer", "regex")),
+        "bm25_backend": str(run_config.get("bm25_backend", "okapi")),
+    }
+
+
+class _TopNForcingReranker:
+    def __init__(self, delegate: Any, forced_top_n: int) -> None:
+        self.delegate = delegate
+        self.forced_top_n = int(forced_top_n)
+
+    def rerank(self, query: str, candidates: list[dict[str, Any]], *, top_n: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        forced = min(self.forced_top_n, len(candidates))
+        pre_topn = [str(item.get("chunk_id") or "") for item in candidates[:forced]]
+        reordered, meta = self.delegate.rerank(query, candidates, top_n=forced)
+        meta = dict(meta)
+        meta["requested_top_n"] = int(top_n)
+        meta["forced_top_n"] = forced
+        meta["pre_rerank_topn"] = pre_topn
+        meta["post_rerank_topn"] = [str(item.get("chunk_id") or "") for item in reordered[:forced]]
+        return reordered, meta
+
+
+@contextmanager
+def force_reranker_top_n(top_n: int | None) -> Iterator[None]:
+    if top_n is None:
+        yield
+        return
+    import rag_reranker
+
+    original = rag_reranker.default_reranker
+    delegate = original()
+
+    def replacement() -> _TopNForcingReranker:
+        return _TopNForcingReranker(delegate, int(top_n))
+
+    rag_reranker.default_reranker = replacement
+    try:
+        yield
+    finally:
+        rag_reranker.default_reranker = original
+
+
+def _run_prediction(index: dict[str, Any], query_text: str, run_config: dict[str, Any], plan_overrides: dict[str, Any], *, context_entities: list[str] | None = None, conversation_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    return _run_rag_query_with_plan_overrides(
+        index,
+        query_text,
+        plan_overrides=plan_overrides,
+        **_query_kwargs(run_config, context_entities=context_entities, conversation_state=conversation_state),
+    )
+
+
+def _mean(values: list[float | None]) -> float | None:
+    return rate([float(value) for value in values if value is not None])
+
+
+def _count_rate(count: int, denominator: int) -> dict[str, Any]:
+    return {"count": count, "rate": (count / denominator) if denominator else None, "denominator": denominator}
+
+
+def _latency_summary(values: list[float]) -> dict[str, Any]:
+    return {"p50": percentile(values, 0.50), "p95": percentile(values, 0.95), "count": len(values)}
+
+
+def _safe_label(value: str | None) -> str | None:
+    if not value:
+        return value
+    return str(value).replace("/", "__").replace("\\", "__")
+
+
+def _citation_issue_rate(results: list[dict[str, Any]]) -> dict[str, Any]:
+    categories = [classify_failure(row) for row in results]
+    count = sum(1 for category in categories if category == "citation_or_page_metadata_issue")
+    return _count_rate(count, len(results))
+
+
+def evaluate_variant(index: dict[str, Any], cases: list[dict[str, Any]], run_config: dict[str, Any], spec: VariantSpec, answer_policy: dict[str, Any] | None) -> dict[str, Any]:
+    scored_results: list[dict[str, Any]] = []
+    pre_topn_recall: list[float | None] = []
+    post_topn_recall: list[float | None] = []
+    pre_topn_mrr: list[float | None] = []
+    post_topn_mrr: list[float | None] = []
+    pre_topn_ndcg: list[float | None] = []
+    post_topn_ndcg: list[float | None] = []
+    fallback_count = 0
+    candidates_scored: list[int] = []
+    reranker_latencies: list[float] = []
+    reranker_backend: str | None = None
+    reranker_model: str | None = None
+
+    with force_reranker_top_n(spec.reranker_top_n):
+        for case in cases:
+            conversation_state: dict[str, Any] = {}
+            for turn in case.get("prior_turns") or []:
+                prior = _run_prediction(
+                    index,
+                    str(turn["query"]),
+                    run_config,
+                    spec.plan_overrides,
+                    context_entities=turn.get("context_entities") or [],
+                    conversation_state=conversation_state,
+                )
+                conversation_state = prior.get("conversation_state") or conversation_state
+            prediction = _run_prediction(
+                index,
+                str(case["query"]),
+                run_config,
+                spec.plan_overrides,
+                context_entities=case.get("context_entities") or [],
+                conversation_state=conversation_state,
+            )
+            gold_evidence = derive_gold_evidence(case, index)
+            gold_chunk_ids = [
+                str(item.get("chunk_id") or "")
+                for item in gold_evidence
+                if isinstance(item, dict) and item.get("chunk_id")
+            ]
+            result = score_case(
+                case,
+                prediction,
+                answer_policy,
+                gold_chunk_ids=gold_chunk_ids,
+                gold_evidence=gold_evidence,
+            )
+            scored_results.append(result)
+            meta = (prediction.get("plan") or {}).get("rerank_cross_encoder_meta") or {}
+            if isinstance(meta, dict) and meta:
+                reranker_backend = str(meta.get("backend") or reranker_backend or "")
+                reranker_model = str(meta.get("model") or reranker_model or "")
+                fallback_count += 1 if meta.get("fell_back") else 0
+                if isinstance(meta.get("candidates_scored"), int):
+                    candidates_scored.append(int(meta["candidates_scored"]))
+                if isinstance(meta.get("latency_ms"), (int, float)) and not isinstance(meta.get("latency_ms"), bool):
+                    reranker_latencies.append(float(meta["latency_ms"]))
+                pre_ids = [str(item) for item in meta.get("pre_rerank_topn") or [] if item]
+                post_ids = [str(item) for item in meta.get("post_rerank_topn") or [] if item]
+                if gold_chunk_ids and pre_ids and post_ids:
+                    k = len(pre_ids)
+                    pre_topn_recall.append(chunk_recall_at_k(pre_ids, gold_chunk_ids, k))
+                    post_topn_recall.append(chunk_recall_at_k(post_ids, gold_chunk_ids, k))
+                    pre_topn_mrr.append(chunk_mrr_at_k(pre_ids, gold_chunk_ids, k))
+                    post_topn_mrr.append(chunk_mrr_at_k(post_ids, gold_chunk_ids, k))
+                    pre_topn_ndcg.append(chunk_ndcg_at_k(pre_ids, gold_chunk_ids, k))
+                    post_topn_ndcg.append(chunk_ndcg_at_k(post_ids, gold_chunk_ids, k))
+
+    latencies = [float(row["latency_ms"]) for row in scored_results if row.get("latency_ms") is not None]
+    return {
+        "name": spec.name,
+        "parameters": {
+            "retrieval_backend": spec.retrieval_backend,
+            "top_k": spec.top_k,
+            "rrf_k": spec.rrf_k,
+            "dense_pool": spec.dense_pool,
+            "bm25_pool": spec.bm25_pool,
+            "rerank_cross_encoder": spec.rerank_cross_encoder,
+            "reranker_top_n": spec.reranker_top_n,
+        },
+        "num_cases": len(scored_results),
+        "reranker_provenance": {
+            "backend": reranker_backend if spec.rerank_cross_encoder else "disabled",
+            "model": _safe_label(reranker_model) if spec.rerank_cross_encoder else "disabled",
+            "fallback": _count_rate(fallback_count, len(scored_results)),
+            "candidates_scored_mean": _mean([float(value) for value in candidates_scored]),
+            "latency_ms": _latency_summary(reranker_latencies) if reranker_latencies else {"p50": None, "p95": None, "count": 0},
+        },
+        "metrics": {
+            "candidate_pool": {
+                "pre_rerank_recall_at_topn": _mean(pre_topn_recall),
+                "post_rerank_recall_at_topn": _mean(post_topn_recall),
+                "pre_rerank_mrr_at_topn": _mean(pre_topn_mrr),
+                "post_rerank_mrr_at_topn": _mean(post_topn_mrr),
+                "pre_rerank_ndcg_at_topn": _mean(pre_topn_ndcg),
+                "post_rerank_ndcg_at_topn": _mean(post_topn_ndcg),
+            },
+            "reranker_precision": {
+                "rerank_delta_mrr": _mean([row.get("rerank_delta_mrr") for row in scored_results]),
+                "rerank_delta_ndcg_at_10": _mean([row.get("rerank_delta_ndcg_at_10") for row in scored_results]),
+            },
+            "final_retrieval": {
+                "recall_at_5": _mean([row.get("chunk_recall_at_5") for row in scored_results]),
+                "recall_at_10": _mean([row.get("chunk_recall_at_10") for row in scored_results]),
+                "mrr_at_5": _mean([row.get("chunk_mrr_at_5") for row in scored_results]),
+                "ndcg_at_5": _mean([row.get("chunk_ndcg_at_5") for row in scored_results]),
+            },
+            "citation_guardrail": {
+                "citation_or_page_metadata_issue": _citation_issue_rate(scored_results),
+            },
+            "latency_ms": _latency_summary(latencies),
+        },
+    }
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _metric(variant: dict[str, Any], *path: str) -> float | None:
+    node: Any = variant
+    for key in path:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    return _number(node)
+
+
+def _latency_hard_ceiling_ms(latency_budget: dict[str, Any] | None) -> float | None:
+    if not isinstance(latency_budget, dict):
+        return None
+    baseline = latency_budget.get("baseline_latency")
+    if isinstance(baseline, dict):
+        value = _number(baseline.get("hard_ceiling_ms"))
+        if value is not None:
+            return value
+    overall = latency_budget.get("overall_budget")
+    if not isinstance(overall, dict):
+        return None
+    return _number(overall.get("hard_no_go_ceiling_ms"))
+
+
+def _cost_status(latency_budget: dict[str, Any] | None) -> str | None:
+    if not isinstance(latency_budget, dict):
+        return None
+    envelope = latency_budget.get("cost_envelope")
+    if isinstance(envelope, dict) and envelope.get("status"):
+        return str(envelope["status"])
+    budget = latency_budget.get("cost_budget")
+    if isinstance(budget, dict) and budget.get("status"):
+        return str(budget["status"])
+    return None
+
+
+def classify_variants(variants: list[dict[str, Any]], latency_budget: dict[str, Any] | None) -> dict[str, Any]:
+    if not variants:
+        return {"overall_classification": "failed_experiment", "selected_variant": None, "variants": []}
+    baseline = variants[0]
+    hard_latency = _latency_hard_ceiling_ms(latency_budget)
+    classified: list[dict[str, Any]] = []
+    for variant in variants[1:]:
+        missing = []
+        for label, value in [
+            ("recall_at_5", _metric(variant, "metrics", "final_retrieval", "recall_at_5")),
+            ("recall_at_10", _metric(variant, "metrics", "final_retrieval", "recall_at_10")),
+            ("mrr_at_5", _metric(variant, "metrics", "final_retrieval", "mrr_at_5")),
+            ("ndcg_at_5", _metric(variant, "metrics", "final_retrieval", "ndcg_at_5")),
+            ("latency_p95_ms", _metric(variant, "metrics", "latency_ms", "p95")),
+            ("baseline_recall_at_10", _metric(baseline, "metrics", "final_retrieval", "recall_at_10")),
+            ("baseline_mrr_at_5", _metric(baseline, "metrics", "final_retrieval", "mrr_at_5")),
+            ("baseline_ndcg_at_5", _metric(baseline, "metrics", "final_retrieval", "ndcg_at_5")),
+        ]:
+            if value is None:
+                missing.append(label)
+        classifications: list[str] = []
+        if missing:
+            classifications = ["failed_experiment"]
+        else:
+            recall_delta = max(
+                (_metric(variant, "metrics", "final_retrieval", "recall_at_5") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "recall_at_5") or 0.0),
+                (_metric(variant, "metrics", "final_retrieval", "recall_at_10") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "recall_at_10") or 0.0),
+            )
+            mrr_delta = (_metric(variant, "metrics", "final_retrieval", "mrr_at_5") or 0.0) - (
+                _metric(baseline, "metrics", "final_retrieval", "mrr_at_5") or 0.0
+            )
+            ndcg_delta = (_metric(variant, "metrics", "final_retrieval", "ndcg_at_5") or 0.0) - (
+                _metric(baseline, "metrics", "final_retrieval", "ndcg_at_5") or 0.0
+            )
+            rerank_delta = max(
+                _metric(variant, "metrics", "reranker_precision", "rerank_delta_mrr") or 0.0,
+                _metric(variant, "metrics", "reranker_precision", "rerank_delta_ndcg_at_10") or 0.0,
+            )
+            citation_delta = (
+                _metric(variant, "metrics", "citation_guardrail", "citation_or_page_metadata_issue", "rate")
+                or 0.0
+            ) - (
+                _metric(baseline, "metrics", "citation_guardrail", "citation_or_page_metadata_issue", "rate")
+                or 0.0
+            )
+            p95 = _metric(variant, "metrics", "latency_ms", "p95") or 0.0
+            baseline_p95 = _metric(baseline, "metrics", "latency_ms", "p95") or 0.0
+            latency_regressed = p95 > baseline_p95 + max(LATENCY_REGRESSION_MS, baseline_p95 * LATENCY_REGRESSION_RATIO)
+            if hard_latency is not None and p95 > hard_latency:
+                latency_regressed = True
+            fallback_rate = _metric(variant, "reranker_provenance", "fallback", "rate") or 0.0
+            if fallback_rate > 0:
+                classifications.append("failed_experiment")
+            if mrr_delta < -RANKING_REGRESSION_TOLERANCE or ndcg_delta < -RANKING_REGRESSION_TOLERANCE:
+                classifications.append("ranking_regression")
+            if citation_delta > RANKING_REGRESSION_TOLERANCE:
+                classifications.append("citation_regression")
+            if latency_regressed:
+                classifications.append("latency_regression")
+            if not classifications and (recall_delta >= MATERIAL_RECALL_DELTA or rerank_delta >= RERANK_PRECISION_DELTA):
+                classifications.append("winner")
+            elif recall_delta >= MATERIAL_RECALL_DELTA and classifications:
+                classifications.insert(0, "recall_only_gain")
+            if not classifications:
+                classifications.append("failed_experiment")
+        deduped = [item for idx, item in enumerate(classifications) if item in ALLOWED_CLASSIFICATIONS and item not in classifications[:idx]]
+        if not deduped:
+            deduped = ["failed_experiment"]
+        row = {
+            "name": str(variant.get("name") or ""),
+            "classifications": deduped,
+            "primary_classification": deduped[0],
+            "missing_metrics": missing,
+            "deltas_vs_control": {
+                "recall_at_5": (_metric(variant, "metrics", "final_retrieval", "recall_at_5") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "recall_at_5") or 0.0),
+                "recall_at_10": (_metric(variant, "metrics", "final_retrieval", "recall_at_10") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "recall_at_10") or 0.0),
+                "mrr_at_5": (_metric(variant, "metrics", "final_retrieval", "mrr_at_5") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "mrr_at_5") or 0.0),
+                "ndcg_at_5": (_metric(variant, "metrics", "final_retrieval", "ndcg_at_5") or 0.0)
+                - (_metric(baseline, "metrics", "final_retrieval", "ndcg_at_5") or 0.0),
+                "latency_p95_ms": (_metric(variant, "metrics", "latency_ms", "p95") or 0.0)
+                - (_metric(baseline, "metrics", "latency_ms", "p95") or 0.0),
+            },
+        }
+        classified.append(row)
+    winners = [row for row in classified if row["primary_classification"] == "winner"]
+    selected = winners[0]["name"] if winners else None
+    overall = "winner" if selected else (classified[0]["primary_classification"] if classified else "failed_experiment")
+    return {"overall_classification": overall, "selected_variant": selected, "variants": classified}
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git_state() -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True, stderr=subprocess.DEVNULL).strip()
+        dirty = bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True, stderr=subprocess.DEVNULL).strip())
+    except (OSError, subprocess.CalledProcessError):
+        return {"git_commit": "unknown", "git_dirty": True}
+    return {"git_commit": commit[:12], "git_dirty": dirty}
+
+
+def load_latency_budget(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"status": "missing"}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("latency budget must be a JSON object")
+    return payload
+
+
+def build_aggregate(*, config_path: Path, index: dict[str, Any], specs: list[VariantSpec], variants: list[dict[str, Any]], latency_budget: dict[str, Any], cases_requested: int, cases_evaluated: int) -> dict[str, Any]:
+    decision = classify_variants(variants, latency_budget)
+    aggregate = {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_reranker_candidate_budget",
+        "privacy_boundary": "aggregate_only_no_raw_questions_answers_evidence_ids_paths_or_filenames",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "run_scope": {
+            "surface": "real100_v2",
+            "cases_requested": cases_requested,
+            "cases_evaluated": cases_evaluated,
+            "subset_run": cases_requested != cases_evaluated,
+            "paired_delta_valid": cases_requested == cases_evaluated and cases_evaluated > 0,
+        },
+        "provenance": {
+            **_git_state(),
+            "eval_config_sha256": _sha256_file(config_path),
+            "index_fingerprint_sha256": _index_fingerprint(index),
+            "input_labels": {
+                "config": "external_private_real100_v2_config",
+                "index": "external_private_real100_v2_index",
+                "latency_budget": "reports_real100_v2_latency_cost_budget_aggregate",
+            },
+        },
+        "sweep": {
+            "control": specs[0].name if specs else "control_no_cross_encoder",
+            "candidate_count": max(0, len(specs) - 1),
+            "reranker_top_n_values": sorted({spec.reranker_top_n for spec in specs if spec.reranker_top_n is not None}),
+            "candidate_pool_values": sorted({spec.dense_pool for spec in specs if spec.dense_pool is not None}),
+            "classification_policy": sorted(ALLOWED_CLASSIFICATIONS),
+        },
+        "latency_budget": {
+            "present": latency_budget.get("profile_type") == "private_real100_v2_latency_cost_budget",
+            "hard_no_go_ceiling_ms": _latency_hard_ceiling_ms(latency_budget),
+            "cost_status": _cost_status(latency_budget),
+        },
+        "decision": decision,
+        "variants": variants,
+        "known_limits": [
+            "This is aggregate-only private-local measurement, not a global reranker improvement claim.",
+            "Legacy real100, v1, 221, and kordoc evidence is not used.",
+            "BGE or other local reranker model availability is environment-dependent.",
+        ],
+    }
+    assert_aggregate_privacy_safe(aggregate)
+    return aggregate
+
+
+def _index_fingerprint(index: dict[str, Any]) -> str:
+    payload = {
+        "build": index.get("build") or {},
+        "embedding": index.get("embedding") or {},
+        "num_documents": len(index.get("documents") or []),
+        "num_chunks": len(index.get("chunks") or []),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{float(value):.4f}"
+    return str(value)
+
+
+def render_markdown(aggregate: dict[str, Any]) -> str:
+    decision = aggregate["decision"]
+    lines = [
+        "# real100_v2 Reranker Candidate-Budget Sweep",
+        "",
+        "This report is aggregate-only. It contains no raw questions, answers, evidence text, filenames, local paths, document identifiers, chunk identifiers, or per-case rows. Legacy `real100`, v1, 221, and kordoc evidence is not used.",
+        "",
+        "## Decision",
+        "",
+        f"- Overall classification: `{decision['overall_classification']}`",
+        f"- Selected variant: `{decision['selected_variant'] or '-'}`",
+        f"- Paired delta valid: `{aggregate['run_scope']['paired_delta_valid']}`",
+        f"- Subset run: `{aggregate['run_scope']['subset_run']}`",
+        f"- Latency hard ceiling ms: `{_fmt(aggregate['latency_budget']['hard_no_go_ceiling_ms'])}`",
+        f"- Cost status: `{aggregate['latency_budget']['cost_status'] or 'not_observable'}`",
+        "",
+        "## Control",
+        "",
+        "| Variant | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | p50 ms | p95 ms |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    control = aggregate["variants"][0]
+    control_metrics = control["metrics"]
+    lines.append(
+        "| {name} | {r5} | {r10} | {mrr} | {ndcg} | {p50} | {p95} |".format(
+            name=control["name"],
+            r5=_fmt(control_metrics["final_retrieval"]["recall_at_5"]),
+            r10=_fmt(control_metrics["final_retrieval"]["recall_at_10"]),
+            mrr=_fmt(control_metrics["final_retrieval"]["mrr_at_5"]),
+            ndcg=_fmt(control_metrics["final_retrieval"]["ndcg_at_5"]),
+            p50=_fmt(control_metrics["latency_ms"]["p50"]),
+            p95=_fmt(control_metrics["latency_ms"]["p95"]),
+        )
+    )
+    lines.extend(
+        [
+            "",
+            "## Candidate Variants",
+            "",
+            "| Variant | Pool | top_n | preR@N | postR@N | dMRR | dNDCG@10 | fallback | p95 ms | Classification |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    classification_by_name = {row["name"]: row for row in decision["variants"]}
+    for variant in aggregate["variants"][1:]:
+        params = variant["parameters"]
+        metrics = variant["metrics"]
+        provenance = variant["reranker_provenance"]
+        row = classification_by_name.get(variant["name"], {})
+        lines.append(
+            "| {name} | {pool} | {topn} | {pre_r} | {post_r} | {dmrr} | {dndcg} | {fallback} | {p95} | {cls} |".format(
+                name=variant["name"],
+                pool=_fmt(params.get("dense_pool")),
+                topn=_fmt(params.get("reranker_top_n")),
+                pre_r=_fmt(metrics["candidate_pool"]["pre_rerank_recall_at_topn"]),
+                post_r=_fmt(metrics["candidate_pool"]["post_rerank_recall_at_topn"]),
+                dmrr=_fmt(metrics["reranker_precision"]["rerank_delta_mrr"]),
+                dndcg=_fmt(metrics["reranker_precision"]["rerank_delta_ndcg_at_10"]),
+                fallback=_fmt((provenance.get("fallback") or {}).get("rate")),
+                p95=_fmt(metrics["latency_ms"]["p95"]),
+                cls=", ".join(row.get("classifications") or ["failed_experiment"]),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- Candidate-pool recall is measured before cross-encoder reranking; reranker precision is measured as MRR/nDCG movement after reranking.",
+            "- `winner` requires material retrieval or reranker-precision gain with no ranking, citation, latency, or fallback regression.",
+            "- `paired_delta_valid=false` means this artifact is screening evidence only and must not be used as a headline private eval improvement claim.",
+            "",
+        ]
+    )
+    rendered = "\n".join(lines)
+    assert_rendered_output_privacy_safe(rendered)
+    return rendered
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = ROOT / config_path
+    index_dir = Path(args.index_dir)
+    if not index_dir.is_absolute():
+        index_dir = ROOT / index_dir
+    budget_path = Path(args.latency_budget)
+    if not budget_path.is_absolute():
+        budget_path = ROOT / budget_path
+    out_json = Path(args.out_json)
+    if not out_json.is_absolute():
+        out_json = ROOT / out_json
+    out_md = Path(args.out_md)
+    if not out_md.is_absolute():
+        out_md = ROOT / out_md
+    _require_real100_v2(config_path, label="config")
+    _require_real100_v2(index_dir, label="index")
+    _require_real100_v2(out_json, label="out-json")
+    _require_real100_v2(out_md, label="out-md")
+
+    if args.reranker_backend:
+        os.environ["BIDMATE_RERANK_BACKEND"] = str(args.reranker_backend)
+    if args.reranker_model:
+        os.environ["BIDMATE_RERANK_MODEL"] = str(args.reranker_model)
+
+    config = load_config(config_path)
+    cases = list(config["cases"])
+    cases_requested = len(cases)
+    if args.cases_subset_n is not None:
+        cases = cases[: args.cases_subset_n]
+    index = load_index(index_dir)
+    specs = resolve_specs(
+        top_k=int(args.top_k),
+        reranker_top_ns=_csv_ints(args.reranker_top_ns),
+        candidate_pools=_csv_ints(args.candidate_pools),
+        rrf_k=int(args.rrf_k),
+    )
+    base = _base_run_config(config, top_k=int(args.top_k))
+    answer_policy = config.get("answer_policy") if isinstance(config.get("answer_policy"), dict) else {}
+    variants = []
+    for idx, spec in enumerate(specs, start=1):
+        print(f"[sweep] {idx}/{len(specs)} {spec.name}", flush=True)
+        run_config = _config_for_variant(base, spec)
+        variants.append(evaluate_variant(index, cases, run_config, spec, answer_policy))
+    aggregate = build_aggregate(
+        config_path=config_path,
+        index=index,
+        specs=specs,
+        variants=variants,
+        latency_budget=load_latency_budget(budget_path),
+        cases_requested=cases_requested,
+        cases_evaluated=len(cases),
+    )
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    out_md.write_text(render_markdown(aggregate), encoding="utf-8")
+    message = f"[OK] wrote {render_output_path(out_json)} and {render_output_path(out_md)}"
+    assert_rendered_output_privacy_safe(message)
+    print(message, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -40,10 +40,10 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
 | 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1622; real100_v2 retrieval diagnostics rendered; next experiment points to T-2026-0032 while T-2026-0031 remains page-metadata blocked. |
-| 30 | `T-2026-0030` | `review` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | issue #1626; real100_v2 latency/cost envelope rendered for review. |
+| 30 | `T-2026-0030` | `done` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | merged in PR #1628; real100_v2 latency/cost envelope landed. |
 | 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
-| 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1624; plan drafted and T-2026-0030 guardrail is ready for review. |
-| 33 | `T-2026-0033` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval/reranker evidence and token budget from T-2026-0030. |
+| 32 | `T-2026-0032` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1629; BGE-KO screening run classifies latency_regression, no winner claim. |
+| 33 | `T-2026-0033` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; unblocked by T-2026-0030 budget and T-2026-0032 reranker latency no-go screening. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
 | 36 | `T-2026-0036` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on stable retrieval/context evidence from P0/P1 tasks. |
@@ -2830,7 +2830,7 @@ make check-branch
 
 - ID: T-2026-0032
 - Title: Reranker candidate-budget experiment
-- Status: blocked
+- Status: review
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
@@ -2859,10 +2859,10 @@ Run with or after the latency/cost guardrail from `T-2026-0030`.
 
 ### Acceptance Criteria
 
-- [ ] Sweep output classifies winner, recall-only gain, ranking regression,
+- [x] Sweep output classifies winner, recall-only gain, ranking regression,
   citation regression, latency regression, or failed experiment.
-- [ ] Candidate-pool recall and reranker precision are reported separately.
-- [ ] Reranker provenance is present in aggregate output.
+- [x] Candidate-pool recall and reranker precision are reported separately.
+- [x] Reranker provenance is present in aggregate output.
 - [x] Latency/cost guardrail from `T-2026-0030` is present or this task remains
   blocked.
 
@@ -2870,8 +2870,8 @@ Run with or after the latency/cost guardrail from `T-2026-0030`.
 
 ```bash
 python3 -m pytest -q tests/test_reranker*.py <focused-new-tests>
-python3 <reranker-sweep-script> --config <local-or-public-config> --out <aggregate-output>
-python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+python3 scripts/run_real100_v2_reranker_budget_sweep.py --config <local-v2-config> --index-dir <local-v2-index> --cases-subset-n 3 --candidate-pools 30 --reranker-top-ns 10 --reranker-backend bge_ko
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>  # optional only when paired full aggregate exists
 git diff --check
 make check-branch
 ```
@@ -2880,14 +2880,35 @@ make check-branch
 
 - Aggregate sweep summary with no raw private content.
 - Latency/cost guardrail from `T-2026-0030`.
+- Current committed result: `reports/real100_v2/reranker_candidate_budget.aggregate.json`
+  classifies the BGE-KO screening variant as `latency_regression` with
+  `paired_delta_valid=false`; this is a no-winner screening result, not a
+  private eval improvement claim.
 
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`](../docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md)
-- Issue: [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624)
+- Issue: [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624) (plan), [#1629](https://github.com/hskim-solv/BidMate-DocAgent/issues/1629) (implementation)
 - PR: TBD
 
 ### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 12:30 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1629-run-real100-v2-reranker-candidate-budget-experim / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1629 / PR TBD
+- Task: T-2026-0032
+- Current status: runner/report implemented; 3-case `real100_v2` BGE-KO screening classifies `latency_regression`.
+- Files touched: scripts/run_real100_v2_reranker_budget_sweep.py, tests/test_real100_v2_reranker_budget_sweep.py, reports/real100_v2/reranker_candidate_budget.aggregate.json, docs/evaluation/real100_v2-reranker-candidate-budget.md, reports/real100_v2/README.md, .gitignore, .githooks/pre-commit, scripts/check_real100_v2_only.py, docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md, tasks/queue.md
+- Decisions made: no winner and no headline improvement claim; paired_delta_valid=false because this was a 3-case screening run; local BGE-KO reranker latency exceeds the 4799 ms hard no-go ceiling by a large margin.
+- Commands run: make ship-start TITLE="Run real100 v2 reranker candidate budget experiment" TYPE=eval; make check-branch; python3 -m py_compile scripts/run_real100_v2_reranker_budget_sweep.py; python3 -m pytest -q tests/test_real100_v2_reranker_budget_sweep.py; python3 scripts/run_real100_v2_reranker_budget_sweep.py --config <external_private_real100_v2_config> --index-dir <external_private_real100_v2_index> --cases-subset-n 3 --candidate-pools 30 --reranker-top-ns 10 --reranker-backend bge_ko.
+- Results: aggregate/report written; candidate-pool recall and reranker precision separated; reranker provenance captured as backend bge_ko and model safe label dragonkue__bge-reranker-v2-m3-ko.
+- Next safe command: make real-eval-v2-guard && python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md docs/evaluation/real100_v2-reranker-candidate-budget.md reports/real100_v2/README.md
+- Open questions: whether to run any further reranker backend requires a GPU or explicit latency budget exception; current CPU local backend is no-go.
+- Risks: subset run is screening evidence only, not paired full private eval delta.
+```
 
 ```markdown
 ## Session Handoff - 2026-05-28 09:55 KST
@@ -2910,16 +2931,21 @@ make check-branch
 
 - ID: T-2026-0033
 - Title: Context packing and citation ordering experiment
-- Status: backlog
+- Status: ready
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-27
+- Last updated: 2026-05-28
 
 ### Goal
 
 Improve how selected evidence is assembled for generation without changing the
 retriever.
+
+Current trigger: `T-2026-0032` produced a no-winner reranker screening result
+because local BGE-KO reranking breached the `T-2026-0030` latency hard ceiling.
+The next experiment should improve evidence assembly while holding retrieval and
+reranker behavior fixed.
 
 ### Scope
 

--- a/tests/test_real100_v2_reranker_budget_sweep.py
+++ b/tests/test_real100_v2_reranker_budget_sweep.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.run_real100_v2_reranker_budget_sweep import (  # noqa: E402
+    VariantSpec,
+    _TopNForcingReranker,
+    build_aggregate,
+    classify_variants,
+    render_markdown,
+)
+
+
+def _variant(
+    name: str,
+    *,
+    topn: int | None = None,
+    recall10: float = 0.40,
+    mrr5: float = 0.30,
+    ndcg5: float = 0.35,
+    p95: float = 100.0,
+    fallback: float = 0.0,
+    citation_issue: float = 0.0,
+    rerank_delta: float | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "parameters": {
+            "retrieval_backend": "hybrid",
+            "top_k": 20,
+            "rrf_k": 60,
+            "dense_pool": 30 if topn is not None else None,
+            "bm25_pool": 30 if topn is not None else None,
+            "rerank_cross_encoder": topn is not None,
+            "reranker_top_n": topn,
+        },
+        "num_cases": 10,
+        "reranker_provenance": {
+            "backend": "stub" if topn is not None else "disabled",
+            "model": "stub" if topn is not None else "disabled",
+            "fallback": {"count": int(fallback * 10), "rate": fallback, "denominator": 10},
+            "candidates_scored_mean": float(topn or 0),
+            "latency_ms": {"p50": 1.0 if topn is not None else None, "p95": 2.0 if topn is not None else None, "count": 10 if topn is not None else 0},
+        },
+        "metrics": {
+            "candidate_pool": {
+                "pre_rerank_recall_at_topn": recall10,
+                "post_rerank_recall_at_topn": recall10,
+                "pre_rerank_mrr_at_topn": mrr5,
+                "post_rerank_mrr_at_topn": mrr5,
+                "pre_rerank_ndcg_at_topn": ndcg5,
+                "post_rerank_ndcg_at_topn": ndcg5,
+            },
+            "reranker_precision": {
+                "rerank_delta_mrr": rerank_delta,
+                "rerank_delta_ndcg_at_10": rerank_delta,
+            },
+            "final_retrieval": {
+                "recall_at_5": recall10 - 0.05,
+                "recall_at_10": recall10,
+                "mrr_at_5": mrr5,
+                "ndcg_at_5": ndcg5,
+            },
+            "citation_guardrail": {
+                "citation_or_page_metadata_issue": {"count": int(citation_issue * 10), "rate": citation_issue, "denominator": 10}
+            },
+            "latency_ms": {"p50": p95 / 2, "p95": p95, "count": 10},
+        },
+    }
+
+
+def test_classifies_winner_when_precision_gain_has_no_regressions() -> None:
+    variants = [
+        _variant("control_no_cross_encoder_top20"),
+        _variant("reranker_budget_pool30_topn20_top20", topn=20, recall10=0.405, mrr5=0.31, ndcg5=0.36, rerank_delta=0.01),
+    ]
+
+    decision = classify_variants(variants, {"overall_budget": {"hard_no_go_ceiling_ms": 200.0}})
+
+    assert decision["overall_classification"] == "winner"
+    assert decision["selected_variant"] == "reranker_budget_pool30_topn20_top20"
+    assert decision["variants"][0]["classifications"] == ["winner"]
+
+
+def test_classifies_recall_only_gain_with_ranking_and_latency_regressions() -> None:
+    variants = [
+        _variant("control_no_cross_encoder_top20"),
+        _variant("reranker_budget_pool30_topn30_top20", topn=30, recall10=0.43, mrr5=0.25, ndcg5=0.34, p95=250.0, rerank_delta=-0.02),
+    ]
+
+    decision = classify_variants(variants, {"overall_budget": {"hard_no_go_ceiling_ms": 200.0}})
+
+    assert decision["overall_classification"] == "recall_only_gain"
+    assert decision["variants"][0]["classifications"] == [
+        "recall_only_gain",
+        "ranking_regression",
+        "latency_regression",
+    ]
+
+
+def test_topn_wrapper_forces_requested_budget_and_records_topn_ids() -> None:
+    class FakeReranker:
+        def rerank(self, query: str, candidates: list[dict], *, top_n: int):
+            return list(reversed(candidates[:top_n])) + candidates[top_n:], {
+                "backend": "fake",
+                "model": "fake",
+                "top_n": top_n,
+                "candidates_scored": top_n,
+                "fell_back": False,
+            }
+
+    candidates = [{"chunk_id": f"c{i}"} for i in range(5)]
+    wrapper = _TopNForcingReranker(FakeReranker(), 2)
+
+    reordered, meta = wrapper.rerank("q", candidates, top_n=30)
+
+    assert [item["chunk_id"] for item in reordered[:2]] == ["c1", "c0"]
+    assert meta["requested_top_n"] == 30
+    assert meta["forced_top_n"] == 2
+    assert meta["pre_rerank_topn"] == ["c0", "c1"]
+    assert meta["post_rerank_topn"] == ["c1", "c0"]
+
+
+def test_build_aggregate_and_markdown_are_privacy_safe(tmp_path: Path) -> None:
+    index = {"build": {"version": 1}, "embedding": {"backend": "hashing"}, "documents": [1], "chunks": [1, 2]}
+    specs = [
+        VariantSpec("control_no_cross_encoder_top20", "hybrid", 20, False, None),
+        VariantSpec("reranker_budget_pool30_topn20_top20", "hybrid", 20, True, 20, 30, 30),
+    ]
+    config = tmp_path / "real100_v2" / "fake_config.local.yaml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text("cases: []\n", encoding="utf-8")
+
+    aggregate = build_aggregate(
+        config_path=config,
+        index=index,
+        specs=specs,
+        variants=[_variant("control_no_cross_encoder_top20"), _variant("reranker_budget_pool30_topn20_top20", topn=20, rerank_delta=0.01)],
+        latency_budget={"profile_type": "private_real100_v2_latency_cost_budget", "overall_budget": {"hard_no_go_ceiling_ms": 200.0}, "cost_budget": {"status": "not_observable"}},
+        cases_requested=10,
+        cases_evaluated=3,
+    )
+    rendered = render_markdown(aggregate)
+
+    assert aggregate["profile_type"] == "private_real100_v2_reranker_candidate_budget"
+    assert aggregate["run_scope"]["subset_run"] is True
+    assert "raw questions" in rendered
+    assert "/Users/" not in json.dumps(aggregate)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [{"name": "control_no_cross_encoder_top20"}, {"name": "bad", "metrics": {"doc_id": "x"}}],
+        [{"name": "control_no_cross_encoder_top20"}, {"name": "bad", "metrics": {"evidence": []}}],
+    ],
+)
+def test_privacy_guard_rejects_raw_private_keys(payload: list[dict]) -> None:
+    config = REPO_ROOT / "reports" / "real100_v2" / "baseline.aggregate.json"
+    index = {"build": {}, "embedding": {}, "documents": [], "chunks": []}
+    with pytest.raises(ValueError, match="privacy guard|aggregate artifact failed"):
+        build_aggregate(
+            config_path=config,
+            index=index,
+            specs=[],
+            variants=payload,
+            latency_budget={},
+            cases_requested=1,
+            cases_evaluated=1,
+        )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1629

`T-2026-0032`의 reranker candidate-budget 실험을 `real100_v2` 전용 aggregate-only runner/report로 구현했습니다. 런타임 기본 동작은 바꾸지 않고, runner 안에서만 candidate pool과 cross-encoder `top_n`을 sweep합니다. 이번 committed evidence는 3-case BGE-KO screening이며, latency hard ceiling을 크게 넘어서 `latency_regression`으로 분류했습니다. `paired_delta_valid=false`이므로 private eval improvement claim은 하지 않습니다.

## 2. 영향 파일

- `scripts/run_real100_v2_reranker_budget_sweep.py` — opt-in private reranker budget sweep runner 추가
- `tests/test_real100_v2_reranker_budget_sweep.py` — classification, top_n wrapper, privacy guard 테스트 추가
- `reports/real100_v2/reranker_candidate_budget.aggregate.json` — aggregate-only screening result 추가
- `docs/evaluation/real100_v2-reranker-candidate-budget.md` — reviewer-facing report 추가
- `docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`, `tasks/queue.md` — T-2026-0032 status/result 및 next T-2026-0033 readiness 업데이트
- `.gitignore`, `.githooks/pre-commit`, `reports/real100_v2/README.md`, `scripts/check_real100_v2_only.py` — aggregate allowlist와 v2-only guard 업데이트

## 3. 리스크

가장 큰 리스크는 private raw fields 또는 stale legacy evidence가 aggregate에 섞이는 것입니다. runner output은 aggregate-only privacy guard를 통과해야 write되고, model id도 path-like 오탐/누출을 피하도록 safe label로 저장합니다. 또 BGE-KO local CPU latency는 screening 3건에서도 hard no-go ceiling을 크게 넘었으므로 이 PR은 no-winner evidence로만 해석해야 합니다.

## 4. 테스트

- `python3 -m py_compile scripts/run_real100_v2_reranker_budget_sweep.py scripts/check_real100_v2_only.py`
- `python3 -m pytest -q tests/test_real100_v2_reranker_budget_sweep.py tests/test_real100_v2_guard.py`
- `python3 scripts/run_real100_v2_reranker_budget_sweep.py --config <external_private_real100_v2_config> --index-dir <external_private_real100_v2_index> --cases-subset-n 3 --candidate-pools 30 --reranker-top-ns 10 --reranker-backend bge_ko`
- `REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml REAL100_V2_INDEX_DIR=data/index/real100_v2 REAL100_V2_REPORT_DIR=reports/real100_v2 make real-eval-v2-check`
- `make real-eval-v2-guard`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md docs/evaluation/real100_v2-reranker-candidate-budget.md reports/real100_v2/README.md`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff origin/main --check && make check-branch`

## 5. Eval 영향

No runtime behavior change. This PR adds an opt-in private measurement runner and aggregate report only. The committed `real100_v2` screening output classifies the local BGE-KO reranker variant as `latency_regression`; it is not a full paired private eval delta and not a performance improvement claim.

### 5b. Real-data delta

| Surface | Result |
| --- | --- |
| eval surface | `real100_v2`, aggregate-only |
| real private eval execution | 3-case local screening run only |
| paired delta validity | `false`; 3 of 300 cases evaluated |
| candidate variant | `reranker_budget_pool30_topn10_top20` |
| reranker provenance | backend `bge_ko`, model safe label `dragonkue__bge-reranker-v2-m3-ko`, fallback rate 0.0 |
| classification | `latency_regression` |
| latency guardrail | hard no-go ceiling 4799 ms from `T-2026-0030`; candidate p95 149369.571 ms |
| cost status | `not_observable_from_committed_aggregate` |
| privacy audit | pass, 0 findings |

검색/검증/답변 path 동작 변화 없음. `paired_delta_valid=false`라서 headline improvement claim 없음.

## 6. 하위 호환

No answer-contract, ingestion, retrieval, reranking default, verifier, API, or eval scoring behavior changes. The runner uses eval-only wrapping to force reranker `top_n`; production/default code paths are unchanged.

## 7. 범위 외

- No GPU reranker run.
- No full 300-case paired private delta.
- No default reranker enablement or backend change.
- No page metadata repair; T-2026-0031 remains blocked.
- No cleanup of unrelated orphan worktrees reported by push hooks.
