### PR TITLE
chore: add active auto-loop driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@
 # they render prompts, classify surfaces, check handoffs, suggest or run
 # allowlisted local validation, and write ignored local planning drafts. They
 # do not perform GitHub mutations.
-.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-active-start agent-loop-active-codex-runner 시작 agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
+.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-active-start agent-loop-active-codex-runner agent-loop-active-auto-loop 시작 agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
@@ -427,6 +427,11 @@ ACTIVE_START_RUNNER_EXECUTE ?= 1
 ACTIVE_CODEX_RUNNER_OUT ?= reports/agent_loop/active/codex_runner.md
 ACTIVE_CODEX_RUNNER_STATE ?= reports/agent_loop/active/codex_runner_state.json
 ACTIVE_CODEX_RUNS_DIR ?= reports/agent_loop/active/codex_runs
+ACTIVE_AUTO_LOOP_OUT ?= reports/agent_loop/active/auto_loop.md
+ACTIVE_AUTO_LOOP_STATE ?= reports/agent_loop/active/auto_loop_state.json
+ACTIVE_AUTO_LOOP_MAX_ITERATIONS ?= 1
+ACTIVE_AUTO_LOOP_EXECUTE_RUNNER ?= 1
+ACTIVE_AUTO_LOOP_EXECUTE_SHIP ?= 0
 ACTIVE_CODEX_SESSIONS ?=
 ACTIVE_CODEX_MAX_PARALLEL ?= 8
 ACTIVE_CODEX_TIMEOUT_SECONDS ?= 0
@@ -951,6 +956,30 @@ agent-loop-active-codex-runner:
 	  --runs-dir "$(ACTIVE_CODEX_RUNS_DIR)" \
 	  --state "$(ACTIVE_CODEX_RUNNER_STATE)" \
 	  --out "$(ACTIVE_CODEX_RUNNER_OUT)"
