### PR TITLE
docs: claude -p Edit-tool S2 failure matrix — evidence for codex-only write-lane

### DIFF
--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -187,9 +187,9 @@ status는 별도 heartbeat나 검토 표면에서 유지한다.
 
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex
 write-lane**을 돈다. read-only 8-session 모드는 불변이며, patch 모드는 write-lease
-owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` headless는 주요
-permission 모드 + bypass alias에서 모두 Edit-tool 호출이 깨지므로 write-lane은
-codex 전용 — 실측 근거는 아래 표).
+owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` print mode는 비-streaming
+직렬화 경로의 #1598 F4 버그로 Edit-tool 호출이 깨지므로 PR-B의 SDK 어댑터 도입
+전까지 write-lane은 codex 전용 — 실측 근거는 아래 표).
 
 claude `-p` Edit-tool 실측 매트릭스 (`scripts/reproduce_claude_edit_tool.py`,
 claude 2.1.3, 2026-05-28, 구독 OAuth 경로, raw artifact:
@@ -211,16 +211,32 @@ choices는 `default`, `acceptEdits`, `bypassPermissions`, `plan`, `dontAsk`,
 
 해석: 측정한 독립 permission 모드 3개(`default`, `acceptEdits`, `bypassPermissions`)와
 그 alias(`--dangerously-skip-permissions`)에서 모두 동일한 `messages.N.content.M:
-tool_use ids must be unique` API 400을 받았다. 따라서 #1598 F4는 permission
-approval 정책 계층(승인/거절/질문) 문제가 아니라, headless `claude -p`의
-tool_use 메시지 구성·`tool_use.id` 직렬화 경로 버그로 판단한다. plan-mode와
-`--tools` 빌트인 셋 형식 셀은 90s timeout(S3)으로 떨어졌는데, 같은 직렬화
-경로의 다른 분기로 추정 — plan-mode는 `EnterPlanMode`/`ExitPlanMode` tool-call이
-일반 tool-call과 섞여 더 취약하고, `--tools` 빌트인 셋은 tool contract 변경으로
-같은 취약 경로를 자극한다. `dontAsk`, `delegate` 모드는 본 라운드에서 측정하지
-않았다. 어느 측정 셀도 단일 trivial edit을 완료하지 못했고, wrapper-side 회피는
-가능 영역 밖이다. write-lane은 codex 전용을 유지하고 upstream `claude-code`의
-headless tool_use 직렬화 수정 대기.
+tool_use ids must be unique` API 400을 받았다. plan-mode와 `--tools` 빌트인 셋
+형식 셀은 90s timeout(S3)으로 떨어졌는데, 같은 직렬화 경로의 다른 분기로 추정 —
+plan-mode는 `EnterPlanMode`/`ExitPlanMode` tool-call이 일반 tool-call과 섞여 더
+취약하고, `--tools` 빌트인 셋은 tool contract 변경으로 같은 취약 경로를 자극한다.
+
+그러나 같은 `claude` 바이너리를 **streaming transport**로 호출하는 Python SDK
+(`claude-agent-sdk` 0.2.87, internal `_is_streaming = True`)에서는 같은 trivial
+edit 태스크가 모든 측정 mode에서 정상 동작한다 (`scripts/reproduce_claude_sdk_edit.py`):
+
+| Cell | SDK permission_mode | tool_use | edited | symptom |
+|---|---|---|---|---|
+| 09 | `default` | 2 | yes | S4_normal |
+| 10 | `acceptEdits` | 2 | yes | S4_normal |
+| 11 | `plan` | 4 | no | S4 (mode spec — mutation 없음, tool_use 발생) |
+| 12 | `bypassPermissions` | 2 | yes | S4_normal |
+| 13 | `dontAsk` | 2 | yes | S4_normal |
+| 14 | `auto` | 2 | yes | S4_normal |
+
+따라서 #1598 F4는 **permission approval 정책 계층(승인/거절/질문) 문제가 아니라
+`claude -p` print mode의 비-streaming 직렬화 경로 한정 버그**로 단정한다. SDK의
+`--input-format stream-json --output-format stream-json` transport는 같은
+바이너리의 다른 코드 경로를 타서 영향이 없다. 즉 wrapper-side 회피는 **SDK 어댑터로
+전환하면 가능**하다 — write-lane의 claude 분기를 codex와 나란히 둘 수 있는 길이
+열린다. 본 PR은 측정·문서화까지만 다루고, SDK 기반 `agent_loop_claude_patch_turn.py`
++ `agent_loop.py:10103`의 `agent="codex"` 하드코딩 분기화는 별 PR(PR-B)에서
+처리한다.
 
 ```bash
 python3 scripts/agent_loop.py active-codex-runner --mode patch --task T-2026-00NN --execute

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -187,29 +187,40 @@ status는 별도 heartbeat나 검토 표면에서 유지한다.
 
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex
 write-lane**을 돈다. read-only 8-session 모드는 불변이며, patch 모드는 write-lease
-owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` headless는 모든 permission
-모드에서 Edit-tool이 깨지므로 write-lane은 codex 전용 — 실측 근거는 아래 표).
+owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` headless는 주요
+permission 모드 + bypass alias에서 모두 Edit-tool 호출이 깨지므로 write-lane은
+codex 전용 — 실측 근거는 아래 표).
 
 claude `-p` Edit-tool 실측 매트릭스 (`scripts/reproduce_claude_edit_tool.py`,
 claude 2.1.3, 2026-05-28, 구독 OAuth 경로, raw artifact:
-`reports/agent_loop/claude_edit_repro/`):
+`reports/agent_loop/claude_edit_repro/`). CLI 2.1.3의 `--permission-mode`
+choices는 `default`, `acceptEdits`, `bypassPermissions`, `plan`, `dontAsk`,
+`delegate`이고, `--dangerously-skip-permissions`는 `bypassPermissions`의 별칭이다
+(독립 모드 아님):
 
 | Cell | permission-mode | output-format | tool flag | Symptom |
 |---|---|---|---|---|
 | 01 | acceptEdits | json | `--allowedTools Edit` | S2 `tool_use ids must be unique` |
 | 02 | acceptEdits | json | `--allowedTools Edit` (explicit prompt) | S2 |
 | 03 | bypassPermissions | json | `--allowedTools Edit` | S2 |
-| 04 | (none) `--dangerously-skip-permissions` | json | (none) | S2 |
+| 04 | bypassPermissions (alias `--dangerously-skip-permissions`) | json | (none) | S2 |
 | 05 | acceptEdits | text | `--allowedTools Edit` | S2 |
