### PR TITLE
Block invalid real100 v2 baseline indexes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -102,6 +102,7 @@ ALLOWED_PATTERNS=(
   '^reports/real100_v2/latency_cost_budget\.aggregate\.json$'
   '^reports/real100_v2/reranker_candidate_budget\.aggregate\.json$'
   '^reports/real100_v2/context_packing\.aggregate\.json$'
+  '^reports/real100_v2/page_metadata_readiness\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.md$'
   '^reports/real100_v2/retrieval_diagnostics\.aggregate\.json$'

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ reports/real100_v2/*
 !reports/real100_v2/latency_cost_budget.aggregate.json
 !reports/real100_v2/reranker_candidate_budget.aggregate.json
 !reports/real100_v2/context_packing.aggregate.json
+!reports/real100_v2/page_metadata_readiness.aggregate.json
 !reports/real100_v2/metric_suite.aggregate.json
 !reports/real100_v2/metric_suite.md
 !reports/real100_v2/retrieval_diagnostics.aggregate.json

--- a/docs/evaluation/real100_v2-context-packing.md
+++ b/docs/evaluation/real100_v2-context-packing.md
@@ -1,5 +1,10 @@
 # real100_v2 Context Packing Experiment
 
+> Invalidated for optimization claims by `T-2026-0047`: this screening used a
+> hashing-backed `real100_v2` index with 0.0 chunk page metadata coverage. Do
+> not use its `latency_regression` result as context-packing evidence until
+> rerun on a MiniLM page-aware v2 index.
+
 This report is aggregate-only. It contains no raw case prompts, generated responses, evidence text, filenames, local paths, document identifiers, chunk identifiers, or per-case rows. Legacy `real100`, v1, 221, and kordoc evidence is not used.
 
 ## Decision

--- a/docs/evaluation/real100_v2-latency-cost-budget.md
+++ b/docs/evaluation/real100_v2-latency-cost-budget.md
@@ -1,5 +1,10 @@
 # real100_v2 Latency And Cost Budget
 
+> Invalidated for optimization claims by `T-2026-0047`: the source baseline was
+> produced from a hashing-backed `real100_v2` index with 0.0 chunk page metadata
+> coverage. Rebuild and rerender from a MiniLM page-aware v2 index before using
+> this as a latency/cost budget.
+
 Issue: [#1626](https://github.com/hskim-solv/BidMate-DocAgent/issues/1626)
 
 Task: `T-2026-0030`

--- a/docs/evaluation/real100_v2-page-metadata-readiness.md
+++ b/docs/evaluation/real100_v2-page-metadata-readiness.md
@@ -1,0 +1,45 @@
+# real100_v2 Page Metadata Recovery Audit
+
+## Decision
+- Citation page claim: `NO-GO`
+- Private real-eval index: `NO-GO`
+- Private real-eval index no-go reasons: `hashing_embeddings_forbidden, minilm_semantic_baseline_required, chunk_page_metadata_coverage_zero`
+- Recoverability: `not_recoverable_from_existing_artifacts`
+- Requires re-index: `True`
+- Requires parser change: `False`
+- Retrieval/verifier/prompt/answer behavior change: `False`
+- Embedding backend/model/dim: `hashing` / `local-hashing-bow` / `384`
+
+## Coverage
+- Documents / chunks / parent sections: `100` / `21800` / `100`
+- Chunk page metadata coverage: `0.0`
+- Chunk page_span coverage: `0.0`
+- Chunk regions.page_number coverage: `0.0`
+- Chunk regions.bbox coverage: `0.0`
+
+## Source Groups
+- `file_format=hwp, text_source=pdf_pymupdf4llm, document_type=private_pdf_hwp_csv_text, chunking_strategy=fixed`: docs=`96`, chunks=`20391`, parents=`96`, page=`0.0`, page_span=`0.0`, regions.page_number=`0.0`, regions.bbox=`0.0`, capability=`page_blind`, decision=`requires_page_aware_reindex`
+- `file_format=pdf, text_source=pdf_pymupdf4llm, document_type=private_pdf_hwp_csv_text, chunking_strategy=fixed`: docs=`4`, chunks=`1409`, parents=`4`, page=`0.0`, page_span=`0.0`, regions.page_number=`0.0`, regions.bbox=`0.0`, capability=`page_blind`, decision=`requires_page_aware_reindex`
+
+## Implementation Matrix
+| source type | current coverage | recoverable? | parser change? | re-index? | OCR/visual? | cost | expected eval impact |
+|---|---:|---|---|---|---|---|---|
+| `existing_index_with_no_page_fields` | 0.000000 | False | False | True | False | S | Enables coverage measurement only after rebuild. |
+| `existing_index_with_no_page_fields` | 0.000000 | False | False | True | False | S | Enables coverage measurement only after rebuild. |
+
+## Readiness Checks
+- Page metadata coverage > 0: `False`
+- Chunk page_span integrity: `True` (checked=`0`, invalid=`0`, region_outside=`0`)
+- Citation renderer compatible: `True`
+- No private path leakage: `True`
+- Aggregate-only outputs: `True`
+
+## Follow-Up Issue Plan
+- Keep page-level citation claims disabled while source-group page coverage is zero.
+- Run a page-aware rebuild spike for page-blind PDF and HWP source groups and verify non-zero regions.page_number coverage.
+- Evaluate page-aware HWP extraction or an adapter that emits sections[].regions or sections[].page_span.
+- Rebuild the private index only after page-aware parser output populates sections[].regions or sections[].page_span.
+- Commit only aggregate reports; keep private raw content, filenames, doc_ids, and source paths out of artifacts.
+
+## Recommendation
+`full re-index`

--- a/docs/evaluation/real100_v2-reranker-candidate-budget.md
+++ b/docs/evaluation/real100_v2-reranker-candidate-budget.md
@@ -1,5 +1,10 @@
 # real100_v2 Reranker Candidate-Budget Sweep
 
+> Invalidated for optimization claims by `T-2026-0047`: this screening used a
+> hashing-backed `real100_v2` index with 0.0 chunk page metadata coverage. Do
+> not use its `latency_regression` result as reranker evidence until rerun on a
+> MiniLM page-aware v2 index.
+
 This report is aggregate-only. It contains no raw questions, answers, evidence text, filenames, local paths, document identifiers, chunk identifiers, or per-case rows. Legacy `real100`, v1, 221, and kordoc evidence is not used.
 
 ## Decision

--- a/docs/evaluation/real100_v2-retrieval-diagnostics.md
+++ b/docs/evaluation/real100_v2-retrieval-diagnostics.md
@@ -1,5 +1,10 @@
 # real100_v2 Retrieval Diagnostics
 
+> Invalidated for optimization claims by `T-2026-0047`: the source `real100_v2`
+> index is hashing-backed and has 0.0 chunk page metadata coverage. Use this
+> artifact only as historical context until a MiniLM page-aware v2 index is
+> rebuilt and remeasured.
+
 Issue: [#1622](https://github.com/hskim-solv/BidMate-DocAgent/issues/1622)
 
 Task: `T-2026-0029`

--- a/docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md
+++ b/docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md
@@ -1,0 +1,175 @@
+# Plan: T-2026-0047 repair or rescope real100_v2 page metadata blocker
+
+- Status: review
+- Owner role: Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0047`
+- Related issue / PR: [#1645](https://github.com/hskim-solv/BidMate-DocAgent/issues/1645) / PR TBD
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0003](../adr/0003-structured-answer-citation-contract.md)
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+`real100_v2` page/window experiments are blocked because the current private v2
+index has no chunk-level page metadata. Without an aggregate readiness packet,
+future work can accidentally claim page-aware citation improvements from an
+index that cannot support those claims.
+
+## Current Behavior
+
+- `reports/real100_v2/retrieval_diagnostics.aggregate.json` records page-span
+  coverage `0.0` and marks page/window claims blocked.
+- `scripts/page_metadata_recovery_audit.py` can audit an index without reading
+  retrieval predictions or emitting raw private content.
+- The canonical private index is external to the tracked tree at
+  `data/index/real100_v2` under the private root.
+
+## Desired Behavior
+
+Commit an aggregate-only `real100_v2` index readiness packet that either clears
+the blocker or explicitly keeps private optimization claims no-go with the next
+repair path. The readiness gate must fail closed for hashing-backed indexes and
+indexes with 0.0 chunk page metadata coverage.
+
+## Constraints
+
+- Scope constraints: readiness/audit packet and guard only; no retrieval ranking
+  change.
+- Architecture constraints: retrieval, verifier, prompt, and answer behavior
+  remain unchanged.
+- Compatibility constraints: additive report and CLI output flags only.
+- Eval/privacy constraints: `real100_v2` only; no legacy `real100`/v1/221/kordoc
+  index evidence; no raw text, filenames, local paths, `doc_id`, or `chunk_id`.
+- Tooling/CI constraints: private index stays ignored; committed output is
+  aggregate-only.
+- Non-goals: parser rewrite, index rebuild, default behavior change.
+
+## Architecture Impact
+
+- Affected modules or docs: `scripts/page_metadata_recovery_audit.py`,
+  `tests/test_page_metadata_recovery_audit.py`, `reports/real100_v2/`,
+  `docs/evaluation/`, `tasks/queue.md`.
+- Affected contracts or invariants: ADR 0003 answer contract unchanged.
+- Load-bearing paths: no runtime load-bearing path behavior change.
+- ADR required: no, additive readiness measurement only.
+- Backward compatibility expectation: existing `--output-dir` behavior remains
+  supported; explicit `--out-json` and `--out-md` are additive.
+
+## Affected Interfaces
+
+- CLI/API/config: add optional `--out-json` and `--out-md` report outputs;
+  tighten `make real-eval-v2-check` so bad private indexes fail closed.
+- Input data: ignored private `real100_v2` index.
+- Output artifacts: `reports/real100_v2/page_metadata_readiness.aggregate.json`
+  and `docs/evaluation/real100_v2-page-metadata-readiness.md`.
+- Docs/review surfaces: plan, queue, readiness report, PR §5b.
+- Tests/eval entrypoints: focused page metadata audit tests and v2 guard.
+
+## Data / Eval Impact
+
+- Surface: private real-eval.
+- Data boundary: aggregate-only private output.
+- Allowed claim: current `real100_v2` index readiness is NO-GO because it uses
+  hashing embeddings and has 0.0 chunk page metadata coverage.
+- Disallowed claim: answer quality, retrieval quality, or page-aware performance
+  improvement.
+- Baseline or control affected: no; current index remains unchanged.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Extend the existing page metadata audit script with explicit aggregate report
+   output paths and MiniLM/page metadata index guard fields.
+2. Run the audit against the canonical private `real100_v2` index only.
+3. Make `real-eval-v2-check` reject hashing-backed private indexes and indexes
+   with 0.0 chunk page metadata coverage.
+4. Mark affected committed experiment reports as invalid for optimization
+   claims until rerun on a MiniLM page-aware v2 index.
+5. Run privacy, claim, link, and branch gates.
+
+## Acceptance Criteria
+
+- [x] The task either clears the page/window blocker or records an explicit
+  no-go/rescope decision for `T-2026-0031`.
+- [x] Page metadata coverage is reported as aggregate counts only.
+- [x] Any index rebuild need records parser/index provenance as a future repair
+  path, not as a completed behavior change.
+- [x] Hashing-backed private real-eval indexes fail closed before experiment
+  execution.
+- [x] 0.0-coverage page metadata indexes fail closed before experiment
+  execution.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-check  # expected to fail for the current invalid hashing/page-0 index
+python3 scripts/page_metadata_recovery_audit.py --index-dir /Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100_v2 --out-json reports/real100_v2/page_metadata_readiness.aggregate.json --out-md docs/evaluation/real100_v2-page-metadata-readiness.md --format markdown
+python3 -m pytest -q tests/test_real_eval_paths.py tests/test_page_metadata_recovery_audit.py tests/test_real100_v2_guard.py
+make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md docs/evaluation/real100_v2-page-metadata-readiness.md reports/real100_v2/README.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused tests and v2 readiness commands pass.
+- Generated or updated artifact: aggregate-only page metadata readiness packet.
+- Reviewer checklist or manual inspection: no private content, no performance
+  improvement claim, no legacy evidence.
+- Explicitly not validated, with reason: no MiniLM page-aware parser/index
+  rebuild is performed in this PR.
+
+## Rollback Strategy
+
+Revert the additive script/report/doc updates. Do not delete private
+`real100_v2` index artifacts or raw source files during rollback.
+
+## Failure Modes
+
+- Failure mode: report is mistaken for a page-aware improvement claim.
+- Detection signal: claim audit or reviewer flags wording beyond NO-GO/readiness.
+- Stop condition or fallback: keep `T-2026-0031` blocked and open a parser/index
+  rebuild task.
+
+- Failure mode: raw private identifiers leak into aggregate output.
+- Detection signal: privacy audit or focused tests fail.
+- Stop condition or fallback: remove unsafe fields and keep only counts/enums.
+
+## Observability
+
+- `reports/real100_v2/page_metadata_readiness.aggregate.json`
+- `docs/evaluation/real100_v2-page-metadata-readiness.md`
+- `make real-eval-v2-guard`
+- `python3 scripts/agent_loop.py privacy-audit-output`
+- `python3 scripts/agent_loop.py claim-audit --from-git`
+
+## Reviewer Notes
+
+Attack claim wording and data boundary first. The correct result is a NO-GO
+readiness packet plus a fail-closed guard: current hashing-backed `real100_v2`
+artifacts are not valid private optimization evidence until a MiniLM page-aware
+index is rebuilt and measured.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 14:25 KST
+
+- Role: Evaluator / Implementer
+- Branch / worktree: eval/issue-1645-repair-real100-v2-page-metadata-blocker / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1645 / PR TBD
+- Task: T-2026-0047
+- Current status: fail-closed guard implemented; aggregate readiness packet generated; affected optimization reports are marked invalid for claims.
+- Files touched: scripts/real_eval_paths.py, tests/test_real_eval_paths.py, scripts/page_metadata_recovery_audit.py, tests/test_page_metadata_recovery_audit.py, reports/real100_v2/page_metadata_readiness.aggregate.json, docs/evaluation/real100_v2-page-metadata-readiness.md, docs/evaluation/real100_v2-retrieval-diagnostics.md, docs/evaluation/real100_v2-latency-cost-budget.md, docs/evaluation/real100_v2-reranker-candidate-budget.md, docs/evaluation/real100_v2-context-packing.md, reports/real100_v2/README.md, .gitignore, .githooks/pre-commit, scripts/check_real100_v2_only.py, docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md, tasks/queue.md
+- Decisions made: no parser/index rebuild in this PR; T-2026-0031 remains blocked; T-2026-0029/T-2026-0030/T-2026-0032/T-2026-0033 optimization conclusions must be rerun on a MiniLM page-aware v2 index.
+- Commands run: make ship-start TITLE="Repair real100 v2 page metadata blocker" TYPE=eval; make check-branch; python3 scripts/page_metadata_recovery_audit.py --index-dir <external_private_real100_v2_index> --out-json reports/real100_v2/page_metadata_readiness.aggregate.json --out-md docs/evaluation/real100_v2-page-metadata-readiness.md --format markdown; REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml REAL100_V2_INDEX_DIR=data/index/real100_v2 REAL100_V2_REPORT_DIR=reports/real100_v2 make real-eval-v2-check.
+- Results: `make real-eval-v2-check` now fails for current real100_v2 index because it uses hashing embeddings and chunk page metadata coverage is 0.0; readiness packet reports private real-eval index NO-GO.
+- Next safe command: python3 -m pytest -q tests/test_real_eval_paths.py tests/test_page_metadata_recovery_audit.py tests/test_real100_v2_guard.py
+- Open questions: none.
+- Risks: existing historical aggregates remain in tree for auditability but are invalidated for optimization claims.
+```

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -11,6 +11,7 @@ Allowed files:
 - `latency_cost_budget.aggregate.json`
 - `reranker_candidate_budget.aggregate.json`
 - `context_packing.aggregate.json`
+- `page_metadata_readiness.aggregate.json`
 - `metric_suite.aggregate.json`
 - `metric_suite.md`
 - `retrieval_diagnostics.aggregate.json`

--- a/reports/real100_v2/page_metadata_readiness.aggregate.json
+++ b/reports/real100_v2/page_metadata_readiness.aggregate.json
@@ -1,0 +1,174 @@
+{
+  "artifacts": {
+    "ingestion_report": {
+      "has_page_like_keys": true,
+      "has_text_source_counts": true,
+      "page_like_key_counts": {
+        "pymupdf4llm_page_chunks": 101
+      },
+      "present": true,
+      "status": "ok"
+    },
+    "kordoc_cache": {
+      "present": false,
+      "status": "not_provided"
+    },
+    "visual_artifacts": {
+      "present": false,
+      "status": "not_provided"
+    }
+  },
+  "decision": {
+    "citation_page_claim_go_no_go": "NO-GO",
+    "current_index_behavior_change": false,
+    "page_claim_scope": "not_supported",
+    "private_real_eval_index_go_no_go": "NO-GO",
+    "private_real_eval_index_no_go_reasons": [
+      "hashing_embeddings_forbidden",
+      "minilm_semantic_baseline_required",
+      "chunk_page_metadata_coverage_zero"
+    ],
+    "recommendation": "full re-index",
+    "recoverability": "not_recoverable_from_existing_artifacts",
+    "recoverable_from_existing_local_artifacts": false,
+    "requires_parser_change": false,
+    "requires_reindex": true,
+    "retrieval_verifier_prompt_answer_change": false
+  },
+  "follow_up_issue_plan": [
+    "Keep page-level citation claims disabled while source-group page coverage is zero.",
+    "Run a page-aware rebuild spike for page-blind PDF and HWP source groups and verify non-zero regions.page_number coverage.",
+    "Evaluate page-aware HWP extraction or an adapter that emits sections[].regions or sections[].page_span.",
+    "Rebuild the private index only after page-aware parser output populates sections[].regions or sections[].page_span.",
+    "Commit only aggregate reports; keep private raw content, filenames, doc_ids, and source paths out of artifacts."
+  ],
+  "implementation_matrix": [
+    {
+      "current_coverage": 0.0,
+      "decision": "requires_page_aware_reindex",
+      "estimated_engineering_cost": "S",
+      "expected_eval_impact": "Enables coverage measurement only after rebuild.",
+      "parent_current_coverage": 0.0,
+      "recoverable": false,
+      "requires_ocr_visual_ingestion": false,
+      "requires_parser_change": false,
+      "requires_reindex": true,
+      "source_group": "file_format=hwp, text_source=pdf_pymupdf4llm, document_type=private_pdf_hwp_csv_text, chunking_strategy=fixed",
+      "source_type": "existing_index_with_no_page_fields"
+    },
+    {
+      "current_coverage": 0.0,
+      "decision": "requires_page_aware_reindex",
+      "estimated_engineering_cost": "S",
+      "expected_eval_impact": "Enables coverage measurement only after rebuild.",
+      "parent_current_coverage": 0.0,
+      "recoverable": false,
+      "requires_ocr_visual_ingestion": false,
+      "requires_parser_change": false,
+      "requires_reindex": true,
+      "source_group": "file_format=pdf, text_source=pdf_pymupdf4llm, document_type=private_pdf_hwp_csv_text, chunking_strategy=fixed",
+      "source_type": "existing_index_with_no_page_fields"
+    }
+  ],
+  "index": {
+    "chunk": {
+      "any_page_metadata_coverage": 0.0,
+      "count": 21800,
+      "page_span_coverage": 0.0,
+      "regions_bbox_coverage": 0.0,
+      "regions_page_number_coverage": 0.0,
+      "with_any_page_metadata_count": 0,
+      "with_page_span_count": 0,
+      "with_regions_bbox_count": 0,
+      "with_regions_page_number_count": 0
+    },
+    "chunk_count": 21800,
+    "document": {
+      "any_page_metadata_coverage": 0.0,
+      "count": 100,
+      "page_span_coverage": 0.0,
+      "regions_bbox_coverage": 0.0,
+      "regions_page_number_coverage": 0.0,
+      "with_any_page_metadata_count": 0,
+      "with_page_span_count": 0,
+      "with_regions_bbox_count": 0,
+      "with_regions_page_number_count": 0
+    },
+    "document_count": 100,
+    "embedding": {
+      "backend": "hashing",
+      "dimension": 384,
+      "model": "local-hashing-bow"
+    },
+    "parent_section": {
+      "any_page_metadata_coverage": 0.0,
+      "count": 100,
+      "page_span_coverage": 0.0,
+      "regions_bbox_coverage": 0.0,
+      "regions_page_number_coverage": 0.0,
+      "with_any_page_metadata_count": 0,
+      "with_page_span_count": 0,
+      "with_regions_bbox_count": 0,
+      "with_regions_page_number_count": 0
+    },
+    "parent_section_count": 100,
+    "schema_version": 2,
+    "source_groups": [
+      {
+        "any_page_metadata_coverage": 0.0,
+        "chunk_count": 20391,
+        "chunking_strategy": "fixed",
+        "decision": "requires_page_aware_reindex",
+        "doc_count": 96,
+        "document_type": "private_pdf_hwp_csv_text",
+        "file_format": "hwp",
+        "page_metadata_capability": "page_blind",
+        "page_span_coverage": 0.0,
+        "parent_any_page_metadata_coverage": 0.0,
+        "parent_section_count": 96,
+        "regions_bbox_coverage": 0.0,
+        "regions_page_number_coverage": 0.0,
+        "text_source": "pdf_pymupdf4llm"
+      },
+      {
+        "any_page_metadata_coverage": 0.0,
+        "chunk_count": 1409,
+        "chunking_strategy": "fixed",
+        "decision": "requires_page_aware_reindex",
+        "doc_count": 4,
+        "document_type": "private_pdf_hwp_csv_text",
+        "file_format": "pdf",
+        "page_metadata_capability": "page_blind",
+        "page_span_coverage": 0.0,
+        "parent_any_page_metadata_coverage": 0.0,
+        "parent_section_count": 4,
+        "regions_bbox_coverage": 0.0,
+        "regions_page_number_coverage": 0.0,
+        "text_source": "pdf_pymupdf4llm"
+      }
+    ]
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "omits_chunk_ids": true,
+    "omits_doc_ids": true,
+    "omits_file_names": true,
+    "omits_raw_text": true,
+    "omits_source_paths": true
+  },
+  "profile_type": "private_real100_v2_page_metadata_readiness",
+  "readiness_checks": {
+    "aggregate_only_outputs": true,
+    "chunk_page_span_integrity": {
+      "checked_count": 0,
+      "invalid_page_span_count": 0,
+      "ok": true,
+      "region_outside_page_span_count": 0
+    },
+    "citation_renderer_compatible": true,
+    "no_private_path_leakage": true,
+    "page_metadata_coverage_gt_0": false
+  },
+  "schema_version": 1,
+  "status": "ok"
+}

--- a/scripts/check_real100_v2_only.py
+++ b/scripts/check_real100_v2_only.py
@@ -22,6 +22,7 @@ DEFAULT_PATHS = (
     Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
     Path("docs/evaluation/real100_v2-reranker-candidate-budget.md"),
     Path("docs/evaluation/real100_v2-context-packing.md"),
+    Path("docs/evaluation/real100_v2-page-metadata-readiness.md"),
     Path("reports/real100_v2/README.md"),
 )
 
@@ -75,6 +76,7 @@ def check_path(path: Path) -> list[str]:
                 _task_block(text, "T-2026-0031", "T-2026-0032"),
                 _task_block(text, "T-2026-0032", "T-2026-0033"),
                 _task_block(text, "T-2026-0033", "T-2026-0034"),
+                _task_block(text, "T-2026-0047", "T-2026-0048"),
             )
             if block
         )
@@ -125,6 +127,7 @@ def check_path(path: Path) -> list[str]:
         Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
         Path("docs/evaluation/real100_v2-reranker-candidate-budget.md"),
         Path("docs/evaluation/real100_v2-context-packing.md"),
+        Path("docs/evaluation/real100_v2-page-metadata-readiness.md"),
     }:
         for lineno, line in enumerate(scoped.splitlines(), start=1):
             if _is_ban_context(line):

--- a/scripts/page_metadata_recovery_audit.py
+++ b/scripts/page_metadata_recovery_audit.py
@@ -34,6 +34,9 @@ FILENAME_VALUE_RE = re.compile(
     r"(^|[\s\"'`])[^/\s\"'`]+\.(pdf|hwp|hwpx|docx|xlsx|csv|jsonl|md|txt)\b",
     re.IGNORECASE,
 )
+DEFAULT_OUT_JSON = _REPO_ROOT / "reports" / "real100_v2" / "page_metadata_readiness.aggregate.json"
+DEFAULT_OUT_MD = _REPO_ROOT / "docs" / "evaluation" / "real100_v2-page-metadata-readiness.md"
+PREFERRED_MINILM_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 
 
 def _rate(numerator: int, denominator: int) -> float:
@@ -47,6 +50,38 @@ def _safe_label(value: Any) -> str:
     if not label:
         return "<missing>"
     return label if SAFE_LABEL_RE.fullmatch(label) else "<redacted_label>"
+
+
+def _embedding_block(index_payload: Mapping[str, Any]) -> dict[str, Any]:
+    embedding = index_payload.get("embedding") if isinstance(index_payload.get("embedding"), Mapping) else {}
+    backend = _safe_label(embedding.get("backend"))
+    model = str(embedding.get("model") or "").strip()
+    if model:
+        model = model.replace("/", "__")
+    if not SAFE_LABEL_RE.fullmatch(model):
+        model = "<redacted_label>" if model else "<missing>"
+    try:
+        dimension = int(embedding.get("dimension"))
+    except (TypeError, ValueError):
+        dimension = None
+    return {"backend": backend, "model": model, "dimension": dimension}
+
+
+def _private_eval_index_guard(
+    embedding: Mapping[str, Any],
+    chunk_coverage: Mapping[str, Any],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if embedding.get("backend") == "hashing":
+        reasons.append("hashing_embeddings_forbidden")
+    if embedding.get("backend") != "sentence-transformers" or embedding.get("model") != PREFERRED_MINILM_MODEL:
+        reasons.append("minilm_semantic_baseline_required")
+    if float(chunk_coverage.get("any_page_metadata_coverage") or 0.0) <= 0.0:
+        reasons.append("chunk_page_metadata_coverage_zero")
+    return {
+        "status": "GO" if not reasons else "NO-GO",
+        "reasons": reasons,
+    }
 
 
 def _load_json(path: Path) -> tuple[dict[str, Any], str | None]:
@@ -255,14 +290,18 @@ def _matrix_row_for_group(group: Mapping[str, Any]) -> dict[str, Any]:
             "source_type": source_type,
             "current_coverage": coverage,
             "parent_current_coverage": parent_coverage,
-            "source_group": (
-                f"{group['file_format']}/{group['text_source']}/"
-                f"{group['document_type']}/{group['chunking_strategy']}"
-            ),
+            "source_group": _format_source_group(group),
             "decision": group["decision"],
         }
     )
     return row
+
+
+def _format_source_group(group: Mapping[str, Any]) -> str:
+    return (
+        f"file_format={group['file_format']}, text_source={group['text_source']}, "
+        f"document_type={group['document_type']}, chunking_strategy={group['chunking_strategy']}"
+    )
 
 
 def implementation_matrix(source_groups: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -622,6 +661,9 @@ def build_audit_report(
     chunk_coverage = coverage_block(chunks)
     document_coverage = coverage_block(documents)
     parent_coverage = coverage_block(parent_sections)
+    embedding_payload = index_payload.get("embedding") if isinstance(index_payload.get("embedding"), Mapping) else {}
+    embedding = _embedding_block(index_payload)
+    private_eval_guard = _private_eval_index_guard(embedding_payload, chunk_coverage)
     source_groups = source_group_coverage(chunks, parent_sections, documents)
 
     ingestion_report_path = ingestion_report_path or (
@@ -649,6 +691,7 @@ def build_audit_report(
     matrix = implementation_matrix(source_groups)
     report = {
         "schema_version": 1,
+        "profile_type": "private_real100_v2_page_metadata_readiness",
         "status": "ok",
         "privacy": privacy,
         "index": {
@@ -656,6 +699,7 @@ def build_audit_report(
             "document_count": len(documents),
             "chunk_count": len(chunks),
             "parent_section_count": len(parent_sections),
+            "embedding": embedding,
             "chunk": chunk_coverage,
             "document": document_coverage,
             "parent_section": parent_coverage,
@@ -669,6 +713,8 @@ def build_audit_report(
         "implementation_matrix": matrix,
         "decision": {
             "citation_page_claim_go_no_go": "GO" if max_source_page_coverage > 0 else "NO-GO",
+            "private_real_eval_index_go_no_go": private_eval_guard["status"],
+            "private_real_eval_index_no_go_reasons": private_eval_guard["reasons"],
             "page_claim_scope": (
                 "covered_source_groups_only" if max_source_page_coverage > 0 else "not_supported"
             ),
@@ -683,8 +729,8 @@ def build_audit_report(
         },
         "follow_up_issue_plan": [
             "Keep page-level citation claims disabled while source-group page coverage is zero.",
-            "Run a PDF visual-ingestion rebuild spike for PDF/kordoc source groups and verify non-zero regions.page_number coverage.",
-            "Evaluate a page-aware HWP parser or adapter; kordoc Markdown/cache without page markers is insufficient.",
+            "Run a page-aware rebuild spike for page-blind PDF and HWP source groups and verify non-zero regions.page_number coverage.",
+            "Evaluate page-aware HWP extraction or an adapter that emits sections[].regions or sections[].page_span.",
             "Rebuild the private index only after page-aware parser output populates sections[].regions or sections[].page_span.",
             "Commit only aggregate reports; keep private raw content, filenames, doc_ids, and source paths out of artifacts.",
         ],
@@ -695,19 +741,22 @@ def build_audit_report(
 
 def render_markdown(report: Mapping[str, Any]) -> str:
     if report.get("status") != "ok":
-        return f"# Page Metadata Recovery Audit\n\n- Status: `{report.get('status')}`\n"
+        return f"# real100_v2 Page Metadata Recovery Audit\n\n- Status: `{report.get('status')}`\n"
 
     decision = report["decision"]
     index = report["index"]
     lines = [
-        "# Page Metadata Recovery Audit",
+        "# real100_v2 Page Metadata Recovery Audit",
         "",
         "## Decision",
         f"- Citation page claim: `{decision['citation_page_claim_go_no_go']}`",
+        f"- Private real-eval index: `{decision['private_real_eval_index_go_no_go']}`",
+        f"- Private real-eval index no-go reasons: `{', '.join(decision['private_real_eval_index_no_go_reasons']) or '-'}`",
         f"- Recoverability: `{decision['recoverability']}`",
         f"- Requires re-index: `{decision['requires_reindex']}`",
         f"- Requires parser change: `{decision['requires_parser_change']}`",
         f"- Retrieval/verifier/prompt/answer behavior change: `{decision['retrieval_verifier_prompt_answer_change']}`",
+        f"- Embedding backend/model/dim: `{index['embedding']['backend']}` / `{index['embedding']['model']}` / `{index['embedding']['dimension']}`",
         "",
         "## Coverage",
         f"- Documents / chunks / parent sections: `{index['document_count']}` / `{index['chunk_count']}` / `{index['parent_section_count']}`",
@@ -721,7 +770,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     for group in index["source_groups"]:
         lines.append(
             "- "
-            f"`{group['file_format']}/{group['text_source']}/{group['document_type']}/{group['chunking_strategy']}`: "
+            f"`{_format_source_group(group)}`: "
             f"docs=`{group['doc_count']}`, chunks=`{group['chunk_count']}`, "
             f"parents=`{group['parent_section_count']}`, "
             f"page=`{group['any_page_metadata_coverage']}`, "
@@ -790,8 +839,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional directory for page_metadata_recovery_audit.json/.md.",
     )
+    parser.add_argument("--out-json", type=Path, default=None, help="Optional aggregate JSON output path.")
+    parser.add_argument("--out-md", type=Path, default=None, help="Optional Markdown report output path.")
     parser.add_argument("--format", choices=["json", "markdown"], default="json")
     return parser.parse_args(argv)
+
+
+def _repo_relative(path: Path) -> Path:
+    return path if path.is_absolute() else _REPO_ROOT / path
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -817,6 +872,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             render_markdown(report),
             encoding="utf-8",
         )
+    if args.out_json:
+        out_json = _repo_relative(args.out_json)
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.out_md:
+        out_md = _repo_relative(args.out_md)
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(render_markdown(report), encoding="utf-8")
     sys.stdout.write(text)
     return 0 if report.get("status") == "ok" else 2
 

--- a/scripts/real_eval_paths.py
+++ b/scripts/real_eval_paths.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover - direct script execution
 ROOT_DIR = Path(__file__).resolve().parents[1]
 PRIVATE_REAL_MIN_DOCS = 50
 LOW_CHUNK_REAL_MAX = 1000
+PREFERRED_MINILM_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 
 
 @dataclass(frozen=True)
@@ -135,23 +136,38 @@ def _choose_path(
     return _resolve_path(default, base), "default"
 
 
-def _index_counts(index_dir: Path) -> tuple[int | None, int | None, str | None]:
+def _is_page_span(value: Any) -> bool:
+    return isinstance(value, list) and len(value) == 2 and all(isinstance(page, int) for page in value)
+
+
+def _has_region_page(item: Mapping[str, Any]) -> bool:
+    regions = item.get("regions")
+    if not isinstance(regions, list):
+        return False
+    return any(isinstance(region, Mapping) and isinstance(region.get("page_number"), int) for region in regions)
+
+
+def _index_metadata(index_dir: Path) -> tuple[dict[str, Any], str | None]:
     index_json = index_dir / "index.json"
     if not index_json.exists():
-        return None, None, None
+        return {}, None
     try:
         payload = json.loads(index_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        return None, None, f"index metadata unreadable: {exc}"
+        return {}, f"index metadata unreadable: {exc}"
     build = payload.get("build") if isinstance(payload, dict) else {}
     if not isinstance(build, dict):
         build = {}
+    embedding = payload.get("embedding") if isinstance(payload, dict) else {}
+    if not isinstance(embedding, dict):
+        embedding = {}
+    chunks_list = payload.get("chunks") if isinstance(payload, dict) and isinstance(payload.get("chunks"), list) else []
     docs = build.get("num_documents")
     chunks = build.get("num_chunks")
     if docs is None and isinstance(payload, dict):
         docs = len(payload.get("documents") or [])
     if chunks is None and isinstance(payload, dict):
-        chunks = len(payload.get("chunks") or [])
+        chunks = len(chunks_list)
     try:
         docs_int = int(docs) if docs is not None else None
     except (TypeError, ValueError):
@@ -160,7 +176,19 @@ def _index_counts(index_dir: Path) -> tuple[int | None, int | None, str | None]:
         chunks_int = int(chunks) if chunks is not None else None
     except (TypeError, ValueError):
         chunks_int = None
-    return docs_int, chunks_int, None
+    page_metadata_chunks = sum(
+        1
+        for chunk in chunks_list
+        if isinstance(chunk, Mapping)
+        and (_is_page_span(chunk.get("page_span")) or _has_region_page(chunk))
+    )
+    return {
+        "num_documents": docs_int,
+        "num_chunks": chunks_int,
+        "embedding_backend": str(embedding.get("backend") or "").strip(),
+        "embedding_model": str(embedding.get("model") or "").strip(),
+        "chunk_page_metadata_count": page_metadata_chunks,
+    }, None
 
 
 def _entry_status(
@@ -176,22 +204,33 @@ def _entry_status(
     num_docs: int | None = None
     num_chunks: int | None = None
     if name == "index_dir" and path.exists():
-        num_docs, num_chunks, count_error = _index_counts(path)
+        metadata, count_error = _index_metadata(path)
+        num_docs = metadata.get("num_documents")
+        num_chunks = metadata.get("num_chunks")
         if count_error:
             return exists, "warn", count_error, num_docs, num_chunks
+        invalid_reasons: list[str] = []
         if (
             num_docs is not None
             and num_chunks is not None
             and num_docs >= PRIVATE_REAL_MIN_DOCS
             and 0 < num_chunks <= LOW_CHUNK_REAL_MAX
         ):
-            return (
-                exists,
-                "invalid",
-                "stale/invalid CSV-fallback index; rebuild from kordoc cache/source",
-                num_docs,
-                num_chunks,
-            )
+            invalid_reasons.append("stale/invalid low-chunk index; rebuild from current private source")
+        if num_docs is not None and num_docs >= PRIVATE_REAL_MIN_DOCS:
+            backend = str(metadata.get("embedding_backend") or "")
+            model = str(metadata.get("embedding_model") or "")
+            page_metadata_count = int(metadata.get("chunk_page_metadata_count") or 0)
+            if backend == "hashing":
+                invalid_reasons.append("hashing embeddings are forbidden for private real-eval and naive baseline evidence")
+            elif backend != "sentence-transformers" or model != PREFERRED_MINILM_MODEL:
+                invalid_reasons.append(
+                    "private real-eval baseline index must use MiniLM sentence-transformers embeddings"
+                )
+            if page_metadata_count <= 0:
+                invalid_reasons.append("chunk page metadata coverage is 0.0; use a page-aware index")
+        if invalid_reasons:
+            return exists, "invalid", "; ".join(invalid_reasons), num_docs, num_chunks
     if exists:
         if name == "index_dir" and num_docs is not None and num_chunks is not None:
             return exists, "ok", f"index metadata: {num_docs} docs, {num_chunks} chunks", num_docs, num_chunks
@@ -582,12 +621,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     invalid = [e for e in entries if e.status == "invalid"]
     if invalid:
-        print("\nWarnings:", file=sys.stderr)
+        print("\nInvalid private real-eval inputs:", file=sys.stderr)
         for entry in invalid:
             suffix = ""
             if entry.num_documents is not None and entry.num_chunks is not None:
                 suffix = f" ({entry.num_documents} docs, {entry.num_chunks} chunks)"
             print(f"- {entry.name}: {entry.message}{suffix}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -42,8 +42,8 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1622; real100_v2 retrieval diagnostics rendered; next experiment points to T-2026-0032 while T-2026-0031 remains page-metadata blocked. |
 | 30 | `T-2026-0030` | `done` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | merged in PR #1628; real100_v2 latency/cost envelope landed. |
 | 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
-| 32 | `T-2026-0032` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1629; BGE-KO screening run classifies latency_regression, no winner claim. |
-| 33 | `T-2026-0033` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issues #1638/#1641; context-packing screening classifies evidence_first as latency_regression, no winner claim. |
+| 32 | `T-2026-0032` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1636; BGE-KO screening run classifies latency_regression, no winner claim. |
+| 33 | `T-2026-0033` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1644; context-packing screening classifies evidence_first as latency_regression, no winner claim. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
 | 36 | `T-2026-0036` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on stable retrieval/context evidence from P0/P1 tasks. |
@@ -57,7 +57,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 44 | `T-2026-0044` | `backlog` | Implementer -> Deep Reviewer -> Reviewer | issue #1588 PR5; Orchestrator-only ship-executor + gate evidence (promote agent_loop.py to LOAD_BEARING); blocked on T-2026-0043. |
 | 45 | `T-2026-0045` | `backlog` | Implementer -> Reviewer | issue #1588 PR6; full active-agent-loop.md ops-doc rewrite; blocked on T-2026-0044. |
 | 46 | `T-2026-0046` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1627; expands the RAG experiment task stack and inserts measurement-driven replanning gates. |
-| 47 | `T-2026-0047` | `backlog` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; repair or explicitly rescope the real100_v2 page metadata blocker before claim-bearing page/window experiments. |
+| 47 | `T-2026-0047` | `review` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1645; hashing/page-0 real100_v2 index now fails v2 readiness, and affected optimization reports are invalidated until a MiniLM page-aware v2 rebuild. |
 | 48 | `T-2026-0048` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; candidate-depth and fusion-budget sweep for the `not_observable_limited_depth` retrieval failure bucket. |
 | 49 | `T-2026-0049` | `backlog` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0 replanning gate after T-2026-0030, T-2026-0032, T-2026-0047, and T-2026-0048 evidence. |
 | 50 | `T-2026-0050` | `backlog` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; parser/layout/table coverage experiment for RFP evidence that is not text-searchable enough. |
@@ -3732,7 +3732,7 @@ make check-branch
 
 - ID: T-2026-0047
 - Title: Repair or rescope real100_v2 page metadata blocker
-- Status: backlog
+- Status: review
 - Priority: P0
 - Owner role: Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-28
@@ -3740,18 +3740,22 @@ make check-branch
 
 ### Goal
 
-Unblock claim-bearing page/window experiments by either repairing `real100_v2`
-page metadata coverage or explicitly proving that the next retrieval experiment
-does not depend on page/window claims.
+Unblock or explicitly stop claim-bearing private experiments by proving whether
+the current `real100_v2` index is valid for baseline evidence. Any hashing-backed
+or page-metadata-0.0 index must be blocked before naive/private eval execution.
 
 ### Scope
 
 - Audit why `reports/real100_v2/retrieval_diagnostics.aggregate.json` reports
   page-span coverage `0.0`.
-- Rebuild or repair the private v2 index only if the parser/index provenance can
-  be recorded aggregate-only.
+- Reject hashing-backed private eval indexes and indexes with zero chunk page
+  metadata coverage in the v2 readiness gate.
+- Record whether a private v2 index rebuild is required; do not perform the
+  rebuild in this PR.
 - Emit a page metadata readiness packet with counts for page span, section, and
   citation-ready evidence coverage.
+- Mark historical optimization reports as invalid for claims until rerun on a
+  MiniLM page-aware v2 index.
 
 ### Non-Goals
 
@@ -3761,32 +3765,65 @@ does not depend on page/window claims.
 
 ### Acceptance Criteria
 
-- [ ] The task either clears the page/window blocker or records an explicit
+- [x] The task either clears the page/window blocker or records an explicit
   no-go/rescope decision for `T-2026-0031`.
-- [ ] Page metadata coverage is reported as aggregate counts only.
-- [ ] Any index rebuild records parser, embedding, and vector backend
-  provenance.
+- [x] Page metadata coverage is reported as aggregate counts only.
+- [x] Required index rebuild is recorded as a future repair path, not a
+  completed behavior change.
+- [x] Hashing-backed private real-eval indexes fail closed before experiment
+  execution.
+- [x] 0.0-coverage page metadata indexes fail closed before experiment
+  execution.
 
 ### Validation Commands
 
 ```bash
-REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-check
-python3 <page-metadata-readiness-script> --index-dir <private-v2-index> --out <aggregate-output>
+REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-check  # expected failure for the current invalid hashing/page-0 index
+python3 scripts/page_metadata_recovery_audit.py --index-dir <private-v2-index> --out-json reports/real100_v2/page_metadata_readiness.aggregate.json --out-md docs/evaluation/real100_v2-page-metadata-readiness.md --format markdown
+python3 -m pytest -q tests/test_real_eval_paths.py tests/test_page_metadata_recovery_audit.py tests/test_real100_v2_guard.py
 make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md docs/evaluation/real100_v2-page-metadata-readiness.md docs/evaluation/real100_v2-retrieval-diagnostics.md docs/evaluation/real100_v2-latency-cost-budget.md docs/evaluation/real100_v2-reranker-candidate-budget.md docs/evaluation/real100_v2-context-packing.md reports/real100_v2/README.md
 git diff --check
 make check-branch
 ```
 
 ### Evidence Required
 
-- Aggregate page metadata readiness report.
-- Explicit `T-2026-0031` unblock, keep-blocked, or rescope recommendation.
+- Aggregate page metadata readiness report:
+  `reports/real100_v2/page_metadata_readiness.aggregate.json`.
+- Explicit `T-2026-0031` keep-blocked recommendation: page/window claims remain
+  NO-GO until a page-aware rebuild produces non-zero chunk page metadata
+  coverage.
+- Explicit baseline guard evidence: the current index is not valid for private
+  optimization evidence because it is hashing-backed and has zero chunk page
+  metadata coverage.
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md`](../docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md)
+- Issue: [#1645](https://github.com/hskim-solv/BidMate-DocAgent/issues/1645)
 - PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 14:25 KST
+
+- Role: Evaluator / Implementer
+- Branch / worktree: eval/issue-1645-repair-real100-v2-page-metadata-blocker / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1645 / PR TBD
+- Task: T-2026-0047
+- Current status: fail-closed guard implemented; aggregate readiness packet generated; current real100_v2 page/window and optimization claims remain NO-GO.
+- Files touched: scripts/real_eval_paths.py, tests/test_real_eval_paths.py, scripts/page_metadata_recovery_audit.py, tests/test_page_metadata_recovery_audit.py, reports/real100_v2/page_metadata_readiness.aggregate.json, docs/evaluation/real100_v2-page-metadata-readiness.md, docs/evaluation/real100_v2-retrieval-diagnostics.md, docs/evaluation/real100_v2-latency-cost-budget.md, docs/evaluation/real100_v2-reranker-candidate-budget.md, docs/evaluation/real100_v2-context-packing.md, reports/real100_v2/README.md, .gitignore, .githooks/pre-commit, scripts/check_real100_v2_only.py, docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md, tasks/queue.md
+- Decisions made: no parser/index rebuild in this PR; T-2026-0031 remains blocked; T-2026-0029/T-2026-0030/T-2026-0032/T-2026-0033 optimization conclusions must be rerun on a MiniLM page-aware v2 index.
+- Commands run: make ship-start TITLE="Repair real100 v2 page metadata blocker" TYPE=eval; make check-branch; python3 scripts/page_metadata_recovery_audit.py --index-dir <external_private_real100_v2_index> --out-json reports/real100_v2/page_metadata_readiness.aggregate.json --out-md docs/evaluation/real100_v2-page-metadata-readiness.md --format markdown; REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml REAL100_V2_INDEX_DIR=data/index/real100_v2 REAL100_V2_REPORT_DIR=reports/real100_v2 make real-eval-v2-check.
+- Results: current real100_v2 index has 100 docs, 21800 chunks, 100 parent sections, hashing embeddings, chunk page metadata coverage 0.0, page_span coverage 0.0, regions.page_number coverage 0.0; readiness is NO-GO and `make real-eval-v2-check` fails as intended.
+- Next safe command: python3 -m pytest -q tests/test_real_eval_paths.py tests/test_page_metadata_recovery_audit.py tests/test_real100_v2_guard.py
+- Open questions: none.
+- Risks: current readiness packet must not be read as a behavior or quality improvement.
+```
 
 ## T-2026-0048 — Candidate-depth and fusion-budget retrieval experiment
 

--- a/tests/test_page_metadata_recovery_audit.py
+++ b/tests/test_page_metadata_recovery_audit.py
@@ -109,6 +109,10 @@ def test_no_page_metadata_reports_no_go_and_parser_change(tmp_path: Path) -> Non
 
     report = build_audit_report(index_dir)
 
+    assert report["profile_type"] == "private_real100_v2_page_metadata_readiness"
+    assert report["decision"]["private_real_eval_index_go_no_go"] == "NO-GO"
+    assert "minilm_semantic_baseline_required" in report["decision"]["private_real_eval_index_no_go_reasons"]
+    assert "chunk_page_metadata_coverage_zero" in report["decision"]["private_real_eval_index_no_go_reasons"]
     assert report["decision"]["citation_page_claim_go_no_go"] == "NO-GO"
     assert report["decision"]["recoverability"] == "not_recoverable_from_existing_artifacts"
     assert report["decision"]["requires_reindex"] is True
@@ -203,6 +207,8 @@ def test_nonzero_source_group_page_coverage_enables_page_claim_scope(tmp_path: P
     report = build_audit_report(index_dir)
 
     assert report["decision"]["citation_page_claim_go_no_go"] == "GO"
+    assert report["decision"]["private_real_eval_index_go_no_go"] == "NO-GO"
+    assert "minilm_semantic_baseline_required" in report["decision"]["private_real_eval_index_no_go_reasons"]
     assert report["decision"]["page_claim_scope"] == "covered_source_groups_only"
     assert report["decision"]["recoverability"] == "recoverable_from_current_index"
     assert report["decision"]["recommendation"] == "lightweight metadata recovery"
@@ -353,6 +359,8 @@ def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
     assert "requires_raw_source_reparse" in markdown
     assert "## Implementation Matrix" in markdown
     assert "## Readiness Checks" in markdown
+    assert "PDF/kordoc" not in markdown
+    assert "Private real-eval index: `NO-GO`" in markdown
     assert markdown.rstrip().endswith("`full re-index`")
     assert report["decision"]["requires_parser_change"] is False
     assert report["implementation_matrix"][0]["source_type"] == "csv_text_fallback"
@@ -366,6 +374,10 @@ def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
             str(index_dir),
             "--output-dir",
             str(out_dir),
+            "--out-json",
+            str(out_dir / "explicit.aggregate.json"),
+            "--out-md",
+            str(out_dir / "explicit.md"),
             "--format",
             "markdown",
         ],
@@ -380,3 +392,5 @@ def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
     assert completed.stdout.rstrip().endswith("`full re-index`")
     assert (out_dir / "page_metadata_recovery_audit.json").is_file()
     assert (out_dir / "page_metadata_recovery_audit.md").is_file()
+    assert (out_dir / "explicit.aggregate.json").is_file()
+    assert (out_dir / "explicit.md").is_file()

--- a/tests/test_real_eval_paths.py
+++ b/tests/test_real_eval_paths.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from scripts.real_eval_paths import missing_required, resolve_entries
+from scripts.real_eval_paths import PREFERRED_MINILM_MODEL, missing_required, resolve_entries
 
 
 def _args(**overrides: str | None) -> argparse.Namespace:
@@ -136,5 +136,81 @@ def test_existing_low_chunk_private_index_is_flagged_but_not_required(tmp_path: 
     entries = resolve_entries(_args(index_dir=str(index_dir)), environ={}, repo_root=tmp_path)
     index = _entry(entries, "index_dir")
     assert index.status == "invalid"
-    assert "CSV-fallback" in index.message
+    assert "low-chunk index" in index.message
     assert index.required_before_run is False
+
+
+def _private_index_payload(*, backend: str, model: str, with_page_metadata: bool) -> dict:
+    chunk = {
+        "chunk_id": "redacted::chunk-001",
+        "doc_id": "redacted",
+        "text": "redacted",
+    }
+    if with_page_metadata:
+        chunk["page_span"] = [1, 1]
+    return {
+        "schema_version": 2,
+        "embedding": {"backend": backend, "model": model, "dimension": 384},
+        "build": {"num_documents": 100, "num_chunks": 21800},
+        "documents": [{"doc_id": "redacted"} for _ in range(100)],
+        "chunks": [chunk],
+    }
+
+
+def test_private_real_eval_index_rejects_hashing_even_with_page_metadata(tmp_path: Path) -> None:
+    index_dir = tmp_path / "data" / "index" / "real100_v2"
+    index_dir.mkdir(parents=True)
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            _private_index_payload(
+                backend="hashing",
+                model="local-hashing-bow",
+                with_page_metadata=True,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    entries = resolve_entries(_args(index_dir=str(index_dir)), environ={}, repo_root=tmp_path)
+    index = _entry(entries, "index_dir")
+    assert index.status == "invalid"
+    assert "hashing embeddings are forbidden" in index.message
+
+
+def test_private_real_eval_index_rejects_zero_page_metadata_coverage(tmp_path: Path) -> None:
+    index_dir = tmp_path / "data" / "index" / "real100_v2"
+    index_dir.mkdir(parents=True)
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            _private_index_payload(
+                backend="sentence-transformers",
+                model=PREFERRED_MINILM_MODEL,
+                with_page_metadata=False,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    entries = resolve_entries(_args(index_dir=str(index_dir)), environ={}, repo_root=tmp_path)
+    index = _entry(entries, "index_dir")
+    assert index.status == "invalid"
+    assert "chunk page metadata coverage is 0.0" in index.message
+
+
+def test_private_real_eval_index_accepts_minilm_page_aware_index(tmp_path: Path) -> None:
+    index_dir = tmp_path / "data" / "index" / "real100_v2"
+    index_dir.mkdir(parents=True)
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            _private_index_payload(
+                backend="sentence-transformers",
+                model=PREFERRED_MINILM_MODEL,
+                with_page_metadata=True,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    entries = resolve_entries(_args(index_dir=str(index_dir)), environ={}, repo_root=tmp_path)
+    index = _entry(entries, "index_dir")
+    assert index.status == "ok"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1645

현재 `real100_v2` index가 hashing-backed이고 chunk page metadata coverage가 0.0인 상태에서 private/naive baseline evidence로 재사용될 수 있어, `make real-eval-v2-check`가 이런 index를 fail-closed 하도록 막았습니다. 함께 aggregate-only page metadata readiness packet을 추가하고, 기존 retrieval/latency/reranker/context-packing reports는 MiniLM page-aware v2 index 재빌드 전까지 optimization claim 근거로 쓰지 말라는 invalidation banner를 붙였습니다.

## 2. 영향 파일

- `scripts/real_eval_paths.py`, `tests/test_real_eval_paths.py`: private real-eval index guard. Existing private index가 `hashing`이거나 MiniLM sentence-transformers가 아니거나 chunk page metadata count가 0이면 invalid로 반환하고 check command를 실패시킵니다.
- `scripts/page_metadata_recovery_audit.py`, `tests/test_page_metadata_recovery_audit.py`: readiness packet에 embedding provenance와 private real-eval index GO/NO-GO reason을 aggregate-only로 추가했습니다.
- `reports/real100_v2/page_metadata_readiness.aggregate.json`, `docs/evaluation/real100_v2-page-metadata-readiness.md`: current index readiness NO-GO packet.
- `docs/evaluation/real100_v2-*.md`: previous optimization reports invalidated for claims until rerun on MiniLM page-aware v2 index.
- `tasks/queue.md`, `docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md`: task/plan/handoff updated.
- `.gitignore`, `.githooks/pre-commit`, `reports/real100_v2/README.md`, `scripts/check_real100_v2_only.py`: allow and guard the new aggregate artifact.

## 3. 리스크

- Risk: current historical aggregate reports may still be read as optimization evidence. Mitigation: added explicit invalidation banners and claim audit.
- Risk: valid future index is blocked if it lacks top-level `page_span` or `regions.page_number`. This is intentional for claim-bearing private baseline evidence; rebuild must emit page-aware chunk metadata.
- Risk: this changes `real-eval-v2-check` from warning to failure for invalid existing indexes. That is the desired fail-closed behavior.

## 4. 테스트

- `python3 -m py_compile scripts/real_eval_paths.py scripts/page_metadata_recovery_audit.py scripts/check_real100_v2_only.py`
- `python3 -m pytest -q tests/test_real_eval_paths.py tests/test_page_metadata_recovery_audit.py tests/test_real100_v2_guard.py`
- `make real-eval-v2-guard`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0047-repair-or-rescope-real100-v2-page-metadata-blocker.md docs/evaluation/real100_v2-page-metadata-readiness.md docs/evaluation/real100_v2-retrieval-diagnostics.md docs/evaluation/real100_v2-latency-cost-budget.md docs/evaluation/real100_v2-reranker-candidate-budget.md docs/evaluation/real100_v2-context-packing.md reports/real100_v2/README.md`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff --check`
- `make check-branch`

Expected-fail validation:

- `REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml REAL100_V2_INDEX_DIR=data/index/real100_v2 REAL100_V2_REPORT_DIR=reports/real100_v2 make real-eval-v2-check` fails as intended because the current index is hashing-backed and chunk page metadata coverage is 0.0.

## 5. Eval 영향

Private real-eval readiness guard only. Retrieval, reranking, verifier, prompt, answer, and eval scoring behavior are unchanged. This PR does not claim quality or latency improvement.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Real-data execution is intentionally blocked for the current local `real100_v2` index because it is hashing-backed and has 0.0 chunk page metadata coverage. The only committed real-data artifact is aggregate-only readiness evidence:

| Surface | Current result | Claim allowed |
|---|---|---|
| `real100_v2` current index readiness | NO-GO | Current index must not be used for private optimization evidence |
| Embedding baseline | hashing-backed current index rejected | MiniLM sentence-transformers page-aware v2 index required |
| Page metadata coverage | chunk/page_span/regions.page_number all 0.0 | Page/window claims remain blocked |
| Paired delta | N/A | No improvement claim |

## 6. 하위 호환

No answer schema or runtime retrieval API changes. `page_metadata_recovery_audit.py --out-json/--out-md` flags are additive. `real-eval-v2-check` now fails invalid private indexes by design.

## 7. 범위 외

- No parser/index rebuild in this PR.
- No Chroma/vector DB backend change in this PR.
- No retrieval/reranking/context-packing optimization claim from the invalidated reports.
