### PR TITLE
chore: guard active Codex auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,7 @@ ACTIVE_CODEX_SESSIONS ?=
 ACTIVE_CODEX_MAX_PARALLEL ?= 8
 ACTIVE_CODEX_TIMEOUT_SECONDS ?= 0
 ACTIVE_CODEX_EXECUTABLE ?= codex
+ACTIVE_CODEX_AUTH_MODE ?= chatgpt
 ACTIVE_CODEX_SANDBOX ?= read-only
 ACTIVE_CODEX_RECORD_GATE_HEARTBEATS ?= 1
 ACTIVE_CODEX_EXECUTE ?=
@@ -948,6 +949,7 @@ agent-loop-active-codex-runner:
 	$(PYTHON) scripts/agent_loop.py active-codex-runner \
 	  $(if $(filter 1 true yes,$(ACTIVE_CODEX_EXECUTE)),--execute,--dry-run) \
 	  --codex-executable "$(ACTIVE_CODEX_EXECUTABLE)" \
+	  --auth-mode "$(ACTIVE_CODEX_AUTH_MODE)" \
 	  --sandbox "$(ACTIVE_CODEX_SANDBOX)" \
 	  --max-parallel "$(ACTIVE_CODEX_MAX_PARALLEL)" \
 	  --timeout-seconds "$(ACTIVE_CODEX_TIMEOUT_SECONDS)" \
@@ -975,6 +977,7 @@ agent-loop-active-auto-loop:
 	  --repair-slug "$(ACTIVE_REPAIR_SLUG)" \
 	  --repair-title "$(ACTIVE_REPAIR_TITLE)" \
 	  --codex-executable "$(ACTIVE_CODEX_EXECUTABLE)" \
