### PR TITLE
docs: add multimodal agent positioning stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 | **어떻게 평가 (evaluated)** | baseline 보존 ablation ([ADR 0001](docs/adr/0001-preserve-naive-baseline.md)) + 공개 fixture smoke / private internal eval 분리 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)) + PR 마다 회귀 게이트 ([pr-eval.yml](.github/workflows/pr-eval.yml)) + 79 ADR |
 | **어떻게 실행 (run it)** | `make index && make demo`, 또는 [5분 quickstart](#실행-5분-quickstart) · [Colab](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) · [Live demo](https://bidmate-docagent-demo.fly.dev/) |
 
-> **Portfolio signal**: 외부 LLM API 를 호출하는 RAG 데모가 아니라, RFP 도메인의 실패 모드를 직접 정의하고 그것을 막는 평가·CI·provenance 게이트를 **소유(system ownership)** 한 사례. 리뷰어용 진입점 → [모듈 맵](docs/architecture/module-map.md) · [실패 모드 케이스 스터디](docs/case-studies/failure-modes.md) · [면접 피치](docs/portfolio-pitch.md).
+> **Portfolio signal**: 외부 LLM API 를 호출하는 RAG 데모가 아니라, RFP 도메인의 실패 모드를 직접 정의하고 그것을 막는 평가·CI·provenance 게이트를 **소유(system ownership)** 한 사례. 현재 포지셔닝은 narrow RAG 가 아니라 문서·표·이미지 evidence 를 다루는 **Multimodal Agentic AI Product Engineer** 트랙으로 확장 중이며, 런타임 변경은 모두 opt-in follow-up task 로 분리한다. 리뷰어용 진입점 → [모듈 맵](docs/architecture/module-map.md) · [실패 모드 케이스 스터디](docs/case-studies/failure-modes.md) · [면접 피치](docs/portfolio-pitch.md).
 
-> **real-eval 읽는 법 (오해 방지)**: 비공개 real-eval (n=221) accuracy 16.10% 는 *제품 성공 지표가 아니라 hardcase 스트레스 테스트* 다 — 실패 모드를 노출하고, ablation 의 distinguishing power(변별력) 를 시험하며, 다음 개선을 안내하는 용도. 공개 fixture smoke eval은 CI 재현성과 평가 harness 동작 확인만 담당하고, 실제 성능 판단은 private/internal eval set aggregate를 기준으로 한다 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)). 낮은 hardcase 수치는 숨기지 않고 **엔지니어링 증거로 의도적으로 노출**한다 ([ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)).
+> **real-eval 읽는 법 (오해 방지)**: 현재 claim-bearing private evidence 는 `real100_v2` aggregate-only 표면만 사용한다. 공개 fixture smoke eval은 CI 재현성과 평가 harness 동작 확인만 담당하고, 실제 성능 판단은 private/internal eval set aggregate를 기준으로 한다 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)). 이전 세대 private-eval artifact 와 wording 은 archive-only 이며, maintainer 가 명시적으로 다시 허용하기 전까지 새 task·PR·claim·handoff 근거로 사용하지 않는다.
 
 <details><summary><b>측정 상세 (over-claim 가드 — 펼치기)</b></summary>
 