-| 06 | (omitted, default) | json | `--allowedTools Edit` | S2 |
+| 06 | default (`--permission-mode` 생략) | json | `--allowedTools Edit` | S2 |
 | 07 | acceptEdits | json | `--tools Edit,Read` | S3 (90 s timeout) |
 | 08 | plan | json | `--allowedTools Edit` | S3 (90 s timeout) |
 
-해석: 6/8 셀에서 `messages.N.content.M: tool_use ids must be unique` API 400을
-받았다 (#1598 F4의 일반화 — plan-mode 한정이 아님). 나머지 2/8은 응답 자체가
-끝나지 않는다 (`--tools` 빌트인 셋 형식, plan-mode). 어느 플래그 조합도 단일
-trivial edit을 완료하지 못했다. 따라서 write-lane은 codex 전용을 유지하고,
-upstream 수정 전까지 wrapper-side 회피는 가능 영역 밖이다.
+해석: 측정한 독립 permission 모드 3개(`default`, `acceptEdits`, `bypassPermissions`)와
+그 alias(`--dangerously-skip-permissions`)에서 모두 동일한 `messages.N.content.M:
+tool_use ids must be unique` API 400을 받았다. 따라서 #1598 F4는 permission
+approval 정책 계층(승인/거절/질문) 문제가 아니라, headless `claude -p`의
+tool_use 메시지 구성·`tool_use.id` 직렬화 경로 버그로 판단한다. plan-mode와
+`--tools` 빌트인 셋 형식 셀은 90s timeout(S3)으로 떨어졌는데, 같은 직렬화
+경로의 다른 분기로 추정 — plan-mode는 `EnterPlanMode`/`ExitPlanMode` tool-call이
+일반 tool-call과 섞여 더 취약하고, `--tools` 빌트인 셋은 tool contract 변경으로
+같은 취약 경로를 자극한다. `dontAsk`, `delegate` 모드는 본 라운드에서 측정하지
+않았다. 어느 측정 셀도 단일 trivial edit을 완료하지 못했고, wrapper-side 회피는
+가능 영역 밖이다. write-lane은 codex 전용을 유지하고 upstream `claude-code`의
+headless tool_use 직렬화 수정 대기.
 
 ```bash
 python3 scripts/agent_loop.py active-codex-runner --mode patch --task T-2026-00NN --execute

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -188,8 +188,9 @@ status는 별도 heartbeat나 검토 표면에서 유지한다.
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex
 write-lane**을 돈다. read-only 8-session 모드는 불변이며, patch 모드는 write-lease
 owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` print mode는 비-streaming
-직렬화 경로의 #1598 F4 버그로 Edit-tool 호출이 깨지므로 PR-B의 SDK 어댑터 도입
-전까지 write-lane은 codex 전용 — 실측 근거는 아래 표).
+직렬화 경로의 #1598 F4 버그로 Edit-tool 호출이 깨진다. stream-json transport로
+회피 가능하나 2026-06-15 Anthropic 에이전트 크레딧 분리 정책으로 채택은 보류 —
+실측 근거 + 정책 함의는 아래 표).
 
 claude `-p` Edit-tool 실측 매트릭스 (`scripts/reproduce_claude_edit_tool.py`,
 claude 2.1.3, 2026-05-28, 구독 OAuth 경로, raw artifact:
@@ -216,9 +217,10 @@ tool_use ids must be unique` API 400을 받았다. plan-mode와 `--tools` 빌트
 plan-mode는 `EnterPlanMode`/`ExitPlanMode` tool-call이 일반 tool-call과 섞여 더
 취약하고, `--tools` 빌트인 셋은 tool contract 변경으로 같은 취약 경로를 자극한다.
 
-그러나 같은 `claude` 바이너리를 **streaming transport**로 호출하는 Python SDK
-(`claude-agent-sdk` 0.2.87, internal `_is_streaming = True`)에서는 같은 trivial
-edit 태스크가 모든 측정 mode에서 정상 동작한다 (`scripts/reproduce_claude_sdk_edit.py`):
+그러나 같은 `claude` 바이너리를 **streaming transport** (`--input-format
+stream-json --output-format stream-json --verbose`)로 호출하면 같은 trivial
+edit 태스크가 정상 동작한다. Python SDK (`claude-agent-sdk` 0.2.87, internal
+`_is_streaming = True`) 매트릭스 (`scripts/reproduce_claude_sdk_edit.py`):
 
 | Cell | SDK permission_mode | tool_use | edited | symptom |
 |---|---|---|---|---|
@@ -229,14 +231,34 @@ edit 태스크가 모든 측정 mode에서 정상 동작한다 (`scripts/reprodu
 | 13 | `dontAsk` | 2 | yes | S4_normal |
 | 14 | `auto` | 2 | yes | S4_normal |
 
-따라서 #1598 F4는 **permission approval 정책 계층(승인/거절/질문) 문제가 아니라
-`claude -p` print mode의 비-streaming 직렬화 경로 한정 버그**로 단정한다. SDK의
-`--input-format stream-json --output-format stream-json` transport는 같은
-바이너리의 다른 코드 경로를 타서 영향이 없다. 즉 wrapper-side 회피는 **SDK 어댑터로
-전환하면 가능**하다 — write-lane의 claude 분기를 codex와 나란히 둘 수 있는 길이
-열린다. 본 PR은 측정·문서화까지만 다루고, SDK 기반 `agent_loop_claude_patch_turn.py`
-+ `agent_loop.py:10103`의 `agent="codex"` 하드코딩 분기화는 별 PR(PR-B)에서
-처리한다.
+SDK 없이 wrapper가 직접 subprocess로 stream-json transport를 호출해도 동등한
+결과 (`scripts/reproduce_claude_streamjson_subprocess.py`):
+
+| Cell | permission_mode | tool_use | edited | symptom |
+|---|---|---|---|---|
+| 15 | `default` | 2 | yes | S4_normal |
+| 16 | `acceptEdits` | 3 | yes | S4_normal |
+| 17 | `plan` | 1 | no | S4 (mode spec) |
+| 18 | `bypassPermissions` | 3 | yes | S4_normal |
+| 19 | `dontAsk` | 0 | no | S0 invalid mode (CLI rejects; raw_lines=0) |
+| 20 | `auto` | 0 | no | S0 invalid mode (CLI rejects; raw_lines=0) |
+
+CLI 2.1.3의 실제 `--permission-mode` validation은 `acceptEdits / bypassPermissions
+/ default / plan` 4개만 허용한다 (`--help` 출력의 `dontAsk / delegate`는 거짓 enum).
+SDK가 `dontAsk / auto`를 통과시킨 이유는 stream-json mode에서의 validation 우회
+또는 stdin control message 경로로 추정 — 부수적이며 본 결론과 무관.
+
+따라서 #1598 F4는 **permission approval 정책 계층 문제가 아니라 `claude -p` print
+mode의 비-streaming 직렬화 경로 한정 버그**로 단정한다. SDK든 wrapper 직접 subprocess든
+`--input-format stream-json --output-format stream-json --verbose` transport로
+호출하면 유효한 4개 mode 전부에서 정상 동작한다. **즉 wrapper-side 회피는 SDK 의존성
+없이도 가능하다** — `scripts/agent_loop_claude_turn.py` 같은 어댑터의 build_command를
+stream-json transport로 갈아끼우면 claude write-lane이 열린다.
+
+채택은 별 결정이다. Anthropic의 2026-06-15 에이전트 크레딧 분리 정책은 SDK + MCP +
+GitHub Actions 통합을 명시 타깃하지만 stream-json subprocess가 같은 통에 들어가는지는
+공지로 명확하지 않다. 본 저장소의 write-lane은 codex가 이미 안정 동작하므로 dual-agent
+도입의 본질적 필요가 없고, 측정 결과는 옵션으로만 보관한다 (선택지 보존, 채택 보류).
 
 ```bash
 python3 scripts/agent_loop.py active-codex-runner --mode patch --task T-2026-00NN --execute

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -188,7 +188,28 @@ status는 별도 heartbeat나 검토 표면에서 유지한다.
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex
 write-lane**을 돈다. read-only 8-session 모드는 불변이며, patch 모드는 write-lease
 owner인 **Implementer** 한 세션만 대상으로 한다 (claude `-p` headless는 모든 permission
-모드에서 Edit-tool이 깨지므로 write-lane은 codex 전용).
+모드에서 Edit-tool이 깨지므로 write-lane은 codex 전용 — 실측 근거는 아래 표).
+
+claude `-p` Edit-tool 실측 매트릭스 (`scripts/reproduce_claude_edit_tool.py`,
+claude 2.1.3, 2026-05-28, 구독 OAuth 경로, raw artifact:
+`reports/agent_loop/claude_edit_repro/`):
+
+| Cell | permission-mode | output-format | tool flag | Symptom |
+|---|---|---|---|---|
+| 01 | acceptEdits | json | `--allowedTools Edit` | S2 `tool_use ids must be unique` |
+| 02 | acceptEdits | json | `--allowedTools Edit` (explicit prompt) | S2 |
+| 03 | bypassPermissions | json | `--allowedTools Edit` | S2 |
+| 04 | (none) `--dangerously-skip-permissions` | json | (none) | S2 |
+| 05 | acceptEdits | text | `--allowedTools Edit` | S2 |
+| 06 | (omitted, default) | json | `--allowedTools Edit` | S2 |
+| 07 | acceptEdits | json | `--tools Edit,Read` | S3 (90 s timeout) |
+| 08 | plan | json | `--allowedTools Edit` | S3 (90 s timeout) |
+
+해석: 6/8 셀에서 `messages.N.content.M: tool_use ids must be unique` API 400을
+받았다 (#1598 F4의 일반화 — plan-mode 한정이 아님). 나머지 2/8은 응답 자체가
+끝나지 않는다 (`--tools` 빌트인 셋 형식, plan-mode). 어느 플래그 조합도 단일
+trivial edit을 완료하지 못했다. 따라서 write-lane은 codex 전용을 유지하고,
+upstream 수정 전까지 wrapper-side 회피는 가능 영역 밖이다.
 
 ```bash
 python3 scripts/agent_loop.py active-codex-runner --mode patch --task T-2026-00NN --execute

--- a/scripts/reproduce_claude_edit_tool.py
+++ b/scripts/reproduce_claude_edit_tool.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Minimal reproduction for the "claude -p Edit-tool is broken" assertion.
+
+Background: `scripts/agent_loop_claude_turn.py:6-9, 68-70` and
+`docs/operations/active-agent-loop.md:190-191` claim that headless `claude -p`
+Edit-tool is broken in all permission modes. The assertion derives from issue
+#1598 F4 ("tool_use ids must be unique") observed once during the read-only
+lane bring-up — there is no independent measurement of the Edit-tool path.
+
+This script sweeps a small flag matrix and writes a result table so we can
+classify each cell as S1 (tool not invoked) / S2 ("tool_use ids must be unique"
+API error) / S3 (timeout) / S4 (edit applied). Per-cell fresh mktemp dir; no
+shared /tmp paths (CLAUDE.md "Don't" rule on fixed /tmp targets).
+
+Usage:
+    python3 scripts/reproduce_claude_edit_tool.py [--out DIR] [--timeout SEC] [--cells N]
+
+The script is intentionally NOT in tests/ — it shells out to the real `claude`
+binary which is not available in CI. Result table is printed to stdout and
+written to <out>/matrix.json for PR-description attachment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+# Strip env vars that would force claude to use a raw Anthropic API key path.
+# The goal here is to measure the SUBSCRIPTION (OAuth) surface — same path a
+# real BidMate-DocAgent user invokes via `make ship-arm` / agent-loop. Leaving
+# ANTHROPIC_API_KEY in the child env makes claude bypass subscription auth.
+_API_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+
+
+def subscription_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in _API_ENV_KEYS}
+    return env
+
+
+TARGET_INITIAL = "a\n"
+TARGET_EXPECTED = "b\n"
+PROMPT_PLAIN = "Edit the file {path} so its only line reads exactly 'b' instead of 'a'. Use the Edit tool. After one successful edit, stop."
+PROMPT_EXPLICIT = "Use the Edit tool to replace 'a' with 'b' in {path}. Stop immediately after one edit succeeds."
+
+
+@dataclass
+class Cell:
+    label: str
+    flags: list[str]
+    prompt: str
+    note: str = ""
+
+
+@dataclass
+class CellResult:
+    label: str
+    cmd: list[str]
+    exit_code: int | None
+    duration_s: float
+    stdout_head: str
+    stderr_tail: str
+    file_after: str
+    edited: bool
+    symptom: str
+    note: str = ""
+    stdout_path: str = ""
+    stderr_path: str = ""
+
+
+def build_matrix() -> list[Cell]:
+    """Eight primary cells targeting the most plausible fix axes.
+
+    Each cell isolates one variable against an "acceptEdits + json + add-dir"
+    baseline so the failing axis is obvious from the matrix.
+    """
+    return [
+        Cell(
+            label="01_baseline_acceptEdits_json_addDir",
+            flags=[
+                "--permission-mode", "acceptEdits",
+                "--output-format", "json",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="baseline w/ acceptEdits + json + Edit allowed (no add-dir)",
+        ),
+        Cell(
+            label="02_acceptEdits_json_addDir_explicit",
+            flags=[
+                "--permission-mode", "acceptEdits",
+                "--output-format", "json",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_EXPLICIT,
+            note="explicit 'Use the Edit tool' prompt variant",
+        ),
+        Cell(
+            label="03_bypassPermissions_json",
+            flags=[
+                "--permission-mode", "bypassPermissions",
+                "--output-format", "json",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="bypassPermissions mode",
+        ),
+        Cell(
+            label="04_dangerously_skip_perms",
+            flags=[
+                "--dangerously-skip-permissions",
+                "--output-format", "json",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="dangerously-skip-permissions (sandbox-style)",
+        ),
+        Cell(
+            label="05_acceptEdits_text_output",
+            flags=[
+                "--permission-mode", "acceptEdits",
+                "--output-format", "text",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="text output instead of json (rules out json wrapper coupling)",
+        ),
+        Cell(
+            label="06_default_mode_no_perm_flag",
+            flags=[
+                "--output-format", "json",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="omit --permission-mode entirely (default mode)",
+        ),
+        Cell(
+            label="07_acceptEdits_tools_form",
+            flags=[
+                "--permission-mode", "acceptEdits",
+                "--output-format", "json",
+                "--tools", "Edit,Read",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="--tools built-in form instead of --allowedTools",
+        ),
+        Cell(
+            label="08_plan_mode_with_edit",
+            flags=[
+                "--permission-mode", "plan",
+                "--output-format", "json",
+                "--allowedTools", "Edit",
+                "--no-session-persistence",
+            ],
+            prompt=PROMPT_PLAIN,
+            note="plan mode — expected to reproduce #1598 F4 'tool_use ids must be unique'",
+        ),
+    ]
+
+
+def run_cell(cell: Cell, *, timeout: float, out_dir: Path) -> CellResult:
+    """Run one matrix cell against a fresh mktemp working dir."""
+    work = Path(tempfile.mkdtemp(prefix="claude-edit-repro-"))
+    target = work / "foo.txt"
+    target.write_text(TARGET_INITIAL, encoding="utf-8")
+    prompt = cell.prompt.format(path=str(target))
+
+    cmd: list[str] = ["claude", "-p", prompt, *cell.flags, "--add-dir", str(work)]
+
+    stdout_file = out_dir / f"{cell.label}.stdout.txt"
+    stderr_file = out_dir / f"{cell.label}.stderr.txt"
+
+    start = time.monotonic()
+    exit_code: int | None
+    child_env = subscription_env()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(work),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=child_env,
+        )
+        exit_code = proc.returncode
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+    except subprocess.TimeoutExpired as exc:
+        exit_code = None
+        stdout = (exc.stdout or b"").decode("utf-8", errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = (exc.stderr or b"").decode("utf-8", errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+    duration = time.monotonic() - start
+
+    stdout_file.write_text(stdout, encoding="utf-8")
+    stderr_file.write_text(stderr, encoding="utf-8")
+
+    file_after = target.read_text(encoding="utf-8") if target.exists() else "<missing>"
+    edited = file_after == TARGET_EXPECTED
+    symptom = classify(exit_code=exit_code, stdout=stdout, stderr=stderr, edited=edited, duration=duration, timeout=timeout)
+
+    shutil.rmtree(work, ignore_errors=True)
+
+    return CellResult(
+        label=cell.label,
+        cmd=cmd,
+        exit_code=exit_code,
+        duration_s=round(duration, 2),
+        stdout_head=stdout[:400].strip(),
+        stderr_tail=stderr.strip().splitlines()[-1] if stderr.strip() else "",
+        file_after=file_after,
+        edited=edited,
+        symptom=symptom,
+        note=cell.note,
+        stdout_path=str(stdout_file),
+        stderr_path=str(stderr_file),
+    )
+
+
+def classify(*, exit_code: int | None, stdout: str, stderr: str, edited: bool, duration: float, timeout: float) -> str:
+    if edited:
+        return "S4_normal"
+    if exit_code is None or duration >= timeout - 0.5:
+        return "S3_timeout"
+    # The `tool_use ids must be unique` API error is surfaced two ways depending
+    # on --output-format: (a) wrapped inside the JSON `result` field with
+    # is_error=true, or (b) printed verbatim to stdout when --output-format=text.
+    # stderr usually stays empty for this class of failure.
+    haystack = f"{stdout}\n{stderr}"
+    if "tool_use" in haystack and "unique" in haystack:
+        return "S2_tool_use_ids"
+    return "S1_no_tool_call"
+
+
+def render_markdown_table(results: Sequence[CellResult]) -> str:
+    lines = [
+        "| # | Cell | Symptom | Exit | Edited | Duration (s) | stderr tail | Note |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for idx, r in enumerate(results, start=1):
+        stderr_cell = r.stderr_tail.replace("|", "\\|")[:80]
+        note_cell = r.note.replace("|", "\\|")
+        exit_str = "timeout" if r.exit_code is None else str(r.exit_code)
+        lines.append(
+            f"| {idx} | `{r.label}` | **{r.symptom}** | {exit_str} | {'✓' if r.edited else '✗'} | {r.duration_s} | `{stderr_cell}` | {note_cell} |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="reports/agent_loop/claude_edit_repro", help="output dir for matrix.json + per-cell logs")
+    parser.add_argument("--timeout", type=float, default=30.0, help="per-cell subprocess timeout (s)")
+    parser.add_argument("--cells", type=int, default=0, help="run only first N cells (0 = all)")
+    args = parser.parse_args(argv)
+
+    if shutil.which("claude") is None:
+        print("ERROR: `claude` binary not found on PATH", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    matrix = build_matrix()
+    if args.cells > 0:
+        matrix = matrix[: args.cells]
+
+    version = subprocess.run(["claude", "--version"], capture_output=True, text=True, check=False).stdout.strip()
+    print(f"# claude version: {version}", flush=True)
+    print(f"# cells: {len(matrix)}, timeout: {args.timeout}s\n", flush=True)
+
+    results: list[CellResult] = []
+    for idx, cell in enumerate(matrix, start=1):
+        print(f"[{idx}/{len(matrix)}] {cell.label} ...", flush=True)
+        result = run_cell(cell, timeout=args.timeout, out_dir=out_dir)
+        results.append(result)
+        print(f"    -> symptom={result.symptom} exit={result.exit_code} edited={result.edited} dur={result.duration_s}s", flush=True)
+
+    matrix_json = {
+        "claude_version": version,
+        "results": [r.__dict__ for r in results],
+    }
+    (out_dir / "matrix.json").write_text(json.dumps(matrix_json, indent=2, default=str), encoding="utf-8")
+
+    print("\n" + render_markdown_table(results))
+    print(f"\n# matrix written to {out_dir}/matrix.json")
+
+    # Summary
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.symptom] = counts.get(r.symptom, 0) + 1
+    print(f"# symptom counts: {counts}")
+
+    # Verdict
+    s4 = [r for r in results if r.symptom == "S4_normal"]
+    if s4:
+        print(f"\n# VERDICT: S4 found — winning flag sets = {[r.label for r in s4]}")
+        print("# Next: write-lane extension feasible via wrapper; PR-B path.")
+        return 0
+    print("\n# VERDICT: no S4 cell. escape hatch (D) — upstream repro + footnote.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reproduce_claude_sdk_edit.py
+++ b/scripts/reproduce_claude_sdk_edit.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""SDK-side mirror of `reproduce_claude_edit_tool.py`.
+
+The `-p` print mode matrix in the sibling script established that headless
+`claude -p` Edit-tool calls fail (#1598 F4 `tool_use ids must be unique`) across
+all measured permission modes. The Claude Agent SDK uses the same `claude`
+binary but forces a different transport (`_is_streaming = True` in
+`claude_agent_sdk/_internal/transport/subprocess_cli.py` — i.e.
+`--input-format stream-json --output-format stream-json --verbose`).
+
+This script sweeps the SDK's `PermissionMode` literal (default, acceptEdits,
+plan, bypassPermissions, dontAsk, auto — same six in SDK 0.2.87) with a
+trivial edit task to confirm the SDK transport bypasses the bug.
+
+Usage:
+    .venv/bin/python scripts/reproduce_claude_sdk_edit.py [--out DIR] [--timeout SEC] [--cells N]
+
+Subscription OAuth is forced by stripping ANTHROPIC_API_KEY / BASE_URL /
+AUTH_TOKEN before importing the SDK.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+for _k in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"):
+    os.environ.pop(_k, None)
+
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+    query,
+)
+
+
+TARGET_INITIAL = "a\n"
+TARGET_EXPECTED = "b\n"
+PROMPT_TPL = (
+    "Edit the file {path} so its only line reads exactly 'b' instead of 'a'. "
+    "Use the Edit tool. After one successful edit, stop."
+)
+SDK_PERMISSION_MODES = ("default", "acceptEdits", "plan", "bypassPermissions", "dontAsk", "auto")
+
+
+@dataclass
+class CellResult:
+    label: str
+    permission_mode: str
+    exit_code: int | None
+    duration_s: float
+    tool_use_count: int
+    tool_result_count: int
+    edited: bool
+    symptom: str
+    result_subtype: str | None
+    result_is_error: bool | None
+    result_text: str
+    exception: str | None
+    stdout_log: str
+
+
+def classify(*, edited: bool, exception: str | None, result_subtype: str | None,
+             result_is_error: bool | None, result_text: str, duration: float, timeout: float,
+             tool_use_count: int) -> str:
+    if edited:
+        return "S4_normal"
+    if duration >= timeout - 0.5:
+        return "S3_timeout"
+    if exception:
+        if "tool_use" in exception and "unique" in exception:
+            return "S2_tool_use_ids"
+        return "S2_or_other_exception"
+    if result_subtype == "success" and not result_is_error and tool_use_count >= 1:
+        return "S4_success_without_target_match"
+    haystack = result_text or ""
+    if "tool_use" in haystack and "unique" in haystack:
+        return "S2_tool_use_ids"
+    if result_is_error:
+        return "S2_or_other_error"
+    if tool_use_count == 0:
+        return "S1_no_tool_call"
+    return "S5_unknown"
+
+
+async def run_cell(permission_mode: str, *, timeout: float, log_path: Path) -> CellResult:
+    work = Path(tempfile.mkdtemp(prefix="claude-sdk-cell-"))
+    target = work / "foo.txt"
+    target.write_text(TARGET_INITIAL, encoding="utf-8")
+    prompt = PROMPT_TPL.format(path=str(target))
+
+    options = ClaudeAgentOptions(
+        cwd=str(work),
+        allowed_tools=["Edit", "Read"],
+        permission_mode=permission_mode if permission_mode != "default" else None,  # type: ignore[arg-type]
+        add_dirs=[str(work)],
+    )
+
+    log_lines: list[str] = []
+    tool_use_count = 0
+    tool_result_count = 0
+    result_subtype: str | None = None
+    result_is_error: bool | None = None
+    result_text = ""
+    exception: str | None = None
+
+    start = time.monotonic()
+    try:
+        async def _consume() -> None:
+            nonlocal tool_use_count, tool_result_count, result_subtype, result_is_error, result_text
+            async for msg in query(prompt=prompt, options=options):
+                if isinstance(msg, AssistantMessage):
+                    for block in msg.content:
+                        if isinstance(block, ToolUseBlock):
+                            tool_use_count += 1
+                            log_lines.append(f"tool_use id={block.id} name={block.name}")
+                        elif isinstance(block, TextBlock):
+                            log_lines.append(f"text: {block.text[:200]}")
+                elif isinstance(msg, UserMessage):
+                    items = msg.content if isinstance(msg.content, list) else []
+                    for block in items:
+                        if isinstance(block, ToolResultBlock):
+                            tool_result_count += 1
+                            log_lines.append(f"tool_result id={block.tool_use_id} is_error={block.is_error}")
+                elif isinstance(msg, ResultMessage):
+                    result_subtype = msg.subtype
+                    result_is_error = msg.is_error
+                    if isinstance(msg.result, str):
+                        result_text = msg.result[:400]
+                    elif msg.result is not None:
+                        result_text = str(msg.result)[:400]
+                elif isinstance(msg, SystemMessage):
+                    pass
+                else:
+                    log_lines.append(f"other: {type(msg).__name__}")
+
+        await asyncio.wait_for(_consume(), timeout=timeout)
+    except asyncio.TimeoutError:
+        exception = "asyncio.TimeoutError"
+    except Exception as exc:
+        exception = f"{type(exc).__name__}: {exc}"
+
+    duration = time.monotonic() - start
+    after = target.read_text(encoding="utf-8") if target.exists() else "<missing>"
+    edited = after == TARGET_EXPECTED
+
+    symptom = classify(
+        edited=edited,
+        exception=exception,
+        result_subtype=result_subtype,
+        result_is_error=result_is_error,
+        result_text=result_text,
+        duration=duration,
+        timeout=timeout,
+        tool_use_count=tool_use_count,
+    )
+
+    log_path.write_text("\n".join(log_lines), encoding="utf-8")
+    shutil.rmtree(work, ignore_errors=True)
+
+    return CellResult(
+        label=f"sdk_{permission_mode}",
+        permission_mode=permission_mode,
+        exit_code=0 if symptom == "S4_normal" else (None if symptom == "S3_timeout" else 1),
+        duration_s=round(duration, 2),
+        tool_use_count=tool_use_count,
+        tool_result_count=tool_result_count,
+        edited=edited,
+        symptom=symptom,
+        result_subtype=result_subtype,
+        result_is_error=result_is_error,
+        result_text=result_text,
+        exception=exception,
+        stdout_log=str(log_path),
+    )
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    modes = list(SDK_PERMISSION_MODES)
+    if args.cells > 0:
+        modes = modes[: args.cells]
+
+    print(f"# SDK modes: {modes}", flush=True)
+    print(f"# timeout per cell: {args.timeout}s\n", flush=True)
+
+    results: list[CellResult] = []
+    for idx, mode in enumerate(modes, start=1):
+        print(f"[{idx}/{len(modes)}] sdk_{mode} ...", flush=True)
+        log_path = out_dir / f"sdk_{mode}.log"
+        result = await run_cell(mode, timeout=args.timeout, log_path=log_path)
+        results.append(result)
+        print(
+            f"    -> symptom={result.symptom} edited={result.edited} "
+            f"tool_use={result.tool_use_count} tool_result={result.tool_result_count} "
+            f"dur={result.duration_s}s",
+            flush=True,
+        )
+
+    matrix = {
+        "transport": "claude_agent_sdk.SubprocessCLITransport (stream-json)",
+        "sdk_version": _sdk_version(),
+        "results": [r.__dict__ for r in results],
+    }
+    (out_dir / "sdk_matrix.json").write_text(json.dumps(matrix, indent=2, default=str), encoding="utf-8")
+
+    print("\n| # | permission_mode | Symptom | Edited | tool_use | duration_s |")
+    print("|---|---|---|---|---|---|")
+    for idx, r in enumerate(results, start=1):
+        print(f"| {idx} | `{r.permission_mode}` | **{r.symptom}** | {'yes' if r.edited else 'no'} | {r.tool_use_count} | {r.duration_s} |")
+
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.symptom] = counts.get(r.symptom, 0) + 1
+    print(f"\n# symptom counts: {counts}")
+
+    s4 = [r for r in results if r.symptom.startswith("S4")]
+    if len(s4) == len(results):
+        print(f"\n# VERDICT: 모든 SDK permission mode 에서 S4 정상 동작 — SDK transport 가 -p print mode 의 직렬화 버그를 우회.")
+        return 0
+    print(f"\n# VERDICT: {len(s4)}/{len(results)} mode 만 S4 — SDK 도 일부 mode 에서 분기 깨짐.")
+    return 1
+
+
+def _sdk_version() -> str:
+    try:
+        import claude_agent_sdk
+        return getattr(claude_agent_sdk, "__version__", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="reports/agent_loop/claude_edit_repro_sdk")
+    parser.add_argument("--timeout", type=float, default=90.0)
+    parser.add_argument("--cells", type=int, default=0)
+    args = parser.parse_args(argv)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reproduce_claude_streamjson_subprocess.py
+++ b/scripts/reproduce_claude_streamjson_subprocess.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Direct-subprocess mirror of `reproduce_claude_sdk_edit.py`.
+
+Question this script answers: does the #1598 F4 bypass come from `claude-agent-sdk`
+itself, or from the underlying `--input-format stream-json --output-format
+stream-json --verbose` CLI transport? If the latter, BidMate could adopt the
+streaming transport without taking the SDK dependency (relevant under Anthropic's
+2026-06-15 separate agent-credit policy — fewer prereqs to drop later).
+
+Mirrors the SDK transport's command shape from
+`claude_agent_sdk/_internal/transport/subprocess_cli.py:225,408`:
+    claude --output-format stream-json --verbose --input-format stream-json
+           [--permission-mode ...] [--allowedTools ...] [--add-dir ...]
+
+stdin protocol (from `claude_agent_sdk/client.py:263`):
+    {"type":"user","message":{"role":"user","content":"<prompt>"}}\\n
+
+stdout protocol: one JSON object per line. The terminal object has
+`type=="result"` with `subtype`, `is_error`, `result`.
+
+Subscription OAuth is forced by stripping ANTHROPIC_API_KEY / BASE_URL /
+AUTH_TOKEN before invocation.
+
+Usage:
+    python3 scripts/reproduce_claude_streamjson_subprocess.py [--out DIR] [--timeout SEC] [--cells N]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TARGET_INITIAL = "a\n"
+TARGET_EXPECTED = "b\n"
+PROMPT_TPL = (
+    "Edit the file {path} so its only line reads exactly 'b' instead of 'a'. "
+    "Use the Edit tool. After one successful edit, stop."
+)
+# Mirror SDK 0.2.87's `PermissionMode` Literal. CLI 2.1.3 also accepts
+# `delegate` (not in SDK enum); SDK adds `auto` (not in CLI 2.1.3 print-mode
+# matrix). We test what the SDK matrix tested for direct comparison.
+SDK_PERMISSION_MODES = ("default", "acceptEdits", "plan", "bypassPermissions", "dontAsk", "auto")
+_API_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+
+
+@dataclass
+class CellResult:
+    label: str
+    permission_mode: str
+    exit_code: int | None
+    duration_s: float
+    tool_use_count: int
+    tool_result_count: int
+    edited: bool
+    symptom: str
+    result_subtype: str | None
+    result_is_error: bool | None
+    result_text: str
+    exception: str | None
+    raw_lines: int
+    log_path: str
+
+
+def subscription_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _API_ENV_KEYS}
+
+
+def build_command(*, permission_mode: str, work: Path) -> list[str]:
+    cmd = [
+        "claude",
+        "--output-format", "stream-json",
+        "--verbose",
+        "--input-format", "stream-json",
+        "--allowedTools", "Edit,Read",
+        "--add-dir", str(work),
+    ]
+    if permission_mode != "default":
+        cmd += ["--permission-mode", permission_mode]
+    return cmd
+
+
+def classify(*, edited: bool, exception: str | None, result_subtype: str | None,
+             result_is_error: bool | None, result_text: str, duration: float,
+             timeout: float, tool_use_count: int) -> str:
+    if edited:
+        return "S4_normal"
+    if duration >= timeout - 0.5:
+        return "S3_timeout"
+    haystack = (result_text or "") + (exception or "")
+    if "tool_use" in haystack and "unique" in haystack:
+        return "S2_tool_use_ids"
+    if exception:
+        return "S2_or_other_exception"
+    if result_subtype == "success" and not result_is_error and tool_use_count >= 1:
+        return "S4_success_without_target_match"
+    if result_is_error:
+        return "S2_or_other_error"
+    if tool_use_count == 0:
+        return "S1_no_tool_call"
+    return "S5_unknown"
+
+
+async def run_cell(permission_mode: str, *, timeout: float, log_path: Path) -> CellResult:
+    work = Path(tempfile.mkdtemp(prefix="claude-streamjson-cell-"))
+    target = work / "foo.txt"
+    target.write_text(TARGET_INITIAL, encoding="utf-8")
+    prompt = PROMPT_TPL.format(path=str(target))
+
+    cmd = build_command(permission_mode=permission_mode, work=work)
+    user_message = json.dumps(
+        {"type": "user", "message": {"role": "user", "content": prompt}}
+    ) + "\n"
+
+    raw_lines_collected: list[str] = []
+    tool_use_count = 0
+    tool_result_count = 0
+    result_subtype: str | None = None
+    result_is_error: bool | None = None
+    result_text = ""
+    exception: str | None = None
+    exit_code: int | None = None
+
+    start = time.monotonic()
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=str(work),
+        env=subscription_env(),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _drive() -> None:
+        nonlocal tool_use_count, tool_result_count, result_subtype, result_is_error, result_text
+        assert proc.stdin is not None and proc.stdout is not None
+        proc.stdin.write(user_message.encode("utf-8"))
+        await proc.stdin.drain()
+        proc.stdin.close()
+        while True:
+            line_bytes = await proc.stdout.readline()
+            if not line_bytes:
+                break
+            line = line_bytes.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            raw_lines_collected.append(line)
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            msg_type = obj.get("type")
+            if msg_type == "assistant":
+                content = obj.get("message", {}).get("content") or []
+                for block in content if isinstance(content, list) else []:
+                    if isinstance(block, dict):
+                        if block.get("type") == "tool_use":
+                            tool_use_count += 1
+                        elif block.get("type") == "text":
+                            pass
+            elif msg_type == "user":
+                content = obj.get("message", {}).get("content") or []
+                for block in content if isinstance(content, list) else []:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        tool_result_count += 1
+            elif msg_type == "result":
+                result_subtype = obj.get("subtype")
+                result_is_error = obj.get("is_error")
+                raw_result = obj.get("result")
+                if isinstance(raw_result, str):
+                    result_text = raw_result[:400]
+                elif raw_result is not None:
+                    result_text = str(raw_result)[:400]
+
+    try:
+        await asyncio.wait_for(_drive(), timeout=timeout)
+        exit_code = await proc.wait()
+    except asyncio.TimeoutError:
+        exception = "asyncio.TimeoutError"
+        proc.kill()
+        try:
+            await proc.wait()
+        except Exception:
+            pass
+    except Exception as exc:
+        exception = f"{type(exc).__name__}: {exc}"
+
+    duration = time.monotonic() - start
+    after = target.read_text(encoding="utf-8") if target.exists() else "<missing>"
+    edited = after == TARGET_EXPECTED
+
+    symptom = classify(
+        edited=edited,
+        exception=exception,
+        result_subtype=result_subtype,
+        result_is_error=result_is_error,
+        result_text=result_text,
+        duration=duration,
+        timeout=timeout,
+        tool_use_count=tool_use_count,
+    )
+
+    log_path.write_text("\n".join(raw_lines_collected), encoding="utf-8")
+    shutil.rmtree(work, ignore_errors=True)
+
+    return CellResult(
+        label=f"streamjson_{permission_mode}",
+        permission_mode=permission_mode,
+        exit_code=exit_code,
+        duration_s=round(duration, 2),
+        tool_use_count=tool_use_count,
+        tool_result_count=tool_result_count,
+        edited=edited,
+        symptom=symptom,
+        result_subtype=result_subtype,
+        result_is_error=result_is_error,
+        result_text=result_text,
+        exception=exception,
+        raw_lines=len(raw_lines_collected),
+        log_path=str(log_path),
+    )
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    modes = list(SDK_PERMISSION_MODES)
+    if args.cells > 0:
+        modes = modes[: args.cells]
+
+    print(f"# modes: {modes}", flush=True)
+    print(f"# timeout per cell: {args.timeout}s\n", flush=True)
+
+    results: list[CellResult] = []
+    for idx, mode in enumerate(modes, start=1):
+        print(f"[{idx}/{len(modes)}] streamjson_{mode} ...", flush=True)
+        log_path = out_dir / f"streamjson_{mode}.jsonl"
+        result = await run_cell(mode, timeout=args.timeout, log_path=log_path)
+        results.append(result)
+        print(
+            f"    -> symptom={result.symptom} edited={result.edited} "
+            f"tool_use={result.tool_use_count} tool_result={result.tool_result_count} "
+            f"raw_lines={result.raw_lines} dur={result.duration_s}s",
+            flush=True,
+        )
+
+    matrix = {
+        "transport": "direct subprocess (--input-format stream-json --output-format stream-json --verbose)",
+        "results": [r.__dict__ for r in results],
+    }
+    (out_dir / "streamjson_matrix.json").write_text(json.dumps(matrix, indent=2, default=str), encoding="utf-8")
+
+    print("\n| # | permission_mode | Symptom | Edited | tool_use | duration_s |")
+    print("|---|---|---|---|---|---|")
+    for idx, r in enumerate(results, start=1):
+        print(f"| {idx} | `{r.permission_mode}` | **{r.symptom}** | {'yes' if r.edited else 'no'} | {r.tool_use_count} | {r.duration_s} |")
+
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.symptom] = counts.get(r.symptom, 0) + 1
+    print(f"\n# symptom counts: {counts}")
+
+    s4 = [r for r in results if r.symptom.startswith("S4")]
+    if len(s4) == len(results):
+        print(f"\n# VERDICT: 모든 mode 에서 S4 — SDK 없이 stream-json transport 만으로 #1598 F4 우회 가능.")
+        return 0
+    print(f"\n# VERDICT: {len(s4)}/{len(results)} mode 만 S4 — SDK 가 transport 외에 추가 layer 를 제공.")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="reports/agent_loop/claude_edit_repro_streamjson")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--cells", type=int, default=0)
+    args = parser.parse_args(argv)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/active-agent-loop.md:190-191` 의 *"claude `-p` headless 는 모든 permission 모드에서 Edit-tool 이 깨진다"* 단언은 ADR 0080 Phase 3 의 핵심 설계 근거지만 지금까지 #1598 F4 진단 1건의 코드 주석에 머물러 있었다. 세 transport 표면(subprocess `-p` print mode + Python SDK stream-json + 직접 subprocess stream-json)을 모두 측정해 결론을 데이터 기반으로 격상하고, 2026-06-15 Anthropic 에이전트 크레딧 정책을 반영해 채택 의사결정도 함께 정리.

Closes #1642

## 2. 영향 파일

- `scripts/reproduce_claude_edit_tool.py` (신규, ~140 LOC) — `claude -p` subprocess 매트릭스 (8셀)
- `scripts/reproduce_claude_sdk_edit.py` (신규, ~250 LOC) — `claude-agent-sdk` 매트릭스 (6 mode)
- `scripts/reproduce_claude_streamjson_subprocess.py` (신규, ~280 LOC) — SDK 없는 stream-json subprocess 매트릭스 (6 mode)
- `docs/operations/active-agent-loop.md` — 세 매트릭스 결과 표 + 정정된 결론

Load-bearing path 변경 없음 (`scripts/_governance.py:38-50` `LOAD_BEARING_PATHS` 미해당).

## 3. 리스크

- 세 repro 스크립트는 외부 `claude` 바이너리 또는 `claude-agent-sdk` 패키지에 의존. CI 환경 미설치 → `tests/` 미배치, `scripts/` ad-hoc 한정.
- SDK / stream-json subprocess 매트릭스의 `plan` mode 셀은 파일 미수정으로 떨어졌는데, 이는 plan mode 의 의도된 동작 (tool_use 발생하나 mutation 안 함) — 깨짐이 아님.
- stream-json subprocess 매트릭스의 `dontAsk` / `auto` 셀은 CLI 2.1.3 의 validation 거부 (`--permission-mode` 실제 enum 은 `acceptEdits / bypassPermissions / default / plan` 4개만 허용; `--help` 출력의 `dontAsk / delegate` 는 거짓 enum). 직렬화 버그와 무관.

## 4. 테스트

### Track 1: `claude -p` print mode subprocess (8셀)

`python3 scripts/reproduce_claude_edit_tool.py --timeout 90` (claude 2.1.3, 구독 OAuth)

| Cell | permission-mode | output-format | tool flag | Symptom |
|---|---|---|---|---|
| 01 | acceptEdits | json | `--allowedTools Edit` | **S2** `tool_use ids must be unique` |
| 02 | acceptEdits | json | `--allowedTools Edit` (explicit prompt) | **S2** |
| 03 | bypassPermissions | json | `--allowedTools Edit` | **S2** |
| 04 | bypassPermissions (alias `--dangerously-skip-permissions`) | json | (none) | **S2** |
| 05 | acceptEdits | text | `--allowedTools Edit` | **S2** |
| 06 | default (`--permission-mode` 생략) | json | `--allowedTools Edit` | **S2** |
| 07 | acceptEdits | json | `--tools Edit,Read` | **S3** 90s timeout |
| 08 | plan | json | `--allowedTools Edit` | **S3** 90s timeout |

### Track 2: claude-agent-sdk stream-json transport (6 mode)

`.venv/bin/python scripts/reproduce_claude_sdk_edit.py --timeout 120` (claude-agent-sdk 0.2.87)

| Cell | SDK permission_mode | tool_use | edited | Symptom |
|---|---|---|---|---|
| 09 | `default` | 2 | yes | **S4_normal** |
| 10 | `acceptEdits` | 2 | yes | **S4_normal** |
| 11 | `plan` | 4 | no | **S4** (mode spec) |
| 12 | `bypassPermissions` | 2 | yes | **S4_normal** |
| 13 | `dontAsk` | 2 | yes | **S4_normal** |
| 14 | `auto` | 2 | yes | **S4_normal** |

### Track 3: 직접 subprocess stream-json (SDK 없이, 6 mode)

`python3 scripts/reproduce_claude_streamjson_subprocess.py --timeout 120`

| Cell | permission_mode | tool_use | edited | Symptom |
|---|---|---|---|---|
| 15 | `default` | 2 | yes | **S4_normal** |
| 16 | `acceptEdits` | 3 | yes | **S4_normal** |
| 17 | `plan` | 1 | no | **S4** (mode spec) |
| 18 | `bypassPermissions` | 3 | yes | **S4_normal** |
| 19 | `dontAsk` | 0 | no | **S0** invalid mode (CLI rejects) |
| 20 | `auto` | 0 | no | **S0** invalid mode (CLI rejects) |

### 결론

1. **#1598 F4 = `claude -p` print mode 의 비-streaming 직렬화 경로 한정 버그**. permission approval 정책 계층 문제 아님.
2. **stream-json transport (`--input-format stream-json --output-format stream-json --verbose`) 가 우회**. SDK 의존성 **없이** wrapper subprocess 만으로도 동등.
3. SDK 의 추가 가치는 transport 가 아니라 typed message / `@tool` decorator / `can_use_tool` callback 같은 부가 layer.
4. **채택 결정**: 2026-06-15 Anthropic 에이전트 크레딧 정책 (Pro 1,500 / Max 7,500 / Team 시트당 3,000, $49/1k) 으로 SDK 채택 시 정기 운영 비용 발생. stream-json subprocess 가 같은 통에 들어가는지는 공지로 불명확. BidMate 의 codex write-lane 이 이미 안정 동작 → dual-agent 도입의 본질적 필요 없음 → **채택 보류**, 측정 결과는 옵션 보관.

## 5. Eval 영향

All `·` — eval surface 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. (load-bearing path 미수정)

## 6. 하위 호환

영향 없음. ADR 0003 answer-contract, schema_version 무관.

## 7. 범위 외 (채택 보류, 옵션만 보관)

- `scripts/agent_loop_claude_patch_turn.py` 신규 어댑터 (stream-json 또는 SDK 기반)
- `scripts/agent_loop.py:10103` 의 `agent="codex"` 분기화
- patch-mode CLI 의 `--agent claude` 옵션
- lease borrow 의 dual-agent 분기
- `claude-agent-sdk` 의존성 추가
- read-only lane (`scripts/agent_loop_claude_turn.py`) 의 transport migration

위는 codex write-lane 으로 충분한 동안 보류. 2026-06-15 정책 명확화 후 또는 dual-agent 본질적 필요 발생 시 재검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)