+	  --auth-mode "$(ACTIVE_CODEX_AUTH_MODE)" \
 	  --sandbox "$(ACTIVE_CODEX_SANDBOX)" \
 	  --max-parallel "$(ACTIVE_CODEX_MAX_PARALLEL)" \
 	  --timeout-seconds "$(ACTIVE_CODEX_TIMEOUT_SECONDS)" \

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -174,6 +174,16 @@ make agent-loop-active-codex-runner
 make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE=1
 ```
 
+기본 인증 정책은 Codex CLI의 **ChatGPT login** 기반 구독제 경로다. Execute mode는
+spawn 전에 `codex login status`가 `Logged in using ChatGPT`를 보고하는지 확인하고,
+API-key login, 미로그인, 인증 오류는 fail-closed 한다. Dry-run은 인증 출처를 확인하지
+않지만 report/state에 `auth_mode`와 `auth_status`를 남긴다. 임시 우회가 필요하면
+`ACTIVE_CODEX_AUTH_MODE=any`를 명시한다.
+
+OpenAI Agents SDK orchestrator는 `OPENAI_API_KEY` 기반 API 호출 경로이므로 이 runner의
+기본 운영 모델에서 제외한다. API-key 기반 orchestration을 도입하려면 구독제 runner와
+분리된 issue/ADR에서 비용, 인증, privacy 경계를 다시 고정한다.
+
 runner는 session마다 `reports/agent_loop/active/codex_runs/<session_id>/` 아래에
 `prompt.md`, `stdout.jsonl`, `stderr.log`, `last_message.md`를 둔다. 기본 sandbox는
 `read-only`이고, 각 prompt는 assignment의 read-only 부분만 실행하게 제한한다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9123,6 +9123,7 @@ def write_active_auto_loop(
     repair_slug: str = "active-start",
     repair_title: str = "Agent loop active start",
     codex_executable: str = "codex",
+    auth_mode: str = "chatgpt",
     sandbox: str = "read-only",
     max_parallel: int = 8,
     timeout_seconds: int = 0,
@@ -9200,6 +9201,7 @@ def write_active_auto_loop(
         runner = write_active_codex_runner(
             execute=execute_runner,
             codex_executable=codex_executable,
+            auth_mode=auth_mode,
             sandbox=sandbox,
             max_parallel=max_parallel,
             timeout_seconds=timeout_seconds,
@@ -10078,6 +10080,8 @@ def write_active_codex_runner(
     mode: str = "read-only",
     task_id: str | None = None,
     base: str = "origin/main",
+    auth_mode: str = "chatgpt",
+    auth_runner=None,
 ) -> ActiveCodexRunnerResult:
     """Plan or spawn Codex processes for the active loop.
 
@@ -10099,6 +10103,8 @@ def write_active_codex_runner(
         raise ValueError("--sandbox must be read-only, workspace-write, or danger-full-access")
     if mode not in {"read-only", "patch"}:
         raise ValueError("--mode must be read-only or patch")
+    if auth_mode not in {"chatgpt", "any"}:
+        raise ValueError("--auth-mode must be chatgpt or any")
     registry_path = _active_path(registry, repo_root=repo_root)
     assignments_path = _active_path(assignments_dir, repo_root=repo_root)
     runs_path = _active_path(runs_dir, repo_root=repo_root)
@@ -10117,6 +10123,8 @@ def write_active_codex_runner(
             execute=execute,
             timeout_seconds=timeout_seconds,
             codex_executable=codex_executable,
+            auth_mode=auth_mode,
+            auth_runner=auth_runner,
             repo_root=repo_root,
             popen_factory=popen_factory,
             which_func=which_func,
@@ -10126,6 +10134,7 @@ def write_active_codex_runner(
     blockers: list[str] = []
     warnings: list[str] = []
     planned: list[dict[str, object]] = []
+    auth_status = "not checked"
     requested_sessions = _parse_active_session_filter(sessions)
     registry_payload: dict[str, object] = {}
 
@@ -10178,7 +10187,23 @@ def write_active_codex_runner(
         resolved_executable = which(codex_executable)
         if not resolved_executable:
             blockers.append(f"codex executable not found: {codex_executable}")
+        elif not blockers:
+            auth_status, auth_blockers, auth_warnings = _active_codex_auth_check(
+                auth_mode=auth_mode,
+                codex_executable=resolved_executable,
+                execute=execute,
+                runner=auth_runner,
+            )
+            blockers.extend(auth_blockers)
+            warnings.extend(auth_warnings)
     else:
+        auth_status, _, auth_warnings = _active_codex_auth_check(
+            auth_mode=auth_mode,
+            codex_executable=codex_executable,
+            execute=execute,
+            runner=auth_runner,
+        )
+        warnings.extend(auth_warnings)
         warnings.append("dry-run only; pass --execute or ACTIVE_CODEX_EXECUTE=1 to spawn Codex processes")
 
     decision = "blocked" if blockers else ("running" if execute else "planned")
@@ -10294,6 +10319,8 @@ def write_active_codex_runner(
         "generated_at": _isoformat(datetime.now(timezone.utc)),
         "execute": execute,
         "decision": decision,
+        "auth_mode": auth_mode,
+        "auth_status": auth_status,
         "sandbox": sandbox,
         "timeout_seconds": timeout_seconds,
         "registry": _repo_path(registry_path, repo_root),
@@ -10312,6 +10339,8 @@ def write_active_codex_runner(
             "event": "active-codex-runner",
             "execute": execute,
             "decision": decision,
+            "auth_mode": auth_mode,
+            "auth_status": auth_status,
             "sandbox": sandbox,
             "sessions": [item["session_id"] for item in planned],
             "blockers": blockers,
@@ -10321,6 +10350,8 @@ def write_active_codex_runner(
     rendered = render_active_codex_runner(
         decision=decision,
         execute=execute,
+        auth_mode=auth_mode,
+        auth_status=auth_status,
         sandbox=sandbox,
         sessions=planned,
         heartbeats=heartbeat_events,
@@ -10401,6 +10432,8 @@ def _write_active_codex_patch(
     execute: bool,
     timeout_seconds: int,
     codex_executable: str,
+    auth_mode: str,
+    auth_runner,
     repo_root: Path,
     popen_factory=None,
     which_func=None,
@@ -10418,6 +10451,7 @@ def _write_active_codex_patch(
     agent = "codex"
     blockers: list[str] = []
     warnings: list[str] = []
+    auth_status = "not checked"
     verdict = "error"
     diff_text = ""
     scratch_branch = ""
@@ -10463,7 +10497,23 @@ def _write_active_codex_patch(
     resolved_executable = which(codex_executable) if execute else codex_executable
     if execute and not resolved_executable:
         blockers.append(f"codex executable not found: {codex_executable}")
+    elif execute and not blockers:
+        auth_status, auth_blockers, auth_warnings = _active_codex_auth_check(
+            auth_mode=auth_mode,
+            codex_executable=str(resolved_executable),
+            execute=execute,
+            runner=auth_runner,
+        )
+        blockers.extend(auth_blockers)
+        warnings.extend(auth_warnings)
     if not execute:
+        auth_status, _, auth_warnings = _active_codex_auth_check(
+            auth_mode=auth_mode,
+            codex_executable=codex_executable,
+            execute=execute,
+            runner=auth_runner,
+        )
+        warnings.extend(auth_warnings)
         warnings.append("dry-run only; pass --execute (or ACTIVE_CODEX_EXECUTE=1) with --mode patch to run the write lane")
 
     run_dir = patch_runs_path / session_id
@@ -10649,6 +10699,8 @@ def _write_active_codex_patch(
         "execute": execute,
         "mode": "patch",
         "decision": decision,
+        "auth_mode": auth_mode,
+        "auth_status": auth_status,
         "sandbox": "workspace-write",
         "task_id": resolved_task,
         "verdict": verdict,
@@ -10666,6 +10718,8 @@ def _write_active_codex_patch(
             "mode": "patch",
             "execute": execute,
             "decision": decision,
+            "auth_mode": auth_mode,
+            "auth_status": auth_status,
             "sandbox": "workspace-write",
             "task_id": resolved_task,
             "verdict": verdict,
@@ -10677,6 +10731,8 @@ def _write_active_codex_patch(
     rendered = render_active_codex_runner(
         decision=decision,
         execute=execute,
+        auth_mode=auth_mode,
+        auth_status=auth_status,
         sandbox="workspace-write",
         sessions=sessions_out,
         heartbeats=(),
@@ -10781,6 +10837,8 @@ def render_active_codex_runner(
     *,
     decision: str,
     execute: bool,
+    auth_mode: str,
+    auth_status: str,
     sandbox: str,
     sessions: Sequence[dict[str, object]],
     heartbeats: Sequence[dict[str, str]],
@@ -10798,9 +10856,12 @@ def render_active_codex_runner(
         "- Spawns read-only `codex exec` processes for agentic sessions; the Eval / Claim / Privacy Auditor gate runs deterministically after run-artifact redaction.",
         "- Separate from `active-start` and `active-loop --execute`; it never calls ship.",
         "- With gate heartbeat recording enabled, completed blocking-role sessions can mark their own pass/clear status from an explicit gate verdict.",
+        "- Default auth policy requires Codex CLI to be logged in with ChatGPT; API-key orchestration is outside this runner.",
         "- Default sandbox is read-only. Use stronger sandboxes only after lease and scope review.",
         f"- Requested execution: `{execute}`",
         f"- Decision: `{decision}`",
+        f"- Auth mode: `{_sanitize_inline_text(auth_mode)}`",
+        f"- Auth status: `{_sanitize_inline_text(auth_status)}`",
         f"- Sandbox: `{_sanitize_inline_text(sandbox)}`",
         "",
         "## Inputs",
@@ -11589,6 +11650,41 @@ def _active_codex_exec_command(
         _repo_path(last_message_path, repo_root),
         "-",
     ]
+
+
+def _active_codex_auth_check(
+    *,
+    auth_mode: str,
+    codex_executable: str,
+    execute: bool,
+    runner=None,
+) -> tuple[str, list[str], list[str]]:
+    if auth_mode == "any":
+        return "skipped (auth-mode any)", [], ["Codex auth source check skipped because --auth-mode any was requested"]
+    if auth_mode != "chatgpt":
+        return f"invalid auth mode: {auth_mode}", [f"unsupported Codex auth mode: {auth_mode}"], []
+    if not execute:
+        return "not checked (dry-run; ChatGPT login required on execute)", [], [
+            "Codex ChatGPT login will be checked when --execute is requested"
+        ]
+
+    run = runner if runner is not None else subprocess.run
+    command = [codex_executable, "login", "status"]
+    try:
+        proc = run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        return f"login status failed: {exc}", [f"codex login status failed for ChatGPT auth guard: {exc}"], []
+
+    stdout = str(getattr(proc, "stdout", "") or "")
+    stderr = str(getattr(proc, "stderr", "") or "")
+    rc = int(getattr(proc, "returncode", 1) or 0)
+    combined = "\n".join(part.strip() for part in (stdout, stderr) if part.strip())
+    summary = _sanitize_inline_text(combined.splitlines()[0] if combined.splitlines() else f"rc={rc}")
+    if rc != 0:
+        return summary, [f"codex login status failed for ChatGPT auth guard (rc={rc}): {summary}"], []
+    if "Logged in using ChatGPT" not in stdout:
+        return summary, [f"Codex auth mode requires ChatGPT login; got: {summary}"], []
+    return "Logged in using ChatGPT", [], []
 
 
 def _active_codex_display_command(command: Sequence[str]) -> list[str]:
@@ -13355,6 +13451,7 @@ def build_parser() -> argparse.ArgumentParser:
     codex_runner.add_argument("--max-parallel", type=int, default=8)
     codex_runner.add_argument("--timeout-seconds", type=int, default=0, help="Per-session wait timeout; 0 means no timeout.")
     codex_runner.add_argument("--codex-executable", default="codex")
+    codex_runner.add_argument("--auth-mode", choices=("chatgpt", "any"), default="chatgpt", help="Require Codex ChatGPT login before execute, or use any to skip the auth-source guard.")
     codex_runner.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
     codex_runner.add_argument("--mode", choices=("read-only", "patch"), default="read-only", help="read-only spawns per-session review processes; patch runs one codex write-lane in a scratch worktree.")
     codex_runner.add_argument("--task", help="Task id for patch mode (T-YYYY-NNNN); defaults to the Implementer session's task.")
@@ -13381,6 +13478,7 @@ def build_parser() -> argparse.ArgumentParser:
     auto_loop.add_argument("--repair-slug", default="active-start")
     auto_loop.add_argument("--repair-title", default="Agent loop active start")
     auto_loop.add_argument("--codex-executable", default="codex")
+    auto_loop.add_argument("--auth-mode", choices=("chatgpt", "any"), default="chatgpt")
     auto_loop.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
     auto_loop.add_argument("--max-parallel", type=int, default=8)
     auto_loop.add_argument("--timeout-seconds", type=int, default=0)
@@ -14312,6 +14410,7 @@ def main(argv: list[str] | None = None) -> int:
                 max_parallel=args.max_parallel,
                 timeout_seconds=args.timeout_seconds,
                 codex_executable=args.codex_executable,
+                auth_mode=args.auth_mode,
                 sandbox=args.sandbox,
                 mode=args.mode,
                 task_id=args.task,
@@ -14346,6 +14445,7 @@ def main(argv: list[str] | None = None) -> int:
                 repair_slug=args.repair_slug,
                 repair_title=args.repair_title,
                 codex_executable=args.codex_executable,
+                auth_mode=args.auth_mode,
                 sandbox=args.sandbox,
                 max_parallel=args.max_parallel,
                 timeout_seconds=args.timeout_seconds,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3571,6 +3571,10 @@ def _write_expanded_active_runner_fixture(repo: Path) -> Path:
     return active
 
 
+def _chatgpt_auth_runner(cmd, **kwargs):  # type: ignore[no-untyped-def]
+    return subprocess.CompletedProcess(cmd, 0, stdout="Logged in using ChatGPT\n", stderr="")
+
+
 def test_active_codex_runner_dry_run_renders_eight_commands_without_spawning(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     active = _write_expanded_active_runner_fixture(repo)
@@ -3643,6 +3647,7 @@ def test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_leas
         repo_root=repo,
         popen_factory=fake_popen,
         which_func=lambda exe: "/opt/codex/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
     )
 
     assert result.decision == "completed"
@@ -3701,6 +3706,7 @@ def test_active_codex_runner_records_passing_gate_heartbeats(tmp_path: Path) -> 
         repo_root=repo,
         popen_factory=fake_popen,
         which_func=lambda exe: "/opt/codex/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
     )
 
     registry = json.loads((active / "session_registry.json").read_text(encoding="utf-8"))
@@ -3766,6 +3772,77 @@ def test_active_codex_runner_execute_fails_closed_without_codex(tmp_path: Path) 
     assert calls == []
 
 
+def test_active_codex_runner_requires_chatgpt_login_by_default(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+
+    def api_key_auth(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 0, stdout="Logged in using API key\n", stderr="")
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        repo_root=repo,
+        popen_factory=lambda cmd, **kwargs: calls.append(list(cmd)),  # type: ignore[arg-type]
+        which_func=lambda exe: "/bin/codex",
+        auth_runner=api_key_auth,
+    )
+
+    assert result.decision == "blocked"
+    assert any("requires ChatGPT login" in blocker for blocker in result.blockers)
+    assert calls == []
+    state = json.loads(result.state_path.read_text(encoding="utf-8"))
+    assert state["auth_mode"] == "chatgpt"
+    assert state["auth_status"] == "Logged in using API key"
+
+
+def test_active_codex_runner_blocks_when_login_status_fails(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    def failed_auth(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="not logged in")
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        repo_root=repo,
+        which_func=lambda exe: "/bin/codex",
+        auth_runner=failed_auth,
+    )
+
+    assert result.decision == "blocked"
+    assert any("codex login status failed" in blocker for blocker in result.blockers)
+
+
+def test_active_codex_runner_auth_mode_any_skips_auth_source_guard(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+    auth_calls: list[list[str]] = []
+
+    class DummyProc:
+        stdin = None
+        pid = 7200
+
+        def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+            return 0
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        auth_mode="any",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kwargs: calls.append(list(cmd)) or DummyProc(),  # type: ignore[arg-type]
+        which_func=lambda exe: "/bin/codex",
+        auth_runner=lambda cmd, **kwargs: auth_calls.append(list(cmd)),  # type: ignore[arg-type]
+    )
+
+    assert result.decision == "completed"
+    assert calls
+    assert auth_calls == []
+    state = json.loads(result.state_path.read_text(encoding="utf-8"))
+    assert state["auth_status"] == "skipped (auth-mode any)"
+
+
 def test_active_codex_runner_fails_closed_on_missing_registry_or_assignment(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
 
@@ -3799,6 +3876,7 @@ def test_active_codex_runner_cli_accepts_execute_and_session_filter() -> None:
     ])
     assert args.execute is True
     assert args.sessions == "reviewer,ci-regression-auditor"
+    assert args.auth_mode == "chatgpt"
     assert args.record_gate_heartbeats is True
 
 
@@ -3816,6 +3894,7 @@ def test_make_active_start_spawns_codex_runner_by_default() -> None:
     assert 'make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="1"' in result.stdout
     assert "scripts/agent_loop.py active-codex-runner" in result.stdout
     assert "--execute" in result.stdout
+    assert '--auth-mode "chatgpt"' in result.stdout
     assert "--record-gate-heartbeats" in result.stdout
 
 
@@ -3840,6 +3919,7 @@ def test_make_active_start_can_disable_runner_and_has_korean_alias() -> None:
     assert "agent-loop-active-codex-runner" not in no_runner.stdout
     assert alias.returncode == 0
     assert 'make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="1"' in alias.stdout
+    assert '--auth-mode "chatgpt"' in alias.stdout
 
 
 def test_active_auto_loop_completes_task_and_picks_next_from_state(monkeypatch, tmp_path: Path) -> None:
@@ -4288,6 +4368,7 @@ def test_codex_runner_patch_mode_execute_captures_patch_and_releases_lease(tmp_p
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=git_runner,
     )
 
@@ -4308,6 +4389,33 @@ def test_codex_runner_patch_mode_execute_captures_patch_and_releases_lease(tmp_p
     assert leases["leases"][0]["active_agent"] is None
 
 
+def test_codex_runner_patch_mode_requires_chatgpt_login(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+    _seed_patch_assignment(repo)
+    calls: list[list[str]] = []
+
+    def api_key_auth(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 0, stdout="Logged in using API key\n", stderr="")
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: calls.append(list(cmd)),  # type: ignore[arg-type]
+        which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=api_key_auth,
+        git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
+    )
+
+    assert result.decision == "blocked"
+    assert any("requires ChatGPT login" in blocker for blocker in result.blockers)
+    assert calls == []
+    assert not (repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json").exists()
+
+
 def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     _seed_patch_registry(repo)
@@ -4322,6 +4430,7 @@ def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) ->
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=_fake_git_runner(diff_stdout=diff),
     )
 
@@ -4347,6 +4456,7 @@ def test_codex_runner_patch_mode_blocks_without_assignment(tmp_path: Path) -> No
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
     )
 
@@ -4370,6 +4480,7 @@ def test_codex_runner_patch_mode_embeds_assignment_in_prompt(tmp_path: Path) -> 
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
     )
 
@@ -4397,6 +4508,7 @@ def test_codex_runner_patch_mode_blocks_out_of_scope_files(tmp_path: Path) -> No
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=_fake_git_runner(diff_stdout=diff),
     )
 
@@ -4423,6 +4535,7 @@ def test_codex_runner_patch_mode_allows_in_scope_files(tmp_path: Path) -> None:
         repo_root=repo,
         popen_factory=lambda cmd, **kw: _FakeCodexProc(),
         which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
         git_runner=_fake_git_runner(diff_stdout=diff),
     )
 


### PR DESCRIPTION
## Summary

- Add a default ChatGPT-login auth guard for `active-codex-runner` execute paths.
- Carry the same auth mode through patch mode and active auto-loop runner execution.
- Document that Agents SDK / API-key orchestration is outside this subscription-based runner path.

## Validation

- [x] `python3 -m py_compile scripts/agent_loop.py`
- [x] `pytest -q tests/test_agent_loop.py -k "active_codex_runner or codex_runner_patch_mode or active_auto_loop"`
- [x] `make check-branch`
- [x] `git diff --check HEAD~1..HEAD`

## Real-data delta (5b)

N/A — agent-loop coordination surface only; no retrieval, answer, ingestion, or eval runtime behavior changed.

Closes #1646
