### PR TITLE
eval: plan context packing experiment

### DIFF
--- a/docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
+++ b/docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
@@ -1,0 +1,191 @@
+# Plan: T-2026-0033 context packing and citation ordering experiment
+
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0033`
+- Related issue / PR: [#1638](https://github.com/hskim-solv/BidMate-DocAgent/issues/1638) / PR TBD
+- Related ADR: [ADR 0003](../adr/0003-structured-answer-citation-contract.md), [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0054](../adr/0054-conditional-on-answer-scorer-semantics.md)
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+`T-2026-0032` showed that local BGE-KO cross-encoder reranking is not a viable
+near-term winner under the `T-2026-0030` latency hard ceiling. The next
+candidate should improve how already-selected evidence is assembled for answer
+generation while holding retrieval and reranker behavior fixed. Without a plan,
+this can easily drift into retrieval ranking, query rewrite, prompt expansion,
+or private raw-context reporting.
+
+## Current Behavior
+
+- `rag_core.py` retrieves and verifies evidence, then passes selected evidence
+  into answer generation.
+- `rag_answer.py` preserves the ADR 0003 answer dict contract and citation
+  structure.
+- `eval/run_eval.py` already reports answer, abstention, citation, latency, and
+  synthesis token/cost fields when present.
+- `reports/real100_v2/reranker_candidate_budget.aggregate.json` classifies the
+  BGE-KO reranker screening as `latency_regression`; no reranker winner is
+  available to promote.
+- `reports/real100_v2/latency_cost_budget.aggregate.json` sets the current
+  baseline hard no-go latency ceiling at 4799 ms and marks cost telemetry as
+  not observable from the committed aggregate.
+
+## Desired Behavior
+
+Run an opt-in context-packing experiment that changes only the evidence assembly
+fed to answer generation. The output should report aggregate-only deltas for
+answer quality, citation guardrails, abstention, token/cost telemetry when
+present, and latency. The experiment must explicitly classify whether citation
+and answer metrics move together or whether any citation regression makes the
+variant no-go.
+
+## Constraints
+
+- Scope constraints: experiment-only; no default runtime change.
+- Architecture constraints: preserve ADR 0003 answer schema and ADR 0001
+  baseline behavior.
+- Compatibility constraints: additive variant/config/script/report only.
+- Eval/privacy constraints: `real100_v2` only; aggregate-only committed output;
+  no raw questions, answers, evidence, filenames, local paths, `doc_id`, or
+  `chunk_id`.
+- Tooling/CI constraints: CI may use a fixture/stub path; private run stays
+  local and aggregate-only.
+- Non-goals: retrieval ranking, reranker behavior, query rewrite, page metadata
+  repair, and context length increase without token/latency budget.
+
+## Architecture Impact
+
+- Affected modules or docs: likely `scripts/`, `tests/`, `docs/evaluation/`,
+  `reports/real100_v2/`, and `tasks/queue.md`.
+- Affected contracts or invariants: ADR 0003 output contract unchanged; ADR 0005
+  private boundary preserved.
+- Load-bearing paths: no runtime paths unless a later implementation adds an
+  opt-in answer/context variant.
+- ADR required: no for an additive experiment; yes if a later PR changes default
+  answer contract, retrieval, or context assembly behavior.
+- Backward compatibility expectation: existing `agentic_full` and
+  `naive_baseline` behavior remain unchanged unless the variant is explicitly
+  selected.
+
+## Affected Interfaces
+
+- CLI/API/config: new or existing local experiment runner with explicit variant
+  name such as `evidence_first`.
+- Input data: ignored local `real100_v2` config/index/eval summaries.
+- Output artifacts: aggregate-only JSON and Markdown report.
+- Docs/review surfaces: plan, queue, sweep report, PR body §5b.
+- Tests/eval entrypoints: focused unit tests plus private runner command.
+
+## Data / Eval Impact
+
+- Surface: private real-eval.
+- Data boundary: aggregate-only private output.
+- Allowed claim: context-packing classification tied to matching `real100_v2`
+  aggregate, latency/cost envelope, and unchanged retrieval/reranker behavior.
+- Disallowed claim: global answer quality improvement, page citation readiness,
+  or any comparison based on legacy `real100`/v1/221/kordoc evidence.
+- Baseline or control affected: no default baseline change; paired control must
+  be a matching `real100_v2` base aggregate.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Define the context-packing matrix: evidence-first ordering, duplicate
+   suppression, conflict grouping, and final context budget.
+2. Implement or reuse an opt-in local runner that compares control vs variant
+   without changing retrieval, reranking, verifier, or answer schema defaults.
+3. Emit aggregate-only metrics for answer quality, citation precision/alignment,
+   abstention, token/cost when present, latency, and no-go classification.
+4. Render a reviewer-facing report and update queue handoff with the next
+   decision.
+5. Run benchmark/privacy/claim audits before PR.
+
+## Acceptance Criteria
+
+- [ ] Context assembly variant is opt-in and separately named.
+- [ ] Retrieval and reranker behavior are explicitly unchanged in the aggregate.
+- [ ] Citation and answer metrics move together; citation regression is no-go.
+- [ ] Token/cost status is reported as present, absent, or not applicable.
+- [ ] No legacy `real100`/v1/221/kordoc evidence is used.
+
+## Validation Strategy
+
+Commands that must be run by the implementation PR:
+
+```bash
+python3 -m pytest -q tests/test_answer_contract_snapshot.py <focused-context-tests>
+python3 <context-packing-experiment> --config <local-v2-config> --index-dir <local-v2-index> --variant evidence_first --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <real100_v2-variant-aggregate>
+make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md <report-path>
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused tests and local private context-packing command pass.
+- Generated or updated artifact: aggregate-only context-packing report.
+- Reviewer checklist or manual inspection: answer contract, citation guardrail,
+  latency/cost, and privacy checks pass.
+- Explicitly not validated, with reason: no default runtime improvement unless
+  paired private delta and latency/cost guardrail support it.
+
+## Rollback Strategy
+
+Revert the experiment runner/report/config additions. Do not delete local
+private `real100_v2` raw run artifacts or indexes during rollback.
+
+## Failure Modes
+
+- Failure mode: answer quality improves while citation precision or
+  claim-citation alignment regresses.
+- Detection signal: report classifies the variant as citation no-go.
+- Stop condition or fallback: do not claim improvement; tighten context
+  selection or abandon the variant.
+
+- Failure mode: variant increases token count or latency beyond the budget.
+- Detection signal: token/cost block or latency budget reports a no-go breach.
+- Stop condition or fallback: reduce context budget or keep control behavior.
+
+- Failure mode: raw private fields leak into aggregate output.
+- Detection signal: privacy audit or focused test fails.
+- Stop condition or fallback: strip to closed enums/counts only.
+
+## Observability
+
+- `reports/real100_v2/latency_cost_budget.aggregate.json`
+- `reports/real100_v2/reranker_candidate_budget.aggregate.json`
+- Future context-packing aggregate and Markdown report
+- `make real-eval-v2-guard`
+- `python3 scripts/agent_loop.py privacy-audit-output`
+- `python3 scripts/agent_loop.py claim-audit --from-git`
+
+## Reviewer Notes
+
+Attack citation regressions and scope drift first. This experiment is only
+useful if retrieval/reranking stay fixed and answer/citation metrics improve
+together within the latency/cost budget.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 12:55 KST
+
+- Role: Planner
+- Branch / worktree: eval/issue-1638-plan-context-packing-citation-ordering-experimen / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1638 / PR TBD
+- Task: T-2026-0033
+- Current status: plan drafted; implementation should add an opt-in context-packing runner/report.
+- Files touched: docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md, tasks/queue.md, scripts/check_real100_v2_only.py
+- Decisions made: next experiment holds retrieval/reranking fixed because T-2026-0032 found local BGE-KO reranker latency no-go; no claim without paired real100_v2 aggregate and citation guardrails.
+- Commands run: make ship-start TITLE="Plan context packing citation ordering experiment" TYPE=eval; make check-branch.
+- Results: issue #1638 and branch created; branch gate passed; plan drafted.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
+- Open questions: none.
+- Risks: implementation can drift into retrieval/reranker/query rewrite unless the variant boundary is kept explicit.
+```

--- a/scripts/check_real100_v2_only.py
+++ b/scripts/check_real100_v2_only.py
@@ -15,6 +15,7 @@ DEFAULT_PATHS = (
     Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
     Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
     Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
+    Path("docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md"),
     Path("docs/evaluation/surface-map.md"),
     Path("docs/evaluation/private_real_eval_workflow.md"),
     Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
@@ -87,6 +88,7 @@ def check_path(path: Path) -> list[str]:
         Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
         Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
         Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
+        Path("docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md"),
         Path("docs/evaluation/surface-map.md"),
         Path("docs/evaluation/private_real_eval_workflow.md"),
     }
@@ -116,6 +118,7 @@ def check_path(path: Path) -> list[str]:
         Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
         Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
         Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
+        Path("docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md"),
         Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
         Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
         Path("docs/evaluation/real100_v2-reranker-candidate-budget.md"),

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -43,7 +43,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 30 | `T-2026-0030` | `done` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | merged in PR #1628; real100_v2 latency/cost envelope landed. |
 | 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
 | 32 | `T-2026-0032` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1629; BGE-KO screening run classifies latency_regression, no winner claim. |
-| 33 | `T-2026-0033` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; unblocked by T-2026-0030 budget and T-2026-0032 reranker latency no-go screening. |
+| 33 | `T-2026-0033` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1638; context-packing plan drafted after T-2026-0032 reranker latency no-go screening. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
 | 36 | `T-2026-0036` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on stable retrieval/context evidence from P0/P1 tasks. |
@@ -2964,7 +2964,9 @@ reranker behavior fixed.
 ### Acceptance Criteria
 
 - [ ] Context assembly variant is opt-in and separately named.
+- [ ] Retrieval and reranker behavior are explicitly unchanged in the aggregate.
 - [ ] Citation and answer metrics move together; citation regression is no-go.
+- [ ] Token/cost status is reported as present, absent, or not applicable.
 - [ ] Conflict grouping is visible to the generator without raw conflict text in
   committed reports.
 
@@ -2972,8 +2974,9 @@ reranker behavior fixed.
 
 ```bash
 python3 -m pytest -q tests/test_answer_contract_snapshot.py <focused-context-tests>