+
+agent-loop-active-auto-loop:
+	$(PYTHON) scripts/agent_loop.py active-auto-loop \
+	  --topology "$(ACTIVE_TOPOLOGY)" \
+	  --agent-mix "$(ACTIVE_AGENT_MIX)" \
+	  --lease-ttl-minutes "$(ACTIVE_LEASE_TTL_MINUTES)" \
+	  --max-iterations "$(ACTIVE_AUTO_LOOP_MAX_ITERATIONS)" \
+	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_EXECUTE_RUNNER)),--execute-runner,) \
+	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_EXECUTE_SHIP)),--execute-ship,) \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",) \
+	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
+	  $(if $(PR_BODY_OUT),--pr-body "$(PR_BODY_OUT)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(filter 1 true yes,$(ACTIVE_REPAIR_BRANCH)),--repair-branch,) \
+	  --repair-branch-type "$(ACTIVE_REPAIR_BRANCH_TYPE)" \
+	  --repair-slug "$(ACTIVE_REPAIR_SLUG)" \
+	  --repair-title "$(ACTIVE_REPAIR_TITLE)" \
+	  --codex-executable "$(ACTIVE_CODEX_EXECUTABLE)" \
+	  --sandbox "$(ACTIVE_CODEX_SANDBOX)" \
+	  --max-parallel "$(ACTIVE_CODEX_MAX_PARALLEL)" \
+	  --timeout-seconds "$(ACTIVE_CODEX_TIMEOUT_SECONDS)" \
+	  --state "$(ACTIVE_AUTO_LOOP_STATE)" \
+	  --out "$(ACTIVE_AUTO_LOOP_OUT)"
 
 시작: agent-loop-active-start
 

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -183,6 +183,30 @@ Execute mode는 8개 process를 spawn한 뒤 종료 코드와 last message artif
 agent process가 끝났다는 사실은 reviewer/auditor gate 통과 근거가 아니며, gate
 status는 별도 heartbeat나 검토 표면에서 유지한다.
 
+## Active Auto Loop
+
+`active-start` + runner를 한 번만 실행하는 wrapper와 별개로, bounded 반복 드라이버는
+다음 target이다.
+
+```bash
+make agent-loop-active-auto-loop
+```
+
+흐름은 `tasks/queue.md`에서 ready/todo/backlog task를 고르고, `active-start`로
+expanded-eight ledger와 assignments를 쓴 뒤, `active-codex-runner`를 실행하고,
+`gate-evidence`를 기록한다. `ACTIVE_AUTO_LOOP_EXECUTE_SHIP=1`일 때만 gate 통과 후
+`active-loop --execute`를 호출한다.
+
+중요한 완료 기준: runner 완료는 task 해결이 아니다. auto loop는 `active-loop
+--execute`가 `executed`를 반환한 task만 `reports/agent_loop/active/auto_loop_state.json`
+의 `completed_task_ids`에 기록하고, 다음 iteration/다음 invocation에서 그 task를
+제외해 즉시 다음 task를 고른다. 기본값은 runner 실행까지이며 ship은 꺼져 있다.
+
+```bash
+make agent-loop-active-auto-loop ACTIVE_AUTO_LOOP_MAX_ITERATIONS=3
+make agent-loop-active-auto-loop ACTIVE_AUTO_LOOP_EXECUTE_SHIP=1 ACTIVE_AUTO_LOOP_MAX_ITERATIONS=3
+```
+
 ## Patch Write-Lane (codex, mutating)
 
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -136,6 +136,8 @@ DEFAULT_ACTIVE_WORKTREE_PREPARE = DEFAULT_ACTIVE_DIR / "active_worktree_prepare.
 DEFAULT_ACTIVE_CODEX_RUNNER = DEFAULT_ACTIVE_DIR / "codex_runner.md"
 DEFAULT_ACTIVE_CODEX_RUNNER_STATE = DEFAULT_ACTIVE_DIR / "codex_runner_state.json"
 DEFAULT_ACTIVE_CODEX_RUNS_DIR = DEFAULT_ACTIVE_DIR / "codex_runs"
+DEFAULT_ACTIVE_AUTO_LOOP = DEFAULT_ACTIVE_DIR / "auto_loop.md"
+DEFAULT_ACTIVE_AUTO_LOOP_STATE = DEFAULT_ACTIVE_DIR / "auto_loop_state.json"
 DEFAULT_ISSUE_STATE = DEFAULT_REPORT_DIR / "issue_state.json"
 DEFAULT_ISSUE_TRIAGE = DEFAULT_REPORT_DIR / "issue_triage.md"
 DEFAULT_ISSUE_QUEUE_TASKS_DIR = DEFAULT_REPORT_DIR / "issue_queue_tasks"
@@ -593,6 +595,18 @@ class ActiveApplyResult:
     decision: str
     integration_branch: str
     applied: bool
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ActiveAutoLoopResult:
+    report_path: Path
+    state_path: Path
+    decision: str
+    cycles: tuple[dict[str, object], ...]
+    completed_task_ids: tuple[str, ...]
+    next_task_id: str | None
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
 
@@ -1537,14 +1551,16 @@ def recommend_next_task(repo_root: Path = ROOT_DIR) -> str:
     return "\n".join(lines) + "\n"
 
 
-def select_next_task(repo_root: Path = ROOT_DIR) -> TaskEntry:
+def select_next_task(repo_root: Path = ROOT_DIR, exclude_task_ids: Sequence[str] = ()) -> TaskEntry:
     queue_text = _read_text(repo_root / QUEUE_PATH)
     entries = parse_task_entries(queue_text)
     if not entries:
         raise ValueError("no task entries found in tasks/queue.md")
-    ready = [entry for entry in entries if (entry.status or "").lower() == "ready"]
-    todo = [entry for entry in entries if (entry.status or "").lower() == "todo"]
-    backlog = [entry for entry in entries if (entry.status or "").lower() == "backlog"]
+    excluded = set(exclude_task_ids)
+    selectable = [entry for entry in entries if entry.task_id not in excluded]
+    ready = [entry for entry in selectable if (entry.status or "").lower() == "ready"]
+    todo = [entry for entry in selectable if (entry.status or "").lower() == "todo"]
+    backlog = [entry for entry in selectable if (entry.status or "").lower() == "backlog"]
     candidates = ready or todo or backlog
     if not candidates:
         raise ValueError("no ready, todo, or backlog task found; choose manually from tasks/queue.md")
@@ -9070,6 +9086,301 @@ def render_active_start(
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
+def _load_active_auto_completed(state_path: Path) -> tuple[list[str], list[str]]:
+    warnings: list[str] = []
+    if not state_path.exists():
+        return [], warnings
+    try:
+        payload = json.loads(_read_text(state_path))
+    except (json.JSONDecodeError, OSError):
+        return [], ["ignored unreadable active auto-loop state"]
+    if not isinstance(payload, dict):
+        return [], ["ignored non-object active auto-loop state"]
+    raw = payload.get("completed_task_ids")
+    if not isinstance(raw, list):
+        return [], warnings
+    completed = [item for item in (str(value) for value in raw) if TASK_ID_RE.fullmatch(item)]
+    return list(_dedupe_preserve_order(completed)), warnings
+
+
+def write_active_auto_loop(
+    *,
+    mode: str = "full-ship",
+    topology: str = "expanded-eight",
+    max_iterations: int = 1,
+    execute_runner: bool = False,
+    execute_ship: bool = False,
+    record_gate_heartbeats: bool = True,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    claim_text: Path | None = None,
+    pr_body: Path | None = None,
+    lease_ttl_minutes: int = 30,
+    batch: Path | None = None,
+    agent_mix: dict[str, object] | None = None,
+    repair_branch: bool = False,
+    repair_branch_type: str = "chore",
+    repair_slug: str = "active-start",
+    repair_title: str = "Agent loop active start",
+    codex_executable: str = "codex",
+    sandbox: str = "read-only",
+    max_parallel: int = 8,
+    timeout_seconds: int = 0,
+    state: Path = DEFAULT_ACTIVE_AUTO_LOOP_STATE,
+    out: Path = DEFAULT_ACTIVE_AUTO_LOOP,
+    repo_root: Path = ROOT_DIR,
+) -> ActiveAutoLoopResult:
+    """Bounded active-loop driver: start, run sessions, gate, ship, then pick next task.
+
+    A task is recorded as completed only after ``active-loop --execute`` returns
+    ``executed``. Dry-run or read-only cycles never advance the completed-task ledger, so the
+    controller cannot mistake a report-only pass for solved work.
+    """
+    if max_iterations < 1:
+        raise ValueError("--max-iterations must be at least 1")
+    if mode != "full-ship":
+        raise ValueError("--mode currently supports only full-ship")
+    if task_id and not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("--task must match T-YYYY-NNNN")
+    if sandbox not in {"read-only", "workspace-write", "danger-full-access"}:
+        raise ValueError("--sandbox must be read-only, workspace-write, or danger-full-access")
+
+    out_path = _active_path(out, repo_root=repo_root)
+    state_path = _active_path(state, repo_root=repo_root)
+    prior_completed, warnings = _load_active_auto_completed(state_path)
+    completed: list[str] = list(prior_completed)
+    blockers: list[str] = []
+    cycles: list[dict[str, object]] = []
+    requested_files = tuple(sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path))
+
+    for iteration in range(1, max_iterations + 1):
+        try:
+            task = load_task(task_id, repo_root) if task_id and iteration == 1 else select_next_task(
+                repo_root, exclude_task_ids=completed
+            )
+        except ValueError as exc:
+            if iteration == 1:
+                blockers.append(str(exc))
+            else:
+                warnings.append(f"no next task selected after iteration {iteration - 1}: {exc}")
+            break
+
+        context_files = tuple(_dedupe_preserve_order((*requested_files, *_active_task_context_files(task, repo_root=repo_root))))
+        cycle: dict[str, object] = {
+            "iteration": iteration,
+            "task_id": task.task_id,
+            "title": task.title,
+            "changed_files": list(context_files),
+            "completed": False,
+        }
+        cycles.append(cycle)
+
+        start = write_active_start(
+            mode=mode,
+            topology=topology,
+            task_id=task.task_id,
+            changed_files=context_files,
+            claim_text=claim_text,
+            pr_body=pr_body,
+            lease_ttl_minutes=lease_ttl_minutes,
+            batch=batch,
+            agent_mix=agent_mix,
+            repair_branch=repair_branch,
+            repair_branch_type=repair_branch_type,
+            repair_slug=repair_slug,
+            repair_title=repair_title,
+            repo_root=repo_root,
+        )
+        cycle["start_decision"] = start.decision
+        cycle["start_report"] = _repo_path(start.report_path, repo_root)
+        if start.blockers:
+            blockers.extend(f"{task.task_id}: {item}" for item in start.blockers)
+            break
+
+        runner = write_active_codex_runner(
+            execute=execute_runner,
+            codex_executable=codex_executable,
+            sandbox=sandbox,
+            max_parallel=max_parallel,
+            timeout_seconds=timeout_seconds,
+            record_gate_heartbeats=record_gate_heartbeats,
+            repo_root=repo_root,
+        )
+        cycle["runner_decision"] = runner.decision
+        cycle["runner_report"] = _repo_path(runner.report_path, repo_root)
+        if execute_runner and runner.decision != "completed":
+            blockers.extend(f"{task.task_id}: runner {item}" for item in runner.blockers)
+            if not runner.blockers:
+                blockers.append(f"{task.task_id}: runner decision was {runner.decision}, expected completed")
+            break
+
+        evidence_path, gate_summary = write_active_gate_evidence(task_id=task.task_id, repo_root=repo_root)
+        cycle["gate_evidence"] = _repo_path(evidence_path, repo_root)
+        cycle["gate_ready"] = bool(gate_summary.get("ready"))
+        cycle["privacy_clean"] = bool(gate_summary.get("privacy_clean"))
+
+        if not execute_ship:
+            warnings.append(f"{task.task_id}: ship execution disabled; not marking task completed")
+            break
+        if not cycle["gate_ready"]:
+            blockers.append(f"{task.task_id}: conservative gate is not ready")
+            break
+
+        ship = write_active_loop(
+            mode=mode,
+            topology=topology,
+            execute=True,
+            task_id=task.task_id,
+            changed_files=context_files,
+            claim_text=claim_text,
+            pr_body=pr_body,
+            lease_ttl_minutes=lease_ttl_minutes,
+            batch=batch,
+            agent_mix=agent_mix,
+            repo_root=repo_root,
+        )
+        cycle["ship_decision"] = ship.decision
+        cycle["ship_report"] = _repo_path(ship.report_path, repo_root)
+        if ship.decision != "executed":
+            blockers.extend(f"{task.task_id}: ship {item}" for item in ship.blockers)
+            if not ship.blockers:
+                blockers.append(f"{task.task_id}: ship decision was {ship.decision}, expected executed")
+            break
+
+        cycle["completed"] = True
+        if task.task_id not in completed:
+            completed.append(task.task_id)
+
+    next_task: TaskEntry | None = None
+    try:
+        next_task = select_next_task(repo_root, exclude_task_ids=completed)
+    except ValueError as exc:
+        warnings.append(f"next task selection stopped: {exc}")
+
+    if blockers:
+        decision = "blocked"
+    elif cycles and all(bool(cycle.get("completed")) for cycle in cycles) and len(cycles) >= max_iterations:
+        decision = "limit-reached"
+    elif cycles and any(bool(cycle.get("completed")) for cycle in cycles):
+        decision = "completed"
+    else:
+        decision = "planned"
+
+    state_payload = {
+        "schema_version": 1,
+        "generated_at": _isoformat(datetime.now(timezone.utc)),
+        "decision": decision,
+        "execute_runner": execute_runner,
+        "execute_ship": execute_ship,
+        "completed_task_ids": completed,
+        "next_task_id": next_task.task_id if next_task else None,
+        "cycles": cycles,
+        "blockers": _dedupe_preserve_order(blockers),
+        "warnings": _dedupe_preserve_order(warnings),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    rendered = render_active_auto_loop(
+        decision=decision,
+        execute_runner=execute_runner,
+        execute_ship=execute_ship,
+        cycles=cycles,
+        completed_task_ids=completed,
+        next_task=next_task,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        state_path=state_path,
+        repo_root=repo_root,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    _append_active_event(
+        _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
+        {
+            "event": "active-auto-loop",
+            "decision": decision,
+            "execute_runner": execute_runner,
+            "execute_ship": execute_ship,
+            "completed_task_ids": completed,
+            "next_task_id": next_task.task_id if next_task else None,
+            "blockers": blockers,
+        },
+    )
+    return ActiveAutoLoopResult(
+        report_path=out_path,
+        state_path=state_path,
+        decision=decision,
+        cycles=tuple(cycles),
+        completed_task_ids=tuple(completed),
+        next_task_id=next_task.task_id if next_task else None,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+    )
+
+
+def render_active_auto_loop(
+    *,
+    decision: str,
+    execute_runner: bool,
+    execute_ship: bool,
+    cycles: Sequence[dict[str, object]],
+    completed_task_ids: Sequence[str],
+    next_task: TaskEntry | None,
+    blockers: Sequence[str],
+    warnings: Sequence[str],
+    state_path: Path,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# Active Auto Loop",
+        "",
+        "- Bounded driver for task selection -> active-start -> 8-session runner -> gate evidence -> optional ship -> next task.",
+        "- A task is completed only after `active-loop --execute` returns `executed`; read-only runner completion alone is not enough.",
+        f"- Decision: `{_sanitize_inline_text(decision)}`",
+        f"- Execute runner: `{execute_runner}`",
+        f"- Execute ship: `{execute_ship}`",
+        f"- State: `{_repo_path(state_path, repo_root)}`",
+        "",
+        "## Cycles",
+        "",
+        "| Iteration | Task | Start | Runner | Gate ready | Ship | Completed |",
+        "|---:|---|---|---|---|---|---|",
+    ]
+    if cycles:
+        for cycle in cycles:
+            lines.append(
+                "| "
+                + " | ".join(
+                    _sanitize_inline_text(str(value))
+                    for value in (
+                        cycle.get("iteration", ""),
+                        cycle.get("task_id", ""),
+                        cycle.get("start_decision", ""),
+                        cycle.get("runner_decision", ""),
+                        cycle.get("gate_ready", ""),
+                        cycle.get("ship_decision", "not-run"),
+                        cycle.get("completed", False),
+                    )
+                )
+                + " |"
+            )
+    else:
+        lines.append("|  | N/A |  |  |  |  | false |")
+    lines.extend(["", "## Completed Tasks", ""])
+    lines.extend(f"- `{task}`" for task in completed_task_ids) if completed_task_ids else lines.append("- None")
+    lines.extend(["", "## Next Task", ""])
+    if next_task is not None:
+        lines.append(f"- `{next_task.task_id}` — {_sanitize_dynamic_text(next_task.title)}")
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Blockers", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in warnings) if warnings else lines.append("- None")
+    lines.append("")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
 def render_active_loop(
     *,
     mode: str,
@@ -9217,6 +9528,10 @@ def _active_path(path: Path, *, repo_root: Path) -> Path:
         path = repo_root / "reports" / "agent_loop" / "active" / "codex_runner_state.json"
     elif path == DEFAULT_ACTIVE_CODEX_RUNS_DIR:
         path = repo_root / "reports" / "agent_loop" / "active" / "codex_runs"
+    elif path == DEFAULT_ACTIVE_AUTO_LOOP:
+        path = repo_root / "reports" / "agent_loop" / "active" / "auto_loop.md"
+    elif path == DEFAULT_ACTIVE_AUTO_LOOP_STATE:
+        path = repo_root / "reports" / "agent_loop" / "active" / "auto_loop_state.json"
     return _safe_output_path(path, repo_root=repo_root)
 
 
@@ -13046,6 +13361,32 @@ def build_parser() -> argparse.ArgumentParser:
     codex_runner.add_argument("--base", default="origin/main", help="Base ref the patch-mode scratch worktree forks from.")
     codex_runner.add_argument("--record-gate-heartbeats", action="store_true")
 
+    auto_loop = sub.add_parser("active-auto-loop", help="Run bounded active-start/runner/gate/ship cycles across queue tasks.")
+    auto_loop.add_argument("--mode", choices=("full-ship",), default="full-ship")
+    auto_loop.add_argument("--topology", choices=ACTIVE_TOPOLOGY_CHOICES, default="expanded-eight")
+    auto_loop.add_argument("--max-iterations", type=int, default=1)
+    auto_loop.add_argument("--execute-runner", action="store_true")
+    auto_loop.add_argument("--execute-ship", action="store_true")
+    auto_loop.add_argument("--record-gate-heartbeats", action=argparse.BooleanOptionalAction, default=True)
+    auto_loop.add_argument("--task")
+    auto_loop.add_argument("--changed-files", type=Path)
+    auto_loop.add_argument("--from-git", action="store_true")
+    auto_loop.add_argument("--claim-text", type=Path)
+    auto_loop.add_argument("--pr-body", type=Path)
+    auto_loop.add_argument("--lease-ttl-minutes", type=int, default=30)
+    auto_loop.add_argument("--batch", type=Path)
+    auto_loop.add_argument("--agent-mix", help="Work-unit mix target, e.g. claude=5,codex=5")
+    auto_loop.add_argument("--repair-branch", action="store_true")
+    auto_loop.add_argument("--repair-branch-type", default="chore")
+    auto_loop.add_argument("--repair-slug", default="active-start")
+    auto_loop.add_argument("--repair-title", default="Agent loop active start")
+    auto_loop.add_argument("--codex-executable", default="codex")
+    auto_loop.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
+    auto_loop.add_argument("--max-parallel", type=int, default=8)
+    auto_loop.add_argument("--timeout-seconds", type=int, default=0)
+    auto_loop.add_argument("--state", type=Path, default=DEFAULT_ACTIVE_AUTO_LOOP_STATE)
+    auto_loop.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_AUTO_LOOP)
+
     active_apply = sub.add_parser("active-apply", help="Apply a codex patch artifact to its integration branch after git apply --check (never touches main).")
     active_apply.add_argument("--patch", type=Path, help="Patch artifact JSON; defaults to the Implementer session's patch_artifact.json.")
     active_apply.add_argument("--base", default="origin/main", help="Base ref the integration branch forks from when created.")
@@ -13979,6 +14320,40 @@ def main(argv: list[str] | None = None) -> int:
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
             return 0 if result.decision in {"planned", "running", "completed"} else 1
+        if args.command == "active-auto-loop":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            result = write_active_auto_loop(
+                mode=args.mode,
+                topology=args.topology,
+                max_iterations=args.max_iterations,
+                execute_runner=args.execute_runner,
+                execute_ship=args.execute_ship,
+                record_gate_heartbeats=args.record_gate_heartbeats,
+                task_id=args.task,
+                changed_files=files,
+                claim_text=args.claim_text,
+                pr_body=args.pr_body,
+                lease_ttl_minutes=args.lease_ttl_minutes,
+                batch=args.batch,
+                agent_mix=_parse_agent_mix(args.agent_mix),
+                repair_branch=args.repair_branch,
+                repair_branch_type=args.repair_branch_type,
+                repair_slug=args.repair_slug,
+                repair_title=args.repair_title,
+                codex_executable=args.codex_executable,
+                sandbox=args.sandbox,
+                max_parallel=args.max_parallel,
+                timeout_seconds=args.timeout_seconds,
+                state=args.state,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
+            return 0 if result.decision in {"planned", "completed", "limit-reached"} else 1
         if args.command == "active-apply":
             apply_result = write_active_apply(
                 patch=args.patch,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3842,6 +3842,126 @@ def test_make_active_start_can_disable_runner_and_has_korean_alias() -> None:
     assert 'make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="1"' in alias.stdout
 
 
+def test_active_auto_loop_completes_task_and_picks_next_from_state(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="First task")
+    queue = repo / "tasks" / "queue.md"
+    queue.write_text(
+        queue.read_text(encoding="utf-8")
+        + """
+
+## T-2026-1002 — Second task
+
+- ID: T-2026-1002
+- Title: Second task
+- Status: ready
+- Owner role: Implementer -> Reviewer
+
+### Goal
+
+Run after the first task completes.
+
+### Acceptance Criteria
+
+- [ ] Selected after T-2026-1001.
+
+### Validation Commands
+
+```bash
+git diff --check
+```
+""",
+        encoding="utf-8",
+    )
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    def fake_ship(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "active_loop.md"
+        registry = active_dir / "session_registry.json"
+        leases = active_dir / "leases.json"
+        events = active_dir / "events.jsonl"
+        assignments = active_dir / "assignments"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# shipped\n", encoding="utf-8")
+        return agent_loop.ActiveLoopResult(registry, leases, events, assignments, report, "executed", (), ())
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+    monkeypatch.setattr(agent_loop, "write_active_loop", fake_ship)
+
+    first = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=True,
+        repo_root=repo,
+    )
+    second = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+
+    assert first.completed_task_ids == ("T-2026-1001",)
+    assert first.next_task_id == "T-2026-1002"
+    assert first.decision == "limit-reached"
+    assert second.cycles[0]["task_id"] == "T-2026-1002"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["completed_task_ids"] == ["T-2026-1001"]
+
+
+def test_active_auto_loop_does_not_mark_read_only_cycle_completed(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Read-only task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "planned", (), (), ("dry-run",))
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "planned"
+    assert result.completed_task_ids == ()
+    assert result.next_task_id == "T-2026-1001"
+    assert any("ship execution disabled" in warning for warning in result.warnings)
+    assert result.cycles[0]["completed"] is False
+
+
 def test_codex_lane_adapter_maps_verdict_severity_and_errors(monkeypatch, tmp_path: Path) -> None:
     from scripts import agent_loop_codex_turn as cx
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`active-start`와 8-session Codex runner 이후 task 완료 판정과 다음 task 선택을 이어주는 bounded `active-auto-loop` driver를 추가했습니다. Runner 완료만으로 task를 해결했다고 보지 않고, 기존 `active-loop --execute`가 `executed`를 반환한 경우에만 `completed_task_ids`에 기록해 다음 task로 넘어가도록 했습니다.

Closes #1634

## 2. 영향 파일

- `scripts/agent_loop.py` — `active-auto-loop` CLI, state/report writer, completed task 제외 선택 로직
- `Makefile` — `agent-loop-active-auto-loop` target 및 설정 변수
- `tests/test_agent_loop.py` — completed task skip / read-only non-completion regression coverage
- `docs/operations/active-agent-loop.md` — 운영 계약 문서화

## 3. 리스크

- 가장 큰 리스크는 runner completion을 task completion으로 오인해 queue task를 건너뛰는 것입니다. 이를 막기 위해 `active-loop --execute == executed`일 때만 completed ledger에 기록하도록 테스트했습니다.
- `active-auto-loop`가 기존 ship semantics를 우회할 위험이 있습니다. `ACTIVE_AUTO_LOOP_EXECUTE_SHIP=1`일 때도 기존 `write_active_loop(... execute=True)` 경로만 호출하도록 제한했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 -m py_compile scripts/agent_loop.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/active-agent-loop.md`
- `git diff --check`
- `make check-branch`
- Smoke: `python3 scripts/agent_loop.py active-auto-loop --max-iterations 1 --out reports/agent_loop/active/auto_loop_probe.md --state reports/agent_loop/active/auto_loop_probe_state.json`

## 5. Eval 영향

All `·` — orchestration/automation surface only. No RAG retrieval, answer, verifier, ingestion, eval harness, or runtime behavior change.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 변경 없음; private real-data delta not run.

## 6. 하위 호환

기존 `active-start`, `active-codex-runner`, `active-loop`, and `four-role`/`expanded-eight` contracts remain compatible. New CLI/Make target is additive.

## 7. 범위 외

- 실제 task queue status를 tracked `done`으로 수정하지 않습니다. Completion is tracked in ignored `reports/agent_loop/active/auto_loop_state.json` only.
- Remote branch cleanup and stale worktree cleanup are not included.