-> **측정**: 공개 가능한 작은 fixture는 `make smoke`와 PR CI에서 평가 harness, metrics schema, latency SLO가 깨지지 않는지 확인하는 용도다. 실제 성능 수치는 private/internal eval set aggregate로 관리하며, 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md))은 hardcase 스트레스와 distinguishing-power 분석에 사용한다. Goodhart 폐루프 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) scorer 정정 → CI-aware 판정, [reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 fixture smoke + private/internal eval 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 80개 설계 결정 (ADR).
+> **측정**: 공개 가능한 작은 fixture는 `make smoke`와 PR CI에서 평가 harness, metrics schema, latency SLO가 깨지지 않는지 확인하는 용도다. 실제 성능 수치는 `real100_v2` private/internal aggregate 로 관리하며, raw question/answer/evidence/text/path/id 는 커밋하지 않는다. 새 성능 claim 은 paired `real100_v2` aggregate delta, provenance, privacy audit, claim audit 를 함께 요구한다. 공개 fixture smoke + private/internal eval 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 80개 설계 결정 (ADR).
 
 </details>
 
@@ -83,7 +83,7 @@ INFO bidmate.rag_core: query_complete  status='supported'  query_type='compariso
 
 LLM synthesis opt-in (`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)) 과 LLM Ops observability ([ADR 0013](docs/adr/0013-observability-as-additive-pluggable-surface.md)) 는 추출형 파이프라인을 *교체하지 않고* additive 분석 변형으로 추가 — [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) / [`docs/operations/observability.md`](docs/operations/observability.md).
 
-> **평가 경계**: 이 레포지토리는 공개 가능한 작은 fixture를 smoke test 용도로만 사용합니다. 실제 성능 평가는 레포지토리에 커밋하지 않는 private/internal eval set을 기준으로 수행하는 것을 전제로 합니다. 비공개 real-eval n=21 → n=221 확장 ([ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md), [issue #942](https://github.com/hskim-solv/BidMate-DocAgent/issues/942))은 LLM-assisted hardcase generator + distinguishing-power floor ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md))로 aggregate evidence를 남기는 구조다. Detection-blind 분석 변형 real-eval 측정은 별도 follow-up.
+> **평가 경계**: 이 레포지토리는 공개 가능한 작은 fixture를 smoke test 용도로만 사용합니다. 실제 성능 평가는 레포지토리에 커밋하지 않는 private/internal eval set aggregate를 기준으로 수행하는 것을 전제로 합니다. 현재 새 task와 PR의 private evidence lane 은 `real100_v2` 전용이며, 이전 세대 private-eval artifact 와 wording 은 archive-only 로 남긴다. Detection-blind 분석 변형 real-eval 측정은 별도 follow-up.
 
 ## 핵심 기술 기여 — comparison-aware balanced top-k
 

--- a/docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md
+++ b/docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md
@@ -1,0 +1,174 @@
+# Plan: T-2026-0057+ Multimodal Agent positioning stack
+
+- Status: proposed
+- Owner role: Planner -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0057` through `T-2026-0070`
+- Related issue / PR: [#1651](https://github.com/hskim-solv/BidMate-DocAgent/issues/1651) / N/A
+- Related ADR: N/A - no decision-level runtime change
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+BidMate-DocAgent already demonstrates RFP-specific Agentic RAG, evaluation
+rigor, citation grounding, and CI/provenance gates. The portfolio framing is
+still too narrow if it reads as "RAG engineer only", and stale legacy private
+eval wording can conflict with the current `real100_v2`-only evidence policy.
+
+The next stack should reposition the repo as evidence for a Multimodal Agentic
+AI Product Engineer profile while keeping every new capability opt-in and
+evidence-gated.
+
+## Current Behavior
+
+- Runtime defaults remain extractive, citation-grounded RAG.
+- `real100_v2` is the current private eval evidence lane for new work.
+- Earlier-generation private-eval artifacts and wording are archive-only and
+  must not back new claims.
+- `T-2026-0056` already exists on `origin/main` as the Ollama local
+  OpenAI-compatible provider spike, so this stack starts at `T-2026-0057`.
+
+## Desired Behavior
+
+- README and portfolio pitch describe the repo as an Agentic RAG foundation that
+  can expand toward multimodal, agent, product, and self-hosted serving work.
+- `tasks/queue.md` contains executable follow-up tasks for the full positioning
+  stack without changing runtime behavior.
+- Any future VLM, agent, product API, graph, or vLLM-style work has an explicit
+  evidence boundary, privacy boundary, and validation route before it starts.
+
+## Constraints
+
+- Scope constraints: docs/task queue only for the first PR.
+- Architecture constraints: no runtime, API, schema, eval scoring, or default
+  pipeline changes in this task.
+- Compatibility constraints: preserve ADR 0001 `naive_baseline`, ADR 0003
+  answer dict contract, and existing FastAPI/demo behavior.
+- Eval/privacy constraints: use `real100_v2` aggregate-only for new private
+  evidence; commit no raw private text, page images, filenames, local paths,
+  `doc_id`, or `chunk_id`.
+- Tooling/CI constraints: keep follow-up implementation tasks issue-linked and
+  one concern per PR.
+- Non-goals: do not implement VLM captioning, new Agent tools, Graph RAG, or
+  self-hosted serving in this planning PR.
+
+## Architecture Impact
+
+- Affected modules or docs: `README.md`, `docs/portfolio-pitch.md`,
+  `tasks/queue.md`, this plan.
+- Affected contracts or invariants: documentation and task queue only.
+- Load-bearing paths: none changed.
+- ADR required: no, because this is planning/wording only.
+- Backward compatibility expectation: no behavior change.
+
+## Affected Interfaces
+
+- CLI/API/config: unchanged.
+- Input data: unchanged.
+- Output artifacts: no new generated artifacts.
+- Docs/review surfaces: README, portfolio pitch, task queue, plan.
+- Tests/eval entrypoints: doc link check, `real100_v2` guard, claim audit.
+
+## Data / Eval Impact
+
+- Surface: none for runtime; private eval policy wording only.
+- Data boundary: no data touched.
+- Allowed claim: the repo is planning an opt-in Multimodal Agent/Product
+  positioning track.
+- Disallowed claim: VLM, Agent, Graph RAG, vLLM, or product quality has already
+  improved because of this PR.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: privacy/evidence wording review only.
+
+## Task Breakdown
+
+1. Update README and portfolio pitch to remove stale legacy private eval wording
+   from current claims and state the `real100_v2` boundary.
+2. Add `T-2026-0057` through `T-2026-0070` to `tasks/queue.md`.
+3. Record that `T-2026-0056` is already occupied by the Ollama provider spike,
+   so the requested stack is shifted by one ID without changing intent.
+4. Validate doc links, `real100_v2` guard, claim audit, whitespace, and branch
+   convention.
+
+## Acceptance Criteria
+
+- [ ] README and portfolio pitch no longer use earlier-generation private-eval
+  wording as current claim evidence.
+- [ ] Queue tasks cover positioning, external source audit, visual evidence,
+  VLM, agent state/security, multimodal vertical slice, trajectory eval,
+  product API, self-hosted serving, graph feasibility, interview pack, and
+  review board refresh.
+- [ ] Follow-up task boundaries make runtime changes opt-in and issue-linked.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md docs/portfolio-pitch.md README.md
+make real-eval-v2-guard
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: doc links, `real100_v2` guard, claim audit, branch check.
+- Generated or updated artifact: none.
+- Reviewer checklist or manual inspection: stale private eval wording and
+  over-claim risk.
+- Explicitly not validated, with reason: no VLM/Agent/Product runtime behavior
+  is implemented in this PR.
+
+## Rollback Strategy
+
+Revert the docs/task-only commit. Do not delete existing `real100_v2` aggregate
+artifacts or the pre-existing `T-2026-0056` Ollama task.
+
+## Failure Modes
+
+- Failure mode: duplicate task ID with existing `T-2026-0056`.
+- Detection signal: `rg "T-2026-0056" tasks/queue.md`.
+- Stop condition or fallback: keep existing task and shift this stack to
+  `T-2026-0057` through `T-2026-0070`.
+
+- Failure mode: new wording implies implemented multimodal capability.
+- Detection signal: claim audit or reviewer inspection.
+- Stop condition or fallback: rewrite as task stack / planned opt-in work.
+
+- Failure mode: external framework claims become uncited trend-chasing.
+- Detection signal: `T-2026-0059` cannot verify source docs or repo grounding.
+- Stop condition or fallback: keep only internal ADR/repo evidence.
+
+## Observability
+
+- `tasks/queue.md` ready-order rows and task detail sections.
+- README and portfolio pitch wording.
+- `real100_v2` guard output.
+- Claim audit output.
+
+## Reviewer Notes
+
+Attack over-claiming first: this PR should change positioning and task planning
+only. It must not claim VLM, Agent, product, Graph RAG, or self-hosted serving
+capability beyond existing repo evidence.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 KST
+
+- Role: Planner
+- Branch / worktree: docs/issue-1651-multimodal-agent-positioning-stack / /Users/hskim/.codex/worktrees/a7c0/BidMate-DocAgent
+- Issue / PR: #1651 / N/A
+- Task: T-2026-0057 through T-2026-0070
+- Current status: docs/task-only stack implemented and locally validated.
+- Files touched: README.md, docs/portfolio-pitch.md, docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md, tasks/queue.md
+- Decisions made: preserve existing T-2026-0056 Ollama task and shift the new stack to T-2026-0057..0070.
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md docs/portfolio-pitch.md README.md; make real-eval-v2-guard; python3 scripts/agent_loop.py claim-audit --from-git; git diff --check; make check-branch
+- Results: all passed.
+- Next safe command: git diff --stat
+- Open questions: none.
+- Risks: wording over-claims planned multimodal/agent/product work.
+```

--- a/docs/portfolio-pitch.md
+++ b/docs/portfolio-pitch.md
@@ -4,9 +4,9 @@
 
 ## 30초 피치
 
-> 이 프로젝트에서 저는 RAG 파이프라인을 단순 구현한 것이 아니라, RFP 문서에서 실제로 발생하는 **검색 실패 · 근거 부족 · 비교 질의 편향을 failure mode 로 정의**하고, 이를 **baseline / ablation / eval / CI 로 검증 가능한 시스템**으로 만들었습니다.
+> 이 프로젝트에서 저는 RAG 파이프라인을 단순 구현한 것이 아니라, RFP 문서에서 실제로 발생하는 **검색 실패 · 근거 부족 · 비교 질의 편향을 failure mode 로 정의**하고, 이를 **baseline / ablation / eval / CI 로 검증 가능한 시스템**으로 만들었습니다. 다음 포지셔닝은 narrow RAG engineer 가 아니라 문서·표·이미지 evidence 를 다루는 **Multimodal Agentic AI Product Engineer** 입니다.
 
-핵심 한 문장: "RAG 데모를 만든 게 아니라, RFP 도메인의 실패 모드를 정의하고 그것을 막는 평가·CI·provenance 게이트를 소유했습니다."
+핵심 한 문장: "RAG 데모를 만든 게 아니라, RFP 도메인의 실패 모드를 정의하고 그것을 막는 평가·CI·provenance 게이트를 소유했고, 이를 VLM/Agent/Product surface 로 확장할 task stack 을 준비했습니다."
 
 ## 3개 핵심 시그널
 
@@ -28,15 +28,21 @@
 - 근거: [pr-eval.yml](../.github/workflows/pr-eval.yml) · [ADR 0062](adr/0062-failure-rate-regression-contract.md) (회귀 ceiling 계약) · [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) (eval 분리).
 - 면접 답변: "측정은 일회성이 아니라 *상시 게이트*입니다. 회귀가 들어오면 CI 가 막고, 실패율 상한은 내려가기만 합니다."
 
+### 4. Multimodal/Agent/Product 확장 경로
+
+- 현재 repo 의 claim-bearing 근거는 `real100_v2` aggregate-only 정책에 묶고, VLM captioning, visual evidence, tool-state trace, Agent trajectory evaluation, FastAPI product workflow, self-hosted OpenAI-compatible serving 은 모두 opt-in follow-up task 로 분리한다.
+- 근거: [`tasks/queue.md`](../tasks/queue.md)의 `T-2026-0057` 이후 positioning stack 과 [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](plans/T-2026-0056-multimodal-agent-positioning-stack.md).
+- 면접 답변: "RAG 는 기본기이고, 제 차별점은 CV/생성형 이미지 경험을 문서·표·이미지 evidence 를 다루는 Agentic product workflow 로 확장한다는 점입니다. 단, 포트폴리오 claim 은 구현보다 먼저 평가·privacy·provenance gate 로 묶습니다."
+
 ## 안전성/품질 trade-off 를 정직하게 설명하기
 
 면접관이 "그런데 `agentic_full` 이 raw accuracy 는 더 낮네요?"라고 물으면:
 
 > "맞습니다. 그건 *실패한 최적화가 아니라 의도된 trade-off* 입니다. `agentic_full` 은 답변율을 극대화하도록 튜닝한 게 아니라, citation precision **+18.0pp** 와 abstention accuracy **+57.1pp** 를 얻는 safety-oriented 파이프라인입니다. RFP 의사결정 맥락에서는 근거 없는 답변보다 근거 있는 보류가 더 안전하니까요. 그래서 메트릭은 하나의 평탄한 aggregate report 가 아니라 slice 별로 읽어야 합니다."
 
-real-eval hardcase(n=221, accuracy 16.10%)를 물으면:
+private real-eval 수치를 물으면:
 
-> "그건 제품 성공 지표가 아니라 hardcase 스트레스 테스트입니다. 일부러 어려운 케이스로 실패 모드를 노출하고 ablation 변별력을 시험하는 용도라, 낮은 수치를 숨기지 않고 엔지니어링 증거로 드러냅니다." ([ADR 0052](adr/0052-real-eval-hardcase-expansion-to-200.md))
+> "현재 새 task 와 PR 의 claim-bearing 근거는 `real100_v2` aggregate-only 표면만 사용합니다. 이전 세대 private-eval artifact 와 wording 은 archive-only 라서 새 성능 주장에는 쓰지 않습니다. 숫자를 말할 때는 paired aggregate delta, provenance, privacy audit, claim audit 를 같이 제시합니다."
 
 ## STAR 정리 (핵심 기여 1건)
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -67,6 +67,20 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 54 | `T-2026-0054` | `backlog` | Implementer -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P2; end-to-end bakeoff of the best isolated experiment winners under one aggregate guardrail. |
 | 55 | `T-2026-0055` | `backlog` | Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P2; final optimization decision packet and default-change or no-go proposal. |
 | 56 | `T-2026-0056` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; Ollama local OpenAI-compatible provider spike for synthesis/judge cost, privacy, and latency evidence. |
+| 57 | `T-2026-0057` | `review` | Planner -> Privacy Auditor -> Reviewer | issue #1651; real100_v2 portfolio wording cleanup and legacy current-claim wording removal. |
+| 58 | `T-2026-0058` | `review` | Planner -> Reviewer | issue #1651; Multimodal Agent/Product positioning map added as a docs-only stack. |
+| 59 | `T-2026-0059` | `backlog` | Planner -> Reviewer | External source and citation audit before framework/vendor claims enter portfolio wording. |
+| 60 | `T-2026-0060` | `backlog` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | Visual evidence contract hardening for OCR/layout/table/image citation readiness. |
+| 61 | `T-2026-0061` | `backlog` | Implementer -> Privacy Auditor -> Reviewer | Opt-in VLM captioning spike on public fixtures only; no private egress by default. |
+| 62 | `T-2026-0062` | `backlog` | Implementer -> Reviewer | Agent tool-state-trace contract for tool calls, state, retry/fallback, and permissions. |
+| 63 | `T-2026-0063` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | Agent security and human-in-the-loop guardrail before tool-using multimodal workflows. |
+| 64 | `T-2026-0064` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | Multimodal troubleshooting vertical slice after visual evidence and agent contracts. |
+| 65 | `T-2026-0065` | `backlog` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | Agent trajectory evaluation across tool calls, retries, fallbacks, latency, and cost. |
+| 66 | `T-2026-0066` | `backlog` | Implementer -> Reviewer | Product API/demo integration for the chosen multimodal agent workflow. |
+| 67 | `T-2026-0067` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | Self-hosted OpenAI-compatible serving demo as auxiliary product/ops evidence. |
+| 68 | `T-2026-0068` | `backlog` | Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | Knowledge/Graph RAG feasibility for relation-structured RFP evidence. |
+| 69 | `T-2026-0069` | `backlog` | Planner -> Reviewer | Interview and resume evidence pack mapping repo artifacts to target roles. |
+| 70 | `T-2026-0070` | `backlog` | Implementer -> Privacy Auditor -> Reviewer | Portfolio review board refresh after the new positioning artifacts settle. |
 
 ## Examples
 
@@ -4376,4 +4390,816 @@ make check-branch
 
 - Plan: TBD - create when the task starts.
 - Issue: #1649
+- PR: TBD
+
+## T-2026-0057 — real100_v2 portfolio wording cleanup
+
+- ID: T-2026-0057
+- Title: real100_v2 portfolio wording cleanup
+- Status: review
+- Priority: P0 positioning
+- Owner role: Planner -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Remove legacy private-eval wording from current portfolio claims so README and
+interview-facing docs use only the `real100_v2` aggregate-only evidence lane for
+new claims.
+
+### Scope
+
+- Update README and portfolio pitch language that currently presents
+  earlier-generation private-eval wording as current evidence.
+- Preserve archive references only when they are explicitly historical and not
+  used as current claim support.
+- State that raw private questions, answers, evidence text, filenames, local
+  paths, `doc_id`, and `chunk_id` remain uncommitted.
+
+### Non-Goals
+
+- Do not run private eval.
+- Do not change scoring, retrieval, answer, API, or runtime behavior.
+- Do not claim quality improved because wording changed.
+
+### Acceptance Criteria
+
+- [ ] README and portfolio pitch name `real100_v2` as the current private
+  evidence lane.
+- [ ] Earlier-generation private-eval wording is not used for a new claim.
+- [ ] Claim audit and `real100_v2` guard pass.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths README.md docs/portfolio-pitch.md tasks/queue.md docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md
+make real-eval-v2-guard
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Doc-link check output.
+- `real100_v2` guard output.
+- Claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: [#1651](https://github.com/hskim-solv/BidMate-DocAgent/issues/1651)
+- PR: TBD
+
+## T-2026-0058 — Multimodal Agent positioning map
+
+- ID: T-2026-0058
+- Title: Multimodal Agent positioning map
+- Status: review
+- Priority: P0 positioning
+- Owner role: Planner -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Convert the career positioning strategy into an executable repo task map:
+RAG as foundation, Agent as primary direction, VLM/multimodal as
+differentiator, evaluation/LLMOps and productization as proof, and vLLM-style
+serving as auxiliary evidence.
+
+### Scope
+
+- Add a queue stack for visual evidence, VLM captioning, agent state/security,
+  trajectory evaluation, product API/demo integration, self-hosted serving,
+  Graph RAG feasibility, interview evidence, and review board refresh.
+- Keep the existing RAG performance experiment stack intact.
+- Record that `T-2026-0056` is already occupied by the Ollama provider spike, so
+  this positioning stack starts at `T-2026-0057`.
+
+### Non-Goals
+
+- Do not implement multimodal or agent runtime features in this task.
+- Do not add new external dependencies.
+- Do not create a new benchmark or metric surface.
+
+### Acceptance Criteria
+
+- [ ] Queue rows and detailed task sections exist for `T-2026-0057` through
+  `T-2026-0070`.
+- [ ] Each follow-up task has an evidence boundary, privacy boundary, and
+  validation route.
+- [ ] Existing optimization tasks `T-2026-0028` through `T-2026-0056` are not
+  reordered or redefined.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md docs/portfolio-pitch.md README.md
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Queue diff.
+- Plan doc.
+- Claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: [#1651](https://github.com/hskim-solv/BidMate-DocAgent/issues/1651)
+- PR: TBD
+
+## T-2026-0059 — External source and citation audit
+
+- ID: T-2026-0059
+- Title: External source and citation audit
+- Status: backlog
+- Priority: P0 positioning
+- Owner role: Planner -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Ensure external framework and vendor claims used in portfolio wording are
+current, cited, and grounded in either official documentation or existing repo
+ADR/implementation evidence.
+
+### Scope
+
+- Audit references to LlamaIndex, LangGraph, OpenAI Agents SDK, RAGAS,
+  LangSmith, MCP/A2A, vLLM, TEI, CrewAI, AutoGen, and related frameworks before
+  using them as portfolio claims.
+- Prefer repo-internal evidence when implementation already exists, such as
+  LangGraph ADRs, OpenAI-compatible provider support, MCP helper tooling,
+  FastAPI docs, and observability docs.
+- Produce a small source map that distinguishes implemented, planned, and
+  external-background-only claims.
+
+### Non-Goals
+
+- Do not add new framework dependencies.
+- Do not rewrite README around trend keywords.
+- Do not cite third-party docs as proof that this repo implements a capability.
+
+### Acceptance Criteria
+
+- [ ] Every external framework mention in positioning docs is marked as
+  implemented, planned, or background-only.
+- [ ] Official docs are used for external claims when needed.
+- [ ] Unverified or low-value framework references are removed.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths docs/portfolio-pitch.md README.md <source-map-path>
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Source map or audit note.
+- Claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0060 — Visual evidence contract hardening
+
+- ID: T-2026-0060
+- Title: Visual evidence contract hardening
+- Status: backlog
+- Priority: P1 multimodal
+- Owner role: Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Define how OCR/layout/table/image evidence becomes retrieval-ready and
+citation-ready before adding VLM captioning or multimodal agent behavior.
+
+### Scope
+
+- Extend or document the visual artifact contract for text blocks, page spans,
+  table cells, region metadata, image captions, and citation anchors.
+- Connect the contract to existing parser/layout/table coverage work rather than
+  bypassing `T-2026-0050`.
+- Add focused public-fixture or aggregate-only checks for visual evidence
+  readiness.
+
+### Non-Goals
+
+- Do not add VLM provider calls.
+- Do not change default ingestion behavior.
+- Do not commit private page images, raw OCR text, filenames, or local paths.
+
+### Acceptance Criteria
+
+- [ ] Visual evidence fields needed by retrieval and citation are documented.
+- [ ] Parser/layout/table readiness is separated from VLM captioning.
+- [ ] Private evidence remains aggregate-only.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_visual_ingestion.py tests/test_page_aware_parser_contract.py <focused-new-tests>
+python3 scripts/check_doc_links.py --check-all --paths docs/vision/visual-ingestion-v2.md tasks/queue.md <contract-doc-path>
+python3 scripts/agent_loop.py privacy-audit-output
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Contract doc or focused test output.
+- Privacy audit output when aggregate artifacts are added.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0061 — Opt-in VLM captioning spike
+
+- ID: T-2026-0061
+- Title: Opt-in VLM captioning spike
+- Status: backlog
+- Priority: P1 multimodal
+- Owner role: Implementer -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Test whether VLM captioning can add useful public visual evidence without
+changing default ingestion or sending private RFP data to external providers.
+
+### Scope
+
+- Add a public-fixture-only spike path for image/page captioning.
+- Record provider, model, payload class, egress mode, latency, cost, and caption
+  failure rate.
+- Keep caption output isolated from canonical private indexes unless a later ADR
+  and privacy boundary approve it.
+
+### Non-Goals
+
+- Do not use private documents or private page images.
+- Do not change retrieval defaults.
+- Do not claim multimodal retrieval quality from a public-only spike.
+
+### Acceptance Criteria
+
+- [ ] Spike can run on public fixtures with explicit provider/payload
+  provenance.
+- [ ] Captions are tagged as experimental and isolated.
+- [ ] Missing provider credentials produce a clear skip/no-go report.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_external_payload_boundary_regression.py <focused-vlm-tests>
+python3 <vlm-caption-spike-runner> --input <public-fixture-path> --out <public-output>
+python3 scripts/agent_loop.py privacy-audit-output
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Public-fixture spike report.
+- Provider/payload provenance.
+- Privacy audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0062 — Agent tool-state-trace contract
+
+- ID: T-2026-0062
+- Title: Agent tool-state-trace contract
+- Status: backlog
+- Priority: P1 agent
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Make tool calling, state transitions, retry/fallback behavior, and permission
+boundaries inspectable before expanding agent workflows.
+
+### Scope
+
+- Define a minimal tool-state-trace shape for agent steps.
+- Reuse existing LangGraph/agentic docs and trace conventions when possible.
+- Include timeout, retry, fallback, user-escalation, and tool-denial states.
+
+### Non-Goals
+
+- Do not replace existing answer dict contract.
+- Do not add CrewAI/AutoGen or another orchestration framework.
+- Do not expose mutating tools without a permission policy.
+
+### Acceptance Criteria
+
+- [ ] Tool call, observation, retry, fallback, and stop states are documented or
+  serialized.
+- [ ] Permission boundary is explicit.
+- [ ] Existing direct and LangGraph paths remain backward compatible.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_langgraph_orchestrator_regression.py tests/test_agent_react_regression.py <focused-agent-trace-tests>
+python3 scripts/check_doc_links.py --check-all --paths docs/agentic/agent-system-design-case-study.md docs/agentic/agent-failure-modes-analysis.md tasks/queue.md <contract-doc-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Contract doc or trace fixture.
+- Focused regression tests.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0063 — Agent security and human-in-the-loop guardrail
+
+- ID: T-2026-0063
+- Title: Agent security and human-in-the-loop guardrail
+- Status: backlog
+- Priority: P1 security
+- Owner role: Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Prevent multimodal/tool-using agent work from expanding before prompt
+injection, tool permission, escalation, and manual review boundaries are
+explicit.
+
+### Scope
+
+- Extend the existing prompt-injection and evidence-boundary guardrails to
+  multimodal and tool-call settings.
+- Define when the agent must ask a user, stop, or route to human review.
+- Add red-team fixtures for tool misuse, indirect instruction injection, and
+  unsafe visual/document content.
+
+### Non-Goals
+
+- Do not add broad new security architecture.
+- Do not enable mutating tools by default.
+- Do not weaken existing verifier/evidence-boundary behavior.
+
+### Acceptance Criteria
+
+- [ ] Tool-call permission failures are fail-closed.
+- [ ] Human review checkpoints are explicit for risky operations.
+- [ ] Security tests cover prompt/document/tool boundary attacks.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_security*.py tests/test_prompt_injection_regression.py tests/test_evidence_boundary_attack_vectors.py <focused-agent-security-tests>
+python3 <security-redteam-runner> --out <aggregate-output>
+python3 scripts/agent_loop.py privacy-audit-output
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused security test output.
+- Red-team aggregate report if added.
+- Privacy audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0064 — Multimodal troubleshooting vertical slice
+
+- ID: T-2026-0064
+- Title: Multimodal troubleshooting vertical slice
+- Status: backlog
+- Priority: P2 product
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Build an opt-in vertical slice that demonstrates image/document analysis,
+manual retrieval, cause ranking, action recommendation, uncertainty handling,
+and trace capture as one product workflow.
+
+### Scope
+
+- Use public fixtures or approved redacted examples only.
+- Connect visual evidence, RAG retrieval, agent state, and answer/citation
+  output through an isolated workflow.
+- Produce a trace and evaluation packet that separates visual, retrieval,
+  tool-call, and answer failures.
+
+### Non-Goals
+
+- Do not change default BidMate RFP query behavior.
+- Do not use private images or private RFP pages without a new approved
+  boundary.
+- Do not claim production readiness.
+
+### Acceptance Criteria
+
+- [ ] The vertical slice runs end-to-end on approved public/redacted inputs.
+- [ ] Failure modes are separated by visual, retrieval, agent, and answer stage.
+- [ ] Output includes confidence/uncertainty and citation/evidence references.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q <focused-vertical-slice-tests>
+python3 <multimodal-troubleshooting-runner> --input <public-or-redacted-input> --out <aggregate-output>
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Public/redacted vertical-slice output.
+- Stage-separated trace or aggregate.
+- Privacy and claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0065 — Agent trajectory evaluation
+
+- ID: T-2026-0065
+- Title: Agent trajectory evaluation
+- Status: backlog
+- Priority: P2 eval
+- Owner role: Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Evaluate agent behavior beyond final-answer correctness by measuring trajectory
+quality, tool-call success, retry/fallback behavior, latency, cost, and
+human-review triggers.
+
+### Scope
+
+- Define trajectory metrics that complement existing answer/retrieval metrics.
+- Reuse existing rationality judge and trace conventions where they fit.
+- Report aggregate-only results with no raw private trace leakage.
+
+### Non-Goals
+
+- Do not replace existing answer-quality metrics.
+- Do not create a new metric surface without ADR review if the metric becomes
+  claim-bearing.
+- Do not average incompatible public and private surfaces.
+
+### Acceptance Criteria
+
+- [ ] Metrics separate final answer outcome from process quality.
+- [ ] Tool-call and retry failures are visible.
+- [ ] Aggregate output is privacy-safe.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_rationality_judge.py tests/test_trace_schema_v2.py <focused-trajectory-tests>
+python3 <trajectory-eval-runner> --out <aggregate-output>
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Trajectory metric spec or aggregate.
+- Focused tests.
+- Privacy and claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0066 — Product API/demo integration
+
+- ID: T-2026-0066
+- Title: Product API/demo integration
+- Status: backlog
+- Priority: P2 product
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Expose the selected multimodal agent workflow through a restrained FastAPI/demo
+surface that proves product integration without changing core RAG defaults.
+
+### Scope
+
+- Add opt-in API/demo entrypoints for the approved workflow.
+- Preserve existing FastAPI query schemas and default behavior.
+- Record latency, trace id, failure status, and user-facing uncertainty.
+
+### Non-Goals
+
+- Do not turn the demo into a broad product rebuild.
+- Do not require frontend work unless the API surface is stable.
+- Do not add auth/rate-limit/security claims unless implemented and tested.
+
+### Acceptance Criteria
+
+- [ ] Existing API tests pass unchanged.
+- [ ] New workflow is opt-in and documented.
+- [ ] Demo/API output exposes traceability and safe failure states.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_api.py tests/test_api_default_pipeline_regression.py <focused-api-tests>
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/api-demo.md README.md tasks/queue.md <api-doc-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused API tests.
+- API docs.
+- Manual smoke result if a UI/demo path is changed.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0067 — Self-hosted OpenAI-compatible serving demo
+
+- ID: T-2026-0067
+- Title: Self-hosted OpenAI-compatible serving demo
+- Status: backlog
+- Priority: P3 serving
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Show service/ops awareness by connecting an opt-in OpenAI-compatible local
+serving endpoint, such as vLLM or llama.cpp, without making serving the primary
+positioning.
+
+### Scope
+
+- Document one self-hosted OpenAI-compatible server path and connect it to
+  existing synthesis or judge provider configuration.
+- Measure latency, throughput/concurrency, JSON compliance, memory/runtime
+  constraints when locally available.
+- Position this as auxiliary product/ops evidence, complementary to the Ollama
+  spike in `T-2026-0056`.
+
+### Non-Goals
+
+- Do not require GPU infrastructure in CI.
+- Do not replace default offline/stub behavior.
+- Do not claim platform/serving specialization as the repo's main positioning.
+
+### Acceptance Criteria
+
+- [ ] The demo has exact setup and skip/no-go instructions.
+- [ ] Provider/runtime effects are separated from retrieval and answer effects.
+- [ ] No private payload leaves approved local boundaries.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_llm_synthesis.py tests/test_external_payload_boundary_regression.py <focused-serving-tests>
+python3 <openai-compatible-serving-smoke> --base-url <local-url> --model <model> --out <aggregate-output>
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Local serving setup note.
+- Aggregate smoke output or explicit unavailable/no-go report.
+- Privacy and claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0068 — Knowledge/Graph RAG feasibility
+
+- ID: T-2026-0068
+- Title: Knowledge/Graph RAG feasibility
+- Status: backlog
+- Priority: P3 architecture
+- Owner role: Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Decide whether relation-structured evidence such as agency, requirement,
+deadline, symptom, cause, procedure, table, and visual region justifies a
+Knowledge/Graph RAG follow-up.
+
+### Scope
+
+- Use measured residual bottlenecks from retrieval, parser/layout, metadata, and
+  advanced architecture gates.
+- Compare simple metadata/entity retrieval, graph retrieval, ontology work, and
+  no-go.
+- Recommend at most one follow-up implementation issue.
+
+### Non-Goals
+
+- Do not build a graph database in this task.
+- Do not introduce Graph RAG because it is trendy.
+- Do not bypass `T-2026-0039` advanced architecture feasibility evidence.
+
+### Acceptance Criteria
+
+- [ ] Feasibility matrix names expected failure-mode reduction.
+- [ ] Build cost, privacy risk, eval burden, latency, and rollback are covered.
+- [ ] Recommendation is implement-one, defer, or no-go.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md <feasibility-report-path>
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Feasibility report.
+- Explicit next issue or no-go rationale.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0069 — Interview and resume evidence pack
+
+- ID: T-2026-0069
+- Title: Interview and resume evidence pack
+- Status: backlog
+- Priority: P2 positioning
+- Owner role: Planner -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Convert the repo evidence into interview-ready and resume-ready artifacts for
+Multimodal Agentic AI Product Engineer, LLM/Agent Engineer, AI Product Engineer,
+LLMOps/Evaluation Engineer, and serving-adjacent roles.
+
+### Scope
+
+- Produce STAR answers, role-specific pitch variants, and a repo evidence link
+  map.
+- Separate implemented evidence from planned tasks.
+- Keep exact private metrics out unless they are `real100_v2` aggregate-safe and
+  current.
+
+### Non-Goals
+
+- Do not create a separate private portfolio repo artifact in this task unless a
+  follow-up issue is opened.
+- Do not include unsupported claims about VLM/Agent/serving implementation.
+- Do not expose private eval payloads.
+
+### Acceptance Criteria
+
+- [ ] Evidence pack maps each role claim to repo files, ADRs, tests, reports, or
+  explicit planned tasks.
+- [ ] Resume/interview wording distinguishes "implemented" from "planned".
+- [ ] Legacy private-eval wording is absent from current claims.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths docs/portfolio-pitch.md tasks/queue.md <evidence-pack-path>
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Interview/resume evidence pack.
+- Claim audit output.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0070 — Portfolio review board refresh
+
+- ID: T-2026-0070
+- Title: Portfolio review board refresh
+- Status: backlog
+- Priority: P2 positioning
+- Owner role: Implementer -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Refresh reviewer-facing generated HTML boards after the Markdown positioning
+docs settle, while keeping Markdown as the source of truth.
+
+### Scope
+
+- Update the portfolio review board inputs to reflect real100_v2-only wording
+  and the Multimodal Agent/Product positioning stack.
+- Keep generated HTML ignored/local and reproducible.
+- Verify no raw private data, local paths, or unsupported claims appear in the
+  generated boards.
+
+### Non-Goals
+
+- Do not make generated HTML canonical.
+- Do not add a new measurement surface.
+- Do not change runtime or eval behavior.
+
+### Acceptance Criteria
+
+- [ ] Portfolio board renders current positioning and evidence links.
+- [ ] Generated HTML contains no raw private payloads or exact local paths.
+- [ ] Tests cover board title/content changes if renderer behavior changes.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_render_priority_review_boards.py
+python3 scripts/render_priority_review_boards.py
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/check_doc_links.py --check-all --paths docs/portfolio-pitch.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused renderer test output.
+- Local generated board path and privacy audit result.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md`](../docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md)
+- Issue: TBD
 - PR: TBD


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

BidMate-DocAgent의 포지셔닝을 narrow RAG가 아니라 Multimodal Agentic AI Product Engineer 증거 stack으로 재정렬하기 위한 docs/task-only 변경입니다. 현재 private eval claim은 `real100_v2` aggregate-only 표면만 사용하도록 README와 portfolio pitch의 이전 세대 private-eval wording을 정리하고, 후속 task stack을 `T-2026-0057`부터 `T-2026-0070`까지 추가했습니다. `T-2026-0056`은 이미 Ollama provider spike로 존재하므로 새 stack은 한 칸 밀었습니다.

Closes #1651

## 2. 영향 파일

- `README.md` - portfolio signal과 private eval 경계 wording 갱신.
- `docs/portfolio-pitch.md` - Multimodal/Agent/Product 확장 경로와 real100_v2-only 답변 wording 추가.
- `docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md` - docs/task-only 계획과 검증 경로 기록.
- `tasks/queue.md` - `T-2026-0057`부터 `T-2026-0070`까지 follow-up task stack 추가.

Load-bearing path 변경 없음.

## 3. 리스크

가장 큰 리스크는 계획 단계 문구가 이미 구현된 VLM/Agent/Product capability처럼 읽히는 것입니다. 이를 줄이기 위해 README, plan, queue 모두 runtime 변경은 opt-in follow-up task라고 명시했고 `claim-audit`를 실행했습니다. 두 번째 리스크는 task ID 충돌인데, `origin/main`의 기존 `T-2026-0056`을 보존하고 새 stack을 `T-2026-0057..0070`으로 밀어 반영했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0056-multimodal-agent-positioning-stack.md docs/portfolio-pitch.md README.md`
- `make real-eval-v2-guard`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff --check`
- `make check-branch`

신규 런타임 동작이 없는 docs/task-only 변경이라 unit test는 추가하지 않았습니다.

## 5. Eval 영향

Docs/task queue 변경만 있습니다. Retrieval, reranking, answer generation, eval scoring, API behavior, private eval runner는 변경하지 않았습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Private real-eval은 실행하지 않았고, 새 성능 claim도 없습니다. 현재 claim-bearing private evidence lane은 `real100_v2` aggregate-only라는 wording만 정리했습니다.

## 6. 하위 호환

기존 CLI/API/schema/answer-contract 변경 없음. ADR 0001 `naive_baseline`, ADR 0003 answer dict contract, FastAPI/demo behavior 모두 그대로입니다.

## 7. 범위 외

- VLM captioning 구현.
- Agent tool runtime 구현.
- Product API/demo 변경.
- Self-hosted serving/vLLM 구현.
- Graph RAG 구현.

위 항목은 `T-2026-0059` 이후 follow-up task로만 진행합니다.