-python3 <context-packing-experiment> --variant evidence_first --summary-out <aggregate-output>
-python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+python3 <context-packing-experiment> --config <local-v2-config> --index-dir <local-v2-index> --variant evidence_first --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <real100_v2-variant-aggregate>
+make real-eval-v2-guard
 git diff --check
 make check-branch
 ```
@@ -2983,12 +2986,32 @@ make check-branch
 - Paired aggregate delta for citation, answer, abstention, token, and latency
   metrics.
 - Explicit no-change statement for retrieval behavior.
+- Aggregate-only privacy boundary, no raw private content.
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md`](../docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md)
+- Issue: [#1638](https://github.com/hskim-solv/BidMate-DocAgent/issues/1638)
 - PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 12:55 KST
+
+- Role: Planner
+- Branch / worktree: eval/issue-1638-plan-context-packing-citation-ordering-experimen / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1638 / PR TBD
+- Task: T-2026-0033
+- Current status: plan drafted; implementation should add an opt-in context-packing runner/report.
+- Files touched: docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md, tasks/queue.md, scripts/check_real100_v2_only.py
+- Decisions made: next experiment holds retrieval/reranking fixed because T-2026-0032 found local BGE-KO reranker latency no-go; no claim without paired real100_v2 aggregate and citation guardrails.
+- Commands run: make ship-start TITLE="Plan context packing citation ordering experiment" TYPE=eval; make check-branch.
+- Results: issue #1638 and branch created; branch gate passed; plan drafted.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
+- Open questions: none.
+- Risks: implementation can drift into retrieval/reranker/query rewrite unless the variant boundary is kept explicit.
+```
 
 ## T-2026-0034 — Query rewrite and decomposition experiment
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1638

`T-2026-0033` context packing and citation ordering experiment의 plan doc를 추가했습니다. 직전 `T-2026-0032`가 local BGE-KO reranker latency no-go를 냈기 때문에, 다음 실험은 retrieval/reranker를 고정하고 answer generation에 들어가는 evidence assembly만 opt-in variant로 측정하도록 범위를 고정했습니다.

## 2. 영향 파일

- `docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md` — 신규 plan doc
- `tasks/queue.md` — T-2026-0033 issue/plan/validation/handoff 연결
- `scripts/check_real100_v2_only.py` — T-2026-0033 plan도 v2-only guard 대상에 추가

## 3. 리스크

가장 큰 리스크는 implementation이 retrieval/reranker/query rewrite로 scope drift하는 것입니다. plan에서 non-goal과 validation을 분리했고, aggregate에는 retrieval/reranker unchanged statement와 citation no-go guardrail을 요구했습니다.

## 4. 테스트

- `make check-branch`
- `make real-eval-v2-guard`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff origin/main --check`

## 5. Eval 영향

Docs/planning only. No runtime behavior change and no benchmark/private-eval claim.

### 5b. Real-data delta

| Surface | Result |
| --- | --- |
| real private eval execution | Not run |
| paired delta validity | Not applicable; planning-only PR |
| eval surface | Future implementation must use `real100_v2`, aggregate-only |
| privacy audit | pass, 0 findings |

검색/검증/답변 path 동작 변화 없음.

## 6. 하위 호환

No CLI/API/schema/runtime behavior changes. The guard only adds a docs plan path to the existing real100_v2-only policy check.

## 7. 범위 외

- No context-packing implementation.
- No private eval run.
- No default answer/context behavior change.
- No cleanup of unrelated orphan worktrees reported by push hooks.
