### PR TITLE
feat: agent-loop 실시간 진행 표시 (`make 시작` live tail)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -15,12 +15,15 @@ import difflib
 import hashlib
 import html
 import json
+import os
 from pathlib import Path
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import time
 from typing import Iterable, Sequence
 
 
@@ -8782,25 +8785,39 @@ def write_active_start(
     outputs: list[Path] = []
     warnings: list[str] = []
     blockers: list[str] = []
+    _emit_progress(
+        f"[active-start] topology={topology} mode={mode} lease-ttl={lease_ttl_minutes}m"
+    )
+    if isinstance(agent_mix, dict):
+        target = agent_mix.get("target") if isinstance(agent_mix.get("target"), dict) else {}
+        if target:
+            mix_str = ",".join(f"{k}={v}" for k, v in sorted(target.items()))
+            _emit_progress(f"[active-start] agent-mix target={mix_str}")
     redacted_runs = _redact_active_codex_runs(active_dir, repo_root=repo_root)
     if redacted_runs:
         warnings.append(f"redacted {redacted_runs} stale active Codex run artifact(s) before privacy audit")
+        _emit_progress(f"[active-start] redacted {redacted_runs} stale codex run artifact(s)")
     selected_task: TaskEntry | None = None
     if task_id is None:
         if files:
             warnings.append("task auto-selection skipped because local changed files already define the active scope")
+            _emit_progress("[active-start] task auto-select skipped (changed files already define scope)")
         else:
             try:
                 selected_task = select_next_task(repo_root)
                 task_id = selected_task.task_id
                 warnings.append(f"auto-selected task `{task_id}` from `{QUEUE_PATH}`")
+                _emit_progress(f"[active-start] auto-selected task={task_id}")
             except ValueError as exc:
                 warnings.append(f"task auto-selection skipped: {exc}")
+                _emit_progress(f"[active-start] task auto-select skipped: {exc}")
     else:
         try:
             selected_task = load_task(task_id, repo_root)
+            _emit_progress(f"[active-start] task loaded: {task_id}")
         except ValueError as exc:
             blockers.append(str(exc))
+            _emit_progress(f"[active-start] task load failed: {exc}")
     if not files and selected_task is not None:
         files = _active_task_context_files(selected_task, repo_root=repo_root)
         if files:
@@ -8829,8 +8846,10 @@ def write_active_start(
             branch_name = repaired_branch
             branch_issue = repaired_issue
             warnings.append(f"branch repair: {repair_action} `{repaired_branch}`")
+            _emit_progress(f"[active-start] branch ready: {repaired_branch} ({repair_action})")
         except ValueError as exc:
             blockers.append(str(exc))
+            _emit_progress(f"[active-start] branch repair failed: {exc}")
 
     if pr_body is not None:
         body_path = _resolve_input_path(pr_body, repo_root=repo_root)
@@ -8854,6 +8873,7 @@ def write_active_start(
             outputs.append(body_out)
             if body_missing:
                 warnings.append(f"generated missing PR body draft at `{_repo_path(body_out, repo_root)}`")
+            _emit_progress(f"[active-start] pr-body draft: {_repo_path(body_out, repo_root)}")
         if not safe_issue:
             active_loop_pr_body = None
             warnings.append("PR body draft was not used as readiness evidence because no issue-linked branch or --issue was available")
@@ -8890,6 +8910,10 @@ def write_active_start(
     )
     outputs.append(active_loop.report_path)
     warnings.extend(active_loop.warnings)
+    _emit_progress(
+        f"[active-start] lease table written: {_repo_path(active_loop.report_path, repo_root)} "
+        f"({active_loop.decision})"
+    )
 
     def capture(label: str, writer) -> None:  # type: ignore[no-untyped-def]
         try:
@@ -8951,6 +8975,7 @@ def write_active_start(
             repo_root=repo_root,
         ),
     )
+    _emit_progress(f"[active-start] auxiliary reports written: {len(outputs)} file(s)")
     try:
         privacy_out, privacy_rc, _ = write_privacy_audit_output(
             path=repo_root / "reports" / "agent_loop",
@@ -8960,8 +8985,12 @@ def write_active_start(
         outputs.append(privacy_out)
         if privacy_rc:
             blockers.append("privacy audit found generated artifact issue(s)")
+            _emit_progress(f"[active-start] privacy audit: {privacy_rc} blocker(s) found")
+        else:
+            _emit_progress("[active-start] privacy audit: clean")
     except ValueError as exc:
         warnings.append(f"privacy-audit-output skipped: {exc}")
+        _emit_progress(f"[active-start] privacy audit skipped: {exc}")
 
     decision = "blocked" if blockers else "started"
     if blockers:
@@ -10059,6 +10088,190 @@ def write_agent_turn(
     )
 
 
+_CODEX_JSONL_EMOJI: dict[str, str] = {
+    "task_started": "▶",
+    "session.created": "▶",
+    "agent_message": "💬",
+    "agent_message_delta": "💬",
+    "assistant_message": "💬",
+    "agent_reasoning": "🧠",
+    "agent_reasoning_delta": "🧠",
+    "reasoning": "🧠",
+    "tool_use": "🔧",
+    "function_call": "🔧",
+    "tool_call": "🔧",
+    "exec_command_begin": "⚙",
+    "exec_command_end": "⚙",
+    "tool_result": "📤",
+    "function_call_output": "📤",
+    "tool_response": "📤",
+    "task_complete": "✓",
+    "session.completed": "✓",
+    "error": "❌",
+    "shutdown": "⛔",
+}
+
+
+def _agent_loop_stream_enabled() -> bool:
+    """True when interactive progress should be emitted to stdout.
+
+    Set ``BIDMATE_AGENT_LOOP_QUIET=1`` to disable (CI / non-TTY callers).
+    """
+    flag = os.environ.get("BIDMATE_AGENT_LOOP_QUIET", "").strip().lower()
+    return flag not in {"1", "true", "yes", "on"}
+
+
+def _agent_loop_stream_raw() -> bool:
+    """True when raw JSONL lines should be emitted instead of emoji summaries.
+
+    Set ``BIDMATE_AGENT_LOOP_RAW=1`` when the codex JSONL schema drifts and the
+    summary formatter loses fidelity — emits the unparsed line with the session
+    prefix so debugging stays possible.
+    """
+    flag = os.environ.get("BIDMATE_AGENT_LOOP_RAW", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    """Write a single progress line to stdout when streaming is enabled."""
+    if not _agent_loop_stream_enabled():
+        return
+    if not message:
+        return
+    sys.stdout.write(message.rstrip() + "\n")
+    sys.stdout.flush()
+
+
+def _format_codex_jsonl_summary(session_id: str, line: str) -> str:
+    """Convert a codex ``--json`` event to ``[session-id] <emoji> <detail>``.
+
+    Unknown ``type`` → ``❔`` (schema drift visible, not silently dropped).
+    JSON parse failure → ``⚠ raw: <line>`` (raw payload preserved).
+    ``BIDMATE_AGENT_LOOP_RAW=1`` → returns the raw line with session prefix.
+    Empty / whitespace-only lines → empty string (caller skips emit).
+    """
+    line = line.rstrip("\n")
+    if not line.strip():
+        return ""
+    if _agent_loop_stream_raw():
+        return f"[{session_id}] {line}"
+    try:
+        payload = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return f"[{session_id}] ⚠ raw: {line[:240]}"
+    if not isinstance(payload, dict):
+        return f"[{session_id}] ⚠ raw: {line[:240]}"
+    inner = payload.get("msg") if isinstance(payload.get("msg"), dict) else payload
+    event_type = str(inner.get("type") or payload.get("type") or "")
+    emoji = _CODEX_JSONL_EMOJI.get(event_type)
+    if emoji is None:
+        snippet = str(inner)[:80].replace("\n", " ")
+        return f"[{session_id}] ❔ {event_type or '<no-type>'}: {snippet}"
+    detail = ""
+    if event_type in {"agent_message", "agent_message_delta", "assistant_message"}:
+        content = inner.get("content") or inner.get("message") or inner.get("text") or ""
+        if isinstance(content, list):
+            parts: list[str] = []
+            for seg in content:
+                if isinstance(seg, dict):
+                    parts.append(str(seg.get("text") or seg.get("content") or ""))
+                else:
+                    parts.append(str(seg))
+            content = " ".join(p for p in parts if p)
+        detail = str(content)[:200].replace("\n", " ")
+    elif event_type in {"agent_reasoning", "agent_reasoning_delta", "reasoning"}:
+        detail = str(inner.get("text") or inner.get("content") or "")[:160].replace("\n", " ")
+    elif event_type in {"tool_use", "function_call", "tool_call"}:
+        name = inner.get("name") or inner.get("tool") or "?"
+        args = inner.get("input") or inner.get("arguments") or {}
+        if isinstance(args, dict):
+            arg_keys = list(args.keys())[:3]
+            detail = f"{name}({', '.join(arg_keys)})"
+        else:
+            detail = f"{name}({str(args)[:60]})"
+    elif event_type in {"exec_command_begin", "exec_command_end"}:
+        cmd = inner.get("command") or inner.get("argv") or ""
+        if isinstance(cmd, list):
+            cmd = " ".join(str(p) for p in cmd[:6])
+        detail = str(cmd)[:160].replace("\n", " ")
+    elif event_type in {"tool_result", "function_call_output", "tool_response"}:
+        out = inner.get("output") or inner.get("content") or ""
+        detail = str(out)[:120].replace("\n", " ")
+    elif event_type in {"task_complete", "session.completed"}:
+        rc = inner.get("exit_code") or inner.get("returncode") or 0
+        elapsed = inner.get("duration_s") or inner.get("duration_ms")
+        detail = f"rc={rc}"
+        if elapsed:
+            detail += f" elapsed={elapsed}"
+    elif event_type == "error":
+        detail = str(inner.get("message") or inner.get("error") or "")[:200].replace("\n", " ")
+    elif event_type == "shutdown":
+        detail = str(inner.get("reason") or "")[:120]
+    else:
+        detail = str(inner)[:80].replace("\n", " ")
+    return f"[{session_id}] {emoji} {detail}".rstrip()
+
+
+def _spawn_codex_reader_thread(
+    proc: object,
+    session_id: str,
+    stdout_path: Path,
+) -> "threading.Thread | None":
+    """Tee a codex subprocess stdout PIPE into ``stdout_path`` while emitting summaries.
+
+    Returns the started daemon thread, or ``None`` when ``proc`` has no readable stdout
+    (mocked test procs, dry-run mode). Creates an empty ``stdout_path`` in that case so
+    downstream code that expects the file to exist still finds it.
+    """
+    stream = getattr(proc, "stdout", None)
+    if stream is None:
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_path.touch()
+        except OSError:
+            pass
+        return None
+    readline = getattr(stream, "readline", None)
+    if not callable(readline):
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_path.touch()
+        except OSError:
+            pass
+        return None
+
+    def reader() -> None:
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            with stdout_path.open("w", encoding="utf-8") as out_file:
+                while True:
+                    try:
+                        line = readline()
+                    except (OSError, ValueError):
+                        break
+                    if not line:
+                        break
+                    if isinstance(line, bytes):
+                        try:
+                            line = line.decode("utf-8", errors="replace")
+                        except Exception:
+                            line = repr(line)
+                    out_file.write(line)
+                    out_file.flush()
+                    formatted = _format_codex_jsonl_summary(session_id, line)
+                    if formatted:
+                        _emit_progress(formatted)
+        finally:
+            try:
+                stream.close()
+            except Exception:  # pragma: no cover - close failures are non-fatal
+                pass
+
+    t = threading.Thread(target=reader, name=f"codex-tail-{session_id}", daemon=True)
+    t.start()
+    return t
+
+
 def write_active_codex_runner(
     *,
     execute: bool = False,
@@ -10212,7 +10425,9 @@ def write_active_codex_runner(
         factory = popen_factory if popen_factory is not None else subprocess.Popen
 
         def spawn_and_wait(batch: Sequence[dict[str, object]]) -> None:
-            batch_spawned: list[tuple[dict[str, object], object]] = []
+            batch_spawned: list[
+                tuple[dict[str, object], object, "threading.Thread | None", object, float]
+            ] = []
             for item in batch:
                 session_id = str(item["session_id"])
                 role = str(item["role"])
@@ -10236,31 +10451,40 @@ def write_active_codex_runner(
                     last_message_path=last_message_path,
                     repo_root=repo_root,
                 )
+                stderr_file = None
                 try:
-                    with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
-                        "w", encoding="utf-8"
-                    ) as stderr_file:
-                        proc = factory(
-                            command,
-                            cwd=repo_root,
-                            stdin=subprocess.PIPE,
-                            stdout=stdout_file,
-                            stderr=stderr_file,
-                            text=True,
-                        )
-                        stdin = getattr(proc, "stdin", None)
-                        if stdin is not None:
-                            stdin.write(prompt)
-                            stdin.close()
+                    stderr_file = stderr_path.open("w", encoding="utf-8")
+                    proc = factory(
+                        command,
+                        cwd=repo_root,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=stderr_file,
+                        text=True,
+                    )
+                    stdin = getattr(proc, "stdin", None)
+                    if stdin is not None:
+                        stdin.write(prompt)
+                        stdin.close()
                 except OSError as exc:
+                    if stderr_file is not None:
+                        try:
+                            stderr_file.close()
+                        except Exception:  # pragma: no cover - close failures non-fatal
+                            pass
                     item["status"] = "spawn-failed"
                     blockers.append(f"failed to spawn session {session_id}: {exc}")
                     return
                 item["status"] = "running"
                 item["pid"] = getattr(proc, "pid", None)
-                batch_spawned.append((item, proc))
+                reader_thread = _spawn_codex_reader_thread(proc, session_id, stdout_path)
+                spawn_start_at = time.monotonic()
+                _emit_progress(
+                    f"[spawn] session={session_id} role={role} pid={item['pid']}"
+                )
+                batch_spawned.append((item, proc, reader_thread, stderr_file, spawn_start_at))
                 spawned.append((item, proc))
-            for item, proc in batch_spawned:
+            for item, proc, reader_thread, stderr_file, spawn_start_at in batch_spawned:
                 if blockers:
                     break
                 wait = getattr(proc, "wait", None)
@@ -10273,12 +10497,27 @@ def write_active_codex_runner(
                     item["status"] = "timeout"
                     item["returncode"] = None
                     blockers.append(f"session {item['session_id']} timed out after {timeout_seconds} seconds")
+                    _emit_progress(f"[done] session={item['session_id']} timeout")
                     continue
+                if reader_thread is not None:
+                    reader_thread.join(timeout=10.0)
+                if stderr_file is not None:
+                    try:
+                        stderr_file.close()
+                    except Exception:  # pragma: no cover - close failures non-fatal
+                        pass
                 item["returncode"] = rc
+                elapsed = time.monotonic() - spawn_start_at
                 if rc == 0:
                     item["status"] = "completed"
+                    _emit_progress(
+                        f"[done] session={item['session_id']} rc=0 elapsed={elapsed:.1f}s"
+                    )
                 else:
                     item["status"] = "failed"
+                    _emit_progress(
+                        f"[done] session={item['session_id']} rc={rc} elapsed={elapsed:.1f}s"
+                    )
                     blockers.append(f"session {item['session_id']} exited with code {rc}")
 
         final_gate_sessions = [item for item in planned if item.get("session_id") == "eval-claim-privacy-auditor"]

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3635,8 +3635,8 @@ def test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_leas
                 "cmd": list(cmd),
                 "cwd": kwargs["cwd"],
                 "stdin": kwargs["stdin"],
-                "stdout": kwargs["stdout"].name,
-                "stderr": kwargs["stderr"].name,
+                "stdout": kwargs["stdout"],
+                "stderr_name": getattr(kwargs["stderr"], "name", None),
                 "text": kwargs["text"],
             }
         )
@@ -3664,6 +3664,9 @@ def test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_leas
         assert cmd[-1] == "-"
         assert call["cwd"] == repo
         assert call["stdin"] == subprocess.PIPE
+        assert call["stdout"] == subprocess.PIPE
+        assert call["stderr_name"] is not None
+        assert call["stderr_name"].endswith("/stderr.log")
         assert call["text"] is True
     assert (active / "codex_runs" / "reviewer" / "prompt.md").exists()
     leases = json.loads((active / "leases.json").read_text(encoding="utf-8"))

--- a/tests/test_agent_loop_streaming.py
+++ b/tests/test_agent_loop_streaming.py
@@ -1,0 +1,247 @@
+"""Tests for issue #1654 — agent-loop live progress streaming.
+
+Covers the JSONL → emoji summary formatter, the env-gated progress emitter,
+and the reader-thread tee for codex subprocess stdout.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_stream_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BIDMATE_AGENT_LOOP_QUIET", raising=False)
+    monkeypatch.delenv("BIDMATE_AGENT_LOOP_RAW", raising=False)
+
+
+def test_stream_enabled_default_true() -> None:
+    assert agent_loop._agent_loop_stream_enabled() is True
+
+
+def test_stream_enabled_quiet_env_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("1", "true", "yes", "ON"):
+        monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", value)
+        assert agent_loop._agent_loop_stream_enabled() is False
+
+
+def test_stream_enabled_quiet_blank_still_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "0")
+    assert agent_loop._agent_loop_stream_enabled() is True
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "")
+    assert agent_loop._agent_loop_stream_enabled() is True
+
+
+def test_emit_progress_writes_and_flushes(capsys: pytest.CaptureFixture[str]) -> None:
+    agent_loop._emit_progress("[active-start] hello world")
+    captured = capsys.readouterr()
+    assert captured.out == "[active-start] hello world\n"
+
+
+def test_emit_progress_noop_when_quiet(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "1")
+    agent_loop._emit_progress("should not appear")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_emit_progress_skips_empty() -> None:
+    # Must not raise / not write — no capsys check needed beyond no exception.
+    agent_loop._emit_progress("")
+
+
+def test_format_jsonl_summary_agent_message() -> None:
+    line = json.dumps({"type": "agent_message", "content": "Reading rag_core.py to understand structure..."})
+    result = agent_loop._format_codex_jsonl_summary("claude-impl", line)
+    assert result.startswith("[claude-impl] 💬 ")
+    assert "Reading rag_core.py" in result
+
+
+def test_format_jsonl_summary_agent_message_nested_msg() -> None:
+    line = json.dumps({"msg": {"type": "agent_message", "content": "Hello from codex"}})
+    result = agent_loop._format_codex_jsonl_summary("codex-review", line)
+    assert "💬" in result
+    assert "Hello from codex" in result
+
+
+def test_format_jsonl_summary_tool_use_extracts_args() -> None:
+    line = json.dumps(
+        {
+            "type": "tool_use",
+            "name": "Read",
+            "input": {"path": "rag_core.py", "limit": 100},
+        }
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "🔧" in result
+    assert "Read(" in result
+    assert "path" in result
+
+
+def test_format_jsonl_summary_exec_command() -> None:
+    line = json.dumps(
+        {"type": "exec_command_begin", "command": ["git", "diff", "--stat"]}
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "⚙" in result
+    assert "git diff" in result
+
+
+def test_format_jsonl_summary_task_complete() -> None:
+    line = json.dumps(
+        {"type": "task_complete", "exit_code": 0, "duration_s": 42.3}
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "✓" in result
+    assert "rc=0" in result
+    assert "42.3" in result
+
+
+def test_format_jsonl_summary_error() -> None:
+    line = json.dumps({"type": "error", "message": "auth required"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "❌" in result
+    assert "auth required" in result
+
+
+def test_format_jsonl_summary_unknown_type_uses_questionmark() -> None:
+    line = json.dumps({"type": "novel_event_v99", "content": "future schema"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "❔" in result
+    assert "novel_event_v99" in result
+
+
+def test_format_jsonl_summary_parse_failure_uses_warn() -> None:
+    result = agent_loop._format_codex_jsonl_summary("impl", "not-a-json-line {{{")
+    assert "⚠" in result
+    assert "not-a-json-line" in result
+
+
+def test_format_jsonl_summary_non_dict_payload() -> None:
+    result = agent_loop._format_codex_jsonl_summary("impl", '"just a string"')
+    assert "⚠" in result
+
+
+def test_format_jsonl_summary_empty_line_returns_empty() -> None:
+    assert agent_loop._format_codex_jsonl_summary("impl", "") == ""
+    assert agent_loop._format_codex_jsonl_summary("impl", "   \n") == ""
+
+
+def test_format_jsonl_summary_raw_env_returns_raw(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_RAW", "1")
+    line = json.dumps({"type": "agent_message", "content": "hi"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert result.startswith("[impl] ")
+    # When RAW=1 the unparsed line is returned, so the literal JSON should appear.
+    assert "agent_message" in result
+    assert "💬" not in result
+
+
+def test_format_jsonl_summary_message_segments_list() -> None:
+    # Codex sometimes sends content as a list of segments.
+    line = json.dumps(
+        {
+            "type": "agent_message",
+            "content": [
+                {"text": "Found bug in"},
+                {"text": "retrieve_candidates"},
+            ],
+        }
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "Found bug in" in result
+    assert "retrieve_candidates" in result
+
+
+def test_spawn_codex_reader_thread_writes_file_and_emits(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stream = io.StringIO(
+        json.dumps({"type": "task_started"}) + "\n"
+        + json.dumps({"type": "agent_message", "content": "hello"}) + "\n"
+        + json.dumps({"type": "task_complete", "exit_code": 0}) + "\n"
+    )
+
+    class FakeProc:
+        def __init__(self, stream_: io.StringIO) -> None:
+            self.stdout = stream_
+
+    proc = FakeProc(stream)
+    stdout_path = tmp_path / "session" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "test-session", stdout_path)
+    assert thread is not None
+    thread.join(timeout=5.0)
+    assert not thread.is_alive()
+
+    written = stdout_path.read_text(encoding="utf-8")
+    assert '"task_started"' in written
+    assert '"agent_message"' in written
+    assert '"task_complete"' in written
+
+    captured = capsys.readouterr()
+    assert "▶" in captured.out
+    assert "💬 hello" in captured.out
+    assert "✓ rc=0" in captured.out
+
+
+def test_spawn_codex_reader_thread_none_stdout_creates_empty_file(tmp_path: Path) -> None:
+    class FakeProc:
+        stdout = None
+
+    proc = FakeProc()
+    stdout_path = tmp_path / "no-stdout" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "x", stdout_path)
+    assert thread is None
+    assert stdout_path.exists()
+    assert stdout_path.read_text(encoding="utf-8") == ""
+
+
+def test_spawn_codex_reader_thread_quiet_env_no_stdout_but_file_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "1")
+    stream = io.StringIO(json.dumps({"type": "agent_message", "content": "secret"}) + "\n")
+
+    class FakeProc:
+        def __init__(self, stream_: io.StringIO) -> None:
+            self.stdout = stream_
+
+    proc = FakeProc(stream)
+    stdout_path = tmp_path / "quiet" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "q", stdout_path)
+    assert thread is not None
+    thread.join(timeout=5.0)
+    captured = capsys.readouterr()
+    # File contract preserved even when stdout muted.
+    assert "secret" in stdout_path.read_text(encoding="utf-8")
+    # Nothing emitted to stdout under QUIET mode.
+    assert captured.out == ""
+
+
+def test_spawn_codex_reader_thread_no_readline_attr_creates_file(tmp_path: Path) -> None:
+    class FakeStream:
+        # No readline attribute — reader should bail and touch the file.
+        def __repr__(self) -> str:
+            return "<no-readline>"
+
+    class FakeProc:
+        stdout = FakeStream()
+
+    proc = FakeProc()
+    stdout_path = tmp_path / "nopen" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "x", stdout_path)
+    assert thread is None
+    assert stdout_path.exists()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make 시작` (`agent-loop-active-start` + `active-codex-runner`) 실행 시 turn 종료 후에야 진행 상황이 보였다. 8 세션이 동시에 도는 동안 `reports/agent_loop/active/codex_runs/<session>/stdout.jsonl` 파일을 별도 터미널에서 tail 하지 않으면 "걸렸는지 정상인지" 판단 불가. 같은 터미널에서 라이브로 진행을 보이게 했다.

Closes #1654

## 2. 영향 파일

- `scripts/agent_loop.py` — supporting (rag_core back-edge 0), 신규 helper 6개 + `write_active_start` 단계별 `_emit_progress` + `spawn_and_wait` PIPE/reader-thread/마커 (+255 LOC)
- `tests/test_agent_loop.py` — 기존 `test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_lease` 의 `kwargs["stdout"].name` 단언을 `kwargs["stdout"] == subprocess.PIPE` 로 교체 (5 LOC delta)
- `tests/test_agent_loop_streaming.py` — 신규 (+222 LOC, 22 test)

Load-bearing 파일 없음 (agent_loop.py 는 `scripts/_governance.py:LOAD_BEARING_PATHS` 에 포함 안 됨).

## 3. 리스크

- **mocked popen 호환성**: 기존 테스트의 fake popen 들은 `proc.stdout` 속성 없음 → `_spawn_codex_reader_thread` 가 `getattr(proc, "stdout", None) → None` 으로 graceful no-op, 빈 파일 touch 로 후속 코드 (privacy redaction, gate heartbeat) 호환. 195개 기존 + 신규 테스트 전부 PASS.
- **codex JSONL schema 드리프트**: 알 수 없는 `type` 은 `❔ <type>: <첫 80자>` 로 표시 (silent drop 금지) — schema 변경 즉시 인지. JSON 파싱 실패는 `⚠ raw: <line>` 로 raw 보존.
- **reader thread leak**: daemon thread 로 생성, wait 후 `.join(timeout=10s)` 으로 회수. 부모 프로세스 종료 시 자동 정리.
- **CI/non-TTY**: `BIDMATE_AGENT_LOOP_QUIET=1` 환경변수로 모든 stdout 진행 표시 off (모든 `_emit_progress` 호출이 env check 후 short-circuit).

## 4. 테스트

`tests/test_agent_loop_streaming.py` 22개 추가:
- `_format_codex_jsonl_summary` 알려진 type 매핑 (`agent_message` → 💬, `tool_use` → 🔧, `task_complete` → ✓ rc=… elapsed=…, `error` → ❌, etc.)
- 알 수 없는 type → ❔ fallback / JSON 파싱 실패 → ⚠ raw fallback / 빈 라인 → 빈 문자열
- `BIDMATE_AGENT_LOOP_RAW=1` → raw 모드 (이모지 미사용, 원본 JSONL prefix만)
- `_emit_progress` default-ON / `BIDMATE_AGENT_LOOP_QUIET=1` 시 no-op
- `_spawn_codex_reader_thread` StringIO 입력 → 파일 tee + stdout summary 동시 emit / proc.stdout=None → 빈 파일 touch / no-readline → 빈 파일 touch / QUIET 모드 시 파일은 그대로 stdout 만 침묵

기존 `test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_lease` 등 21 케이스 PASS — 회귀 없음. 전체 195/195 PASS.

## 5. Eval 영향

검색/검증/답변 path 동작 변화 없음 — `scripts/agent_loop.py` 는 RAG 파이프라인 외부 (orchestration CLI). 평가 surface 미접촉.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. agent-loop orchestration CLI 변경 — 평가/색인/문서 backend 미접촉. load-bearing path 변경 없음 (`scripts/_governance.py:LOAD_BEARING_PATHS` 기준).

## 6. 하위 호환

- `subprocess.Popen` 호출 시 `stdout=stdout_file` → `stdout=subprocess.PIPE` 로 변경됨. 외부 파일 계약 (`stdout.jsonl` 의 내용/존재) 은 reader thread 가 동일하게 보장 — 후속 코드 (privacy redaction, gate heartbeat parsing) 영향 없음.
- 신규 환경변수 `BIDMATE_AGENT_LOOP_QUIET` / `BIDMATE_AGENT_LOOP_RAW` 둘 다 opt-in (미설정 시 새 동작이 default).
- CLI flag / 답변 계약 (ADR 0003 `schema_version`) 변경 없음.

## 7. 범위 외

- **Quota-aware agent-mix 비율 조정** — 별도 이슈 + PR 로 본 PR 위에 스택 (issue 별도 생성 예정, `feat/issue-M-agent-loop-quota-aware-mix`)
- **색깔 (ANSI)** — 사용자 선호 옵션 3 (이모지 요약) 채택. 색깔은 파이프/로깅 시 escape 잔존이라 거부.
- **codex JSONL schema 자동 적응** — 모르는 type 은 `❔` 로 표시만 하고 작업은 진행. 자동 재해석 없음.
