### PR TITLE
feat: agent-mix를 주간 quota 잔량 기반 동적 조절

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -15,12 +15,15 @@ import difflib
 import hashlib
 import html
 import json
+import os
 from pathlib import Path
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import time
 from typing import Iterable, Sequence
 
 
@@ -8782,25 +8785,39 @@ def write_active_start(
     outputs: list[Path] = []
     warnings: list[str] = []
     blockers: list[str] = []
+    _emit_progress(
+        f"[active-start] topology={topology} mode={mode} lease-ttl={lease_ttl_minutes}m"
+    )
+    if isinstance(agent_mix, dict):
+        target = agent_mix.get("target") if isinstance(agent_mix.get("target"), dict) else {}
+        if target:
+            mix_str = ",".join(f"{k}={v}" for k, v in sorted(target.items()))
+            _emit_progress(f"[active-start] agent-mix target={mix_str}")
     redacted_runs = _redact_active_codex_runs(active_dir, repo_root=repo_root)
     if redacted_runs:
         warnings.append(f"redacted {redacted_runs} stale active Codex run artifact(s) before privacy audit")
+        _emit_progress(f"[active-start] redacted {redacted_runs} stale codex run artifact(s)")
     selected_task: TaskEntry | None = None
     if task_id is None:
         if files:
             warnings.append("task auto-selection skipped because local changed files already define the active scope")
+            _emit_progress("[active-start] task auto-select skipped (changed files already define scope)")
         else:
             try:
                 selected_task = select_next_task(repo_root)
                 task_id = selected_task.task_id
                 warnings.append(f"auto-selected task `{task_id}` from `{QUEUE_PATH}`")
+                _emit_progress(f"[active-start] auto-selected task={task_id}")
             except ValueError as exc:
                 warnings.append(f"task auto-selection skipped: {exc}")
+                _emit_progress(f"[active-start] task auto-select skipped: {exc}")
     else:
         try:
             selected_task = load_task(task_id, repo_root)
+            _emit_progress(f"[active-start] task loaded: {task_id}")
         except ValueError as exc:
             blockers.append(str(exc))
+            _emit_progress(f"[active-start] task load failed: {exc}")
     if not files and selected_task is not None:
         files = _active_task_context_files(selected_task, repo_root=repo_root)
         if files:
@@ -8829,8 +8846,10 @@ def write_active_start(
             branch_name = repaired_branch
             branch_issue = repaired_issue
             warnings.append(f"branch repair: {repair_action} `{repaired_branch}`")
+            _emit_progress(f"[active-start] branch ready: {repaired_branch} ({repair_action})")
         except ValueError as exc:
             blockers.append(str(exc))
+            _emit_progress(f"[active-start] branch repair failed: {exc}")
 
     if pr_body is not None:
         body_path = _resolve_input_path(pr_body, repo_root=repo_root)
@@ -8854,6 +8873,7 @@ def write_active_start(
             outputs.append(body_out)
             if body_missing:
                 warnings.append(f"generated missing PR body draft at `{_repo_path(body_out, repo_root)}`")
+            _emit_progress(f"[active-start] pr-body draft: {_repo_path(body_out, repo_root)}")
         if not safe_issue:
             active_loop_pr_body = None
             warnings.append("PR body draft was not used as readiness evidence because no issue-linked branch or --issue was available")
@@ -8890,6 +8910,10 @@ def write_active_start(
     )
     outputs.append(active_loop.report_path)
     warnings.extend(active_loop.warnings)
+    _emit_progress(
+        f"[active-start] lease table written: {_repo_path(active_loop.report_path, repo_root)} "
+        f"({active_loop.decision})"
+    )
 
     def capture(label: str, writer) -> None:  # type: ignore[no-untyped-def]
         try:
@@ -8951,6 +8975,7 @@ def write_active_start(
             repo_root=repo_root,
         ),
     )
+    _emit_progress(f"[active-start] auxiliary reports written: {len(outputs)} file(s)")
     try:
         privacy_out, privacy_rc, _ = write_privacy_audit_output(
             path=repo_root / "reports" / "agent_loop",
@@ -8960,8 +8985,12 @@ def write_active_start(
         outputs.append(privacy_out)
         if privacy_rc:
             blockers.append("privacy audit found generated artifact issue(s)")
+            _emit_progress(f"[active-start] privacy audit: {privacy_rc} blocker(s) found")
+        else:
+            _emit_progress("[active-start] privacy audit: clean")
     except ValueError as exc:
         warnings.append(f"privacy-audit-output skipped: {exc}")
+        _emit_progress(f"[active-start] privacy audit skipped: {exc}")
 
     decision = "blocked" if blockers else "started"
     if blockers:
@@ -10059,6 +10088,190 @@ def write_agent_turn(
     )
 
 
+_CODEX_JSONL_EMOJI: dict[str, str] = {
+    "task_started": "▶",
+    "session.created": "▶",
+    "agent_message": "💬",
+    "agent_message_delta": "💬",
+    "assistant_message": "💬",
+    "agent_reasoning": "🧠",
+    "agent_reasoning_delta": "🧠",
+    "reasoning": "🧠",
+    "tool_use": "🔧",
+    "function_call": "🔧",
+    "tool_call": "🔧",
+    "exec_command_begin": "⚙",
+    "exec_command_end": "⚙",
+    "tool_result": "📤",
+    "function_call_output": "📤",
+    "tool_response": "📤",
+    "task_complete": "✓",
+    "session.completed": "✓",
+    "error": "❌",
+    "shutdown": "⛔",
+}
+
+
+def _agent_loop_stream_enabled() -> bool:
+    """True when interactive progress should be emitted to stdout.
+
+    Set ``BIDMATE_AGENT_LOOP_QUIET=1`` to disable (CI / non-TTY callers).
+    """
+    flag = os.environ.get("BIDMATE_AGENT_LOOP_QUIET", "").strip().lower()
+    return flag not in {"1", "true", "yes", "on"}
+
+
+def _agent_loop_stream_raw() -> bool:
+    """True when raw JSONL lines should be emitted instead of emoji summaries.
+
+    Set ``BIDMATE_AGENT_LOOP_RAW=1`` when the codex JSONL schema drifts and the
+    summary formatter loses fidelity — emits the unparsed line with the session
+    prefix so debugging stays possible.
+    """
+    flag = os.environ.get("BIDMATE_AGENT_LOOP_RAW", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    """Write a single progress line to stdout when streaming is enabled."""
+    if not _agent_loop_stream_enabled():
+        return
+    if not message:
+        return
+    sys.stdout.write(message.rstrip() + "\n")
+    sys.stdout.flush()
+
+
+def _format_codex_jsonl_summary(session_id: str, line: str) -> str:
+    """Convert a codex ``--json`` event to ``[session-id] <emoji> <detail>``.
+
+    Unknown ``type`` → ``❔`` (schema drift visible, not silently dropped).
+    JSON parse failure → ``⚠ raw: <line>`` (raw payload preserved).
+    ``BIDMATE_AGENT_LOOP_RAW=1`` → returns the raw line with session prefix.
+    Empty / whitespace-only lines → empty string (caller skips emit).
+    """
+    line = line.rstrip("\n")
+    if not line.strip():
+        return ""
+    if _agent_loop_stream_raw():
+        return f"[{session_id}] {line}"
+    try:
+        payload = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return f"[{session_id}] ⚠ raw: {line[:240]}"
+    if not isinstance(payload, dict):
+        return f"[{session_id}] ⚠ raw: {line[:240]}"
+    inner = payload.get("msg") if isinstance(payload.get("msg"), dict) else payload
+    event_type = str(inner.get("type") or payload.get("type") or "")
+    emoji = _CODEX_JSONL_EMOJI.get(event_type)
+    if emoji is None:
+        snippet = str(inner)[:80].replace("\n", " ")
+        return f"[{session_id}] ❔ {event_type or '<no-type>'}: {snippet}"
+    detail = ""
+    if event_type in {"agent_message", "agent_message_delta", "assistant_message"}:
+        content = inner.get("content") or inner.get("message") or inner.get("text") or ""
+        if isinstance(content, list):
+            parts: list[str] = []
+            for seg in content:
+                if isinstance(seg, dict):
+                    parts.append(str(seg.get("text") or seg.get("content") or ""))
+                else:
+                    parts.append(str(seg))
+            content = " ".join(p for p in parts if p)
+        detail = str(content)[:200].replace("\n", " ")
+    elif event_type in {"agent_reasoning", "agent_reasoning_delta", "reasoning"}:
+        detail = str(inner.get("text") or inner.get("content") or "")[:160].replace("\n", " ")
+    elif event_type in {"tool_use", "function_call", "tool_call"}:
+        name = inner.get("name") or inner.get("tool") or "?"
+        args = inner.get("input") or inner.get("arguments") or {}
+        if isinstance(args, dict):
+            arg_keys = list(args.keys())[:3]
+            detail = f"{name}({', '.join(arg_keys)})"
+        else:
+            detail = f"{name}({str(args)[:60]})"
+    elif event_type in {"exec_command_begin", "exec_command_end"}:
+        cmd = inner.get("command") or inner.get("argv") or ""
+        if isinstance(cmd, list):
+            cmd = " ".join(str(p) for p in cmd[:6])
+        detail = str(cmd)[:160].replace("\n", " ")
+    elif event_type in {"tool_result", "function_call_output", "tool_response"}:
+        out = inner.get("output") or inner.get("content") or ""
+        detail = str(out)[:120].replace("\n", " ")
+    elif event_type in {"task_complete", "session.completed"}:
+        rc = inner.get("exit_code") or inner.get("returncode") or 0
+        elapsed = inner.get("duration_s") or inner.get("duration_ms")
+        detail = f"rc={rc}"
+        if elapsed:
+            detail += f" elapsed={elapsed}"
+    elif event_type == "error":
+        detail = str(inner.get("message") or inner.get("error") or "")[:200].replace("\n", " ")
+    elif event_type == "shutdown":
+        detail = str(inner.get("reason") or "")[:120]
+    else:
+        detail = str(inner)[:80].replace("\n", " ")
+    return f"[{session_id}] {emoji} {detail}".rstrip()
+
+
+def _spawn_codex_reader_thread(
+    proc: object,
+    session_id: str,
+    stdout_path: Path,
+) -> "threading.Thread | None":
+    """Tee a codex subprocess stdout PIPE into ``stdout_path`` while emitting summaries.
+
+    Returns the started daemon thread, or ``None`` when ``proc`` has no readable stdout
+    (mocked test procs, dry-run mode). Creates an empty ``stdout_path`` in that case so
+    downstream code that expects the file to exist still finds it.
+    """
+    stream = getattr(proc, "stdout", None)
+    if stream is None:
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_path.touch()
+        except OSError:
+            pass
+        return None
+    readline = getattr(stream, "readline", None)
+    if not callable(readline):
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_path.touch()
+        except OSError:
+            pass
+        return None
+
+    def reader() -> None:
+        try:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            with stdout_path.open("w", encoding="utf-8") as out_file:
+                while True:
+                    try:
+                        line = readline()
+                    except (OSError, ValueError):
+                        break
+                    if not line:
+                        break
+                    if isinstance(line, bytes):
+                        try:
+                            line = line.decode("utf-8", errors="replace")
+                        except Exception:
+                            line = repr(line)
+                    out_file.write(line)
+                    out_file.flush()
+                    formatted = _format_codex_jsonl_summary(session_id, line)
+                    if formatted:
+                        _emit_progress(formatted)
+        finally:
+            try:
+                stream.close()
+            except Exception:  # pragma: no cover - close failures are non-fatal
+                pass
+
+    t = threading.Thread(target=reader, name=f"codex-tail-{session_id}", daemon=True)
+    t.start()
+    return t
+
+
 def write_active_codex_runner(
     *,
     execute: bool = False,
@@ -10212,7 +10425,9 @@ def write_active_codex_runner(
         factory = popen_factory if popen_factory is not None else subprocess.Popen
 
         def spawn_and_wait(batch: Sequence[dict[str, object]]) -> None:
-            batch_spawned: list[tuple[dict[str, object], object]] = []
+            batch_spawned: list[
+                tuple[dict[str, object], object, "threading.Thread | None", object, float]
+            ] = []
             for item in batch:
                 session_id = str(item["session_id"])
                 role = str(item["role"])
@@ -10236,31 +10451,40 @@ def write_active_codex_runner(
                     last_message_path=last_message_path,
                     repo_root=repo_root,
                 )
+                stderr_file = None
                 try:
-                    with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
-                        "w", encoding="utf-8"
-                    ) as stderr_file:
-                        proc = factory(
-                            command,
-                            cwd=repo_root,
-                            stdin=subprocess.PIPE,
-                            stdout=stdout_file,
-                            stderr=stderr_file,
-                            text=True,
-                        )
-                        stdin = getattr(proc, "stdin", None)
-                        if stdin is not None:
-                            stdin.write(prompt)
-                            stdin.close()
+                    stderr_file = stderr_path.open("w", encoding="utf-8")
+                    proc = factory(
+                        command,
+                        cwd=repo_root,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=stderr_file,
+                        text=True,
+                    )
+                    stdin = getattr(proc, "stdin", None)
+                    if stdin is not None:
+                        stdin.write(prompt)
+                        stdin.close()
                 except OSError as exc:
+                    if stderr_file is not None:
+                        try:
+                            stderr_file.close()
+                        except Exception:  # pragma: no cover - close failures non-fatal
+                            pass
                     item["status"] = "spawn-failed"
                     blockers.append(f"failed to spawn session {session_id}: {exc}")
                     return
                 item["status"] = "running"
                 item["pid"] = getattr(proc, "pid", None)
-                batch_spawned.append((item, proc))
+                reader_thread = _spawn_codex_reader_thread(proc, session_id, stdout_path)
+                spawn_start_at = time.monotonic()
+                _emit_progress(
+                    f"[spawn] session={session_id} role={role} pid={item['pid']}"
+                )
+                batch_spawned.append((item, proc, reader_thread, stderr_file, spawn_start_at))
                 spawned.append((item, proc))
-            for item, proc in batch_spawned:
+            for item, proc, reader_thread, stderr_file, spawn_start_at in batch_spawned:
                 if blockers:
                     break
                 wait = getattr(proc, "wait", None)
@@ -10273,12 +10497,27 @@ def write_active_codex_runner(
                     item["status"] = "timeout"
                     item["returncode"] = None
                     blockers.append(f"session {item['session_id']} timed out after {timeout_seconds} seconds")
+                    _emit_progress(f"[done] session={item['session_id']} timeout")
                     continue
+                if reader_thread is not None:
+                    reader_thread.join(timeout=10.0)
+                if stderr_file is not None:
+                    try:
+                        stderr_file.close()
+                    except Exception:  # pragma: no cover - close failures non-fatal
+                        pass
                 item["returncode"] = rc
+                elapsed = time.monotonic() - spawn_start_at
                 if rc == 0:
                     item["status"] = "completed"
+                    _emit_progress(
+                        f"[done] session={item['session_id']} rc=0 elapsed={elapsed:.1f}s"
+                    )
                 else:
                     item["status"] = "failed"
+                    _emit_progress(
+                        f"[done] session={item['session_id']} rc={rc} elapsed={elapsed:.1f}s"
+                    )
                     blockers.append(f"session {item['session_id']} exited with code {rc}")
 
         final_gate_sessions = [item for item in planned if item.get("session_id") == "eval-claim-privacy-auditor"]

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9644,6 +9644,27 @@ def _parse_agent_mix(spec: str | None) -> dict[str, object]:
     }
 
 
+def _resolve_agent_mix_for_cli(spec: str | None) -> dict[str, object]:
+    """Parse --agent-mix and apply quota-aware target rebalancing (issue #1656).
+
+    The rebalance is opt-in via signal availability: when agentcat is unavailable
+    AND no local quota_config.json exists, the parsed default flows through
+    unchanged. ``BIDMATE_AGENT_LOOP_QUOTA_OFF=1`` forces the static target even
+    when signals are present.
+    """
+    policy = _parse_agent_mix(spec)
+    try:
+        from scripts.agent_loop_quota import apply_quota_aware_target
+    except ImportError:
+        return policy
+    policy, _explanation = apply_quota_aware_target(
+        policy,
+        now=datetime.now(timezone.utc),
+        repo_root=ROOT_DIR,
+    )
+    return policy
+
+
 def _coerce_wu(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
@@ -11197,6 +11218,12 @@ def write_agent_mix_report(
         "within_tolerance": within,
         "recommended_next_agent": recommended,
     }
+    quota_explanation_raw = policy.get("quota_explanation")
+    quota_explanation = (
+        str(quota_explanation_raw)
+        if isinstance(quota_explanation_raw, str) and quota_explanation_raw
+        else ""
+    )
     lines = [
         "# Active-loop agent-mix report",
         "",
@@ -11206,6 +11233,9 @@ def write_agent_mix_report(
         f"- Skew: {skew} WU (max allowed {max_skew}) — {'within tolerance' if within else 'REBALANCE'}",
         f"- Recommended next lane: **{recommended}**",
     ]
+    if quota_explanation:
+        lines.append(f"- {quota_explanation}")
+    summary["quota_explanation"] = quota_explanation
     if not within:
         lines.append("")
         lines.append(f"Skew exceeds tolerance; route upcoming read-only turns to **{recommended}** until balanced.")
@@ -14568,7 +14598,7 @@ def main(argv: list[str] | None = None) -> int:
                 pr_body=args.pr_body,
                 lease_ttl_minutes=args.lease_ttl_minutes,
                 batch=args.batch,
-                agent_mix=_parse_agent_mix(args.agent_mix),
+                agent_mix=_resolve_agent_mix_for_cli(args.agent_mix),
                 repair_branch=args.repair_branch,
                 repair_branch_type=args.repair_branch_type,
                 repair_slug=args.repair_slug,
@@ -14596,7 +14626,7 @@ def main(argv: list[str] | None = None) -> int:
                 pr_body=args.pr_body,
                 lease_ttl_minutes=args.lease_ttl_minutes,
                 batch=args.batch,
-                agent_mix=_parse_agent_mix(args.agent_mix),
+                agent_mix=_resolve_agent_mix_for_cli(args.agent_mix),
                 out=args.out,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
@@ -14678,7 +14708,7 @@ def main(argv: list[str] | None = None) -> int:
                 pr_body=args.pr_body,
                 lease_ttl_minutes=args.lease_ttl_minutes,
                 batch=args.batch,
-                agent_mix=_parse_agent_mix(args.agent_mix),
+                agent_mix=_resolve_agent_mix_for_cli(args.agent_mix),
                 repair_branch=args.repair_branch,
                 repair_branch_type=args.repair_branch_type,
                 repair_slug=args.repair_slug,

--- a/scripts/agent_loop_quota.example.json
+++ b/scripts/agent_loop_quota.example.json
@@ -1,0 +1,28 @@
+{
+  "_comment": [
+    "Local fallback for agent-mix quota-aware rebalancing (issue #1656).",
+    "Used when agentcat snapshot --json is unavailable OR does not surface the",
+    "weekly remaining percent for that provider. Copy to quota_config.json",
+    "(no .example) and fill in your subscription numbers.",
+    "",
+    "weekly_limit_units: total work-units allowed per 7-day window.",
+    "used_this_week_units: running counter; you maintain this manually (or wire",
+    "  a separate collector). When agentcat works, this file is ignored.",
+    "reset_dow: day-of-week string when your weekly window rolls over (mon/tue/.../sun).",
+    "reset_hour_utc: hour (0-23) UTC when reset occurs.",
+    "",
+    "If both providers' signals come from agentcat, this file has no effect."
+  ],
+  "claude": {
+    "weekly_limit_units": 7500,
+    "used_this_week_units": 0,
+    "reset_dow": "mon",
+    "reset_hour_utc": 0
+  },
+  "codex": {
+    "weekly_limit_units": 3000,
+    "used_this_week_units": 0,
+    "reset_dow": "mon",
+    "reset_hour_utc": 0
+  }
+}

--- a/scripts/agent_loop_quota.py
+++ b/scripts/agent_loop_quota.py
@@ -1,0 +1,423 @@
+"""Quota-aware agent-mix rebalancing (issue #1656).
+
+Reads remaining weekly quota for the Claude and Codex providers from
+``agentcat snapshot --json`` (1st priority) or a local config file
+(``reports/agent_loop/active/quota_config.json``, fallback). Then rebalances
+the static ``claude=5,codex=5`` target so both providers burn down their
+weekly allowance at the same rate ("drain both before reset" policy).
+
+When neither signal is available, the original target is returned untouched
+— the new behaviour is opt-in via signal availability, not via a flag.
+
+This module is intentionally pure-functional: ``read_quota_signals`` does
+I/O via an injectable runner; ``compute_dynamic_target`` is deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable
+
+ACTIVE_LANE_AGENTS = ("claude", "codex")
+
+# Quota IDs surfaced by agentcat 0.x for the 7-day window. Verified empirically
+# 2026-05-28 with /Users/hskim/.local/bin/agentcat 0.x — these are the only
+# weekly entries today; if agentcat renames them, falls through to config.
+_AGENTCAT_WEEKLY_IDS: dict[str, tuple[str, ...]] = {
+    "claude": ("claude:seven_day",),
+    "codex": ("codex:7d",),
+}
+
+_DOW_INDEX = {
+    "mon": 0, "monday": 0,
+    "tue": 1, "tuesday": 1,
+    "wed": 2, "wednesday": 2,
+    "thu": 3, "thursday": 3,
+    "fri": 4, "friday": 4,
+    "sat": 5, "saturday": 5,
+    "sun": 6, "sunday": 6,
+}
+
+
+@dataclass(frozen=True)
+class QuotaState:
+    """Snapshot of one provider's weekly quota.
+
+    ``remaining_pct`` is in [0.0, 100.0]. ``reset_at`` is the next weekly reset
+    in UTC. ``source`` records where the signal came from so the report can
+    explain the rebalance to a human reviewer.
+    """
+
+    remaining_pct: float
+    reset_at: datetime
+    source: str  # "agentcat" | "config"
+
+    def remaining_hours(self, now: datetime) -> float:
+        delta = self.reset_at - now
+        hours = delta.total_seconds() / 3600.0
+        return hours if hours > 0 else 0.0
+
+
+def _snapshot_runner_default(executable: str) -> str:
+    """Default subprocess runner — invokes ``agentcat snapshot --json``."""
+    try:
+        completed = subprocess.run(
+            [executable, "snapshot", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout or ""
+
+
+def _coerce_remaining_pct(raw: object) -> float | None:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        if value < 0 or value > 100:
+            return None
+        return value
+    return None
+
+
+def _coerce_reset_at(raw: object) -> datetime | None:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+        except (OSError, ValueError, OverflowError):
+            return None
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_agentcat_payload(payload: object) -> dict[str, QuotaState | None]:
+    """Pick the weekly quota entry per provider from agentcat snapshot output."""
+    result: dict[str, QuotaState | None] = {agent: None for agent in ACTIVE_LANE_AGENTS}
+    if not isinstance(payload, dict):
+        return result
+    providers = payload.get("providers")
+    if not isinstance(providers, dict):
+        return result
+    for agent, weekly_ids in _AGENTCAT_WEEKLY_IDS.items():
+        provider = providers.get(agent)
+        if not isinstance(provider, dict):
+            continue
+        limits = provider.get("limits")
+        if not isinstance(limits, dict):
+            continue
+        quotas = limits.get("quotas")
+        if not isinstance(quotas, list):
+            continue
+        weekly_entry: dict | None = None
+        for quota in quotas:
+            if not isinstance(quota, dict):
+                continue
+            if str(quota.get("id") or "") in weekly_ids:
+                weekly_entry = quota
+                break
+        if weekly_entry is None:
+            continue
+        remaining_pct = _coerce_remaining_pct(weekly_entry.get("remainingPercent"))
+        reset_at_raw = weekly_entry.get("resetAt")
+        if reset_at_raw is None:
+            reset_at_raw = limits.get("weeklyResetAt")
+        reset_at = _coerce_reset_at(reset_at_raw)
+        if remaining_pct is None or reset_at is None:
+            continue
+        result[agent] = QuotaState(
+            remaining_pct=remaining_pct,
+            reset_at=reset_at,
+            source="agentcat",
+        )
+    return result
+
+
+def _next_weekly_reset(*, reset_dow: int, reset_hour_utc: int, now: datetime) -> datetime:
+    """Compute the next UTC weekly reset >= ``now`` for the given day-of-week + hour."""
+    reset_dow = max(0, min(6, reset_dow))
+    reset_hour_utc = max(0, min(23, reset_hour_utc))
+    candidate = now.astimezone(timezone.utc).replace(
+        hour=reset_hour_utc, minute=0, second=0, microsecond=0
+    )
+    delta_days = (reset_dow - candidate.weekday()) % 7
+    candidate = candidate + timedelta(days=delta_days)
+    if candidate <= now:
+        candidate = candidate + timedelta(days=7)
+    return candidate
+
+
+def _read_config_signals(
+    config_path: Path,
+    *,
+    now: datetime,
+) -> dict[str, QuotaState | None]:
+    """Parse the local ``quota_config.json`` fallback file."""
+    result: dict[str, QuotaState | None] = {agent: None for agent in ACTIVE_LANE_AGENTS}
+    if not config_path.exists():
+        return result
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return result
+    if not isinstance(payload, dict):
+        return result
+    for agent in ACTIVE_LANE_AGENTS:
+        entry = payload.get(agent)
+        if not isinstance(entry, dict):
+            continue
+        weekly_limit = entry.get("weekly_limit_units")
+        used = entry.get("used_this_week_units")
+        if not isinstance(weekly_limit, (int, float)) or not isinstance(used, (int, float)):
+            continue
+        if weekly_limit <= 0:
+            continue
+        remaining_pct = max(0.0, min(100.0, (1.0 - float(used) / float(weekly_limit)) * 100.0))
+        dow_raw = str(entry.get("reset_dow") or "mon").strip().lower()
+        reset_dow = _DOW_INDEX.get(dow_raw)
+        hour_raw = entry.get("reset_hour_utc", 0)
+        try:
+            reset_hour_utc = int(hour_raw)
+        except (TypeError, ValueError):
+            reset_hour_utc = 0
+        if reset_dow is None:
+            continue
+        reset_at = _next_weekly_reset(
+            reset_dow=reset_dow,
+            reset_hour_utc=reset_hour_utc,
+            now=now,
+        )
+        result[agent] = QuotaState(
+            remaining_pct=remaining_pct,
+            reset_at=reset_at,
+            source="config",
+        )
+    return result
+
+
+def read_quota_signals(
+    *,
+    config_path: Path,
+    now: datetime,
+    agentcat_executable: str = "agentcat",
+    snapshot_runner: Callable[[str], str] | None = None,
+) -> dict[str, QuotaState | None]:
+    """Read per-provider weekly quota signals.
+
+    Priority: agentcat snapshot --json (when the binary exists and returns the
+    expected fields), then the local config file. Missing signals stay
+    ``None`` and ``compute_dynamic_target`` falls back to the default mix.
+
+    ``snapshot_runner`` is injectable so tests don't need to spawn the real
+    agentcat binary.
+    """
+    result: dict[str, QuotaState | None] = {agent: None for agent in ACTIVE_LANE_AGENTS}
+
+    runner = snapshot_runner if snapshot_runner is not None else _snapshot_runner_default
+    resolved_executable = shutil.which(agentcat_executable) or agentcat_executable
+    snapshot_text = ""
+    try:
+        snapshot_text = runner(resolved_executable) or ""
+    except Exception:  # pragma: no cover - runner errors are non-fatal
+        snapshot_text = ""
+    if snapshot_text:
+        try:
+            payload = json.loads(snapshot_text)
+        except (json.JSONDecodeError, ValueError):
+            payload = None
+        if payload is not None:
+            result.update({k: v for k, v in _parse_agentcat_payload(payload).items() if v is not None})
+
+    if any(result[agent] is None for agent in ACTIVE_LANE_AGENTS):
+        config_signals = _read_config_signals(config_path, now=now)
+        for agent in ACTIVE_LANE_AGENTS:
+            if result[agent] is None and config_signals.get(agent) is not None:
+                result[agent] = config_signals[agent]
+
+    return result
+
+
+def compute_dynamic_target(
+    default_target: dict[str, int],
+    signals: dict[str, QuotaState | None],
+    *,
+    now: datetime,
+) -> tuple[dict[str, int], str]:
+    """Rebalance the mix target so both providers burn down evenly before reset.
+
+    Returns ``(target_map, explanation)``. ``target_map`` always sums to the
+    same total as ``default_target`` and reserves at least 1 to each lane that
+    started non-zero in the default. ``explanation`` is a single-line string
+    suitable for the agent_mix_report.md observability row.
+    """
+    agents = list(ACTIVE_LANE_AGENTS)
+    default = {a: int(default_target.get(a, 0)) for a in agents}
+    total = sum(max(0, default[a]) for a in agents)
+    if total <= 0:
+        return dict(default), "Quota signals: ignored (default target is zero)"
+
+    known: dict[str, QuotaState] = {}
+    for agent in agents:
+        candidate = signals.get(agent)
+        if isinstance(candidate, QuotaState):
+            known[agent] = candidate
+    if not known:
+        return dict(default), "Quota signals: none available — using default target"
+
+    if len(known) == 1:
+        known_agent, state = next(iter(known.items()))
+        other_agent = next(a for a in agents if a != known_agent)
+        # Compare remaining_pct to the "flat burn" expected at this point in
+        # the week. Slack > +5pp → known lane has cushion → tilt to it.
+        # Slack < -5pp → known lane is running thin → tilt away.
+        hours_left = state.remaining_hours(now)
+        tilt = 0
+        if hours_left > 0:
+            expected_pct = (hours_left / 168.0) * 100.0
+            slack = state.remaining_pct - expected_pct
+            if slack > 5.0:
+                tilt = +1
+            elif slack < -5.0:
+                tilt = -1
+        if tilt != 0 and default[other_agent] - tilt >= 1 and default[known_agent] + tilt >= 1:
+            adjusted = dict(default)
+            adjusted[known_agent] += tilt
+            adjusted[other_agent] -= tilt
+            return (
+                adjusted,
+                _format_explanation(signals, adjusted, partial_agent=known_agent),
+            )
+        return dict(default), _format_explanation(signals, default, partial_agent=known_agent)
+
+    # Both providers known — compute burn-rate weighted shares.
+    burn_rates: dict[str, float] = {}
+    for agent, state in known.items():
+        hours_left = state.remaining_hours(now)
+        if hours_left <= 0:
+            burn_rates[agent] = 0.0
+        else:
+            burn_rates[agent] = max(0.0, state.remaining_pct / hours_left)
+
+    burn_total = sum(burn_rates.values())
+    if burn_total <= 0:
+        return dict(default), _format_explanation(signals, default)
+
+    raw_weights = {a: (burn_rates.get(a, 0.0) / burn_total) * total for a in agents}
+    # Round to integers while preserving the total and a min of 1 per lane.
+    floored = {a: max(1, int(round(raw_weights.get(a, 0.0)))) for a in agents}
+    drift = total - sum(floored.values())
+    while drift != 0:
+        if drift > 0:
+            candidates = sorted(
+                agents, key=lambda a: raw_weights.get(a, 0.0) - floored[a], reverse=True
+            )
+            if not candidates:
+                break
+            floored[candidates[0]] += 1
+            drift -= 1
+        else:
+            candidates = [a for a in agents if floored[a] > 1]
+            if not candidates:
+                break
+            candidates.sort(key=lambda a: raw_weights.get(a, 0.0) - floored[a])
+            floored[candidates[0]] -= 1
+            drift += 1
+
+    return floored, _format_explanation(signals, floored)
+
+
+def _format_explanation(
+    signals: dict[str, QuotaState | None],
+    effective: dict[str, int],
+    *,
+    partial_agent: str | None = None,
+) -> str:
+    """Render the one-line observability hint for agent_mix_report.md."""
+    parts: list[str] = []
+    for agent in ACTIVE_LANE_AGENTS:
+        state = signals.get(agent)
+        if isinstance(state, QuotaState):
+            reset_iso = state.reset_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%MZ")
+            parts.append(
+                f"{agent}={state.remaining_pct:.0f}% (source={state.source}, resets {reset_iso})"
+            )
+        else:
+            parts.append(f"{agent}=unknown")
+    effective_str = ",".join(f"{k}={v}" for k, v in sorted(effective.items()))
+    suffix = ""
+    if partial_agent is not None:
+        suffix = " (partial: only one signal known)"
+    return f"Quota signals: {' / '.join(parts)} → effective={effective_str}{suffix}"
+
+
+def quota_config_default_path(repo_root: Path) -> Path:
+    """Runtime config path — gitignored (user-local, may contain plan info)."""
+    return repo_root / "reports" / "agent_loop" / "active" / "quota_config.json"
+
+
+def quota_config_example_path(repo_root: Path) -> Path:
+    """Tracked example template — under scripts/ so it lands in the repo."""
+    return repo_root / "scripts" / "agent_loop_quota.example.json"
+
+
+def apply_quota_aware_target(
+    agent_mix_policy: dict[str, object],
+    *,
+    now: datetime,
+    repo_root: Path,
+    snapshot_runner: Callable[[str], str] | None = None,
+    agentcat_executable: str | None = None,
+) -> tuple[dict[str, object], str]:
+    """Wrap an ``agent_mix`` policy dict with quota-aware target rebalancing.
+
+    Returns the updated policy dict (target may have been replaced) and the
+    human-readable explanation string. ``agent_mix_policy['quota_explanation']``
+    is set so downstream reporters can surface it.
+    """
+    target_raw = agent_mix_policy.get("target")
+    if not isinstance(target_raw, dict):
+        return agent_mix_policy, "Quota signals: no target in policy"
+    default_target = {k: int(v) for k, v in target_raw.items() if isinstance(v, (int, float))}
+
+    if os.environ.get("BIDMATE_AGENT_LOOP_QUOTA_OFF", "").strip().lower() in {"1", "true", "yes", "on"}:
+        explanation = "Quota signals: disabled via BIDMATE_AGENT_LOOP_QUOTA_OFF"
+        agent_mix_policy = dict(agent_mix_policy)
+        agent_mix_policy["quota_explanation"] = explanation
+        return agent_mix_policy, explanation
+
+    executable = agentcat_executable or os.environ.get("BIDMATE_AGENTCAT", "agentcat")
+    config_path = quota_config_default_path(repo_root)
+    signals = read_quota_signals(
+        config_path=config_path,
+        now=now,
+        agentcat_executable=executable,
+        snapshot_runner=snapshot_runner,
+    )
+    new_target, explanation = compute_dynamic_target(default_target, signals, now=now)
+
+    if new_target == default_target:
+        agent_mix_policy = dict(agent_mix_policy)
+        agent_mix_policy["quota_explanation"] = explanation
+        return agent_mix_policy, explanation
+
+    agent_mix_policy = dict(agent_mix_policy)
+    agent_mix_policy["target"] = new_target
+    agent_mix_policy["quota_explanation"] = explanation
+    return agent_mix_policy, explanation

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3635,8 +3635,8 @@ def test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_leas
                 "cmd": list(cmd),
                 "cwd": kwargs["cwd"],
                 "stdin": kwargs["stdin"],
-                "stdout": kwargs["stdout"].name,
-                "stderr": kwargs["stderr"].name,
+                "stdout": kwargs["stdout"],
+                "stderr_name": getattr(kwargs["stderr"], "name", None),
                 "text": kwargs["text"],
             }
         )
@@ -3664,6 +3664,9 @@ def test_active_codex_runner_execute_spawns_agentic_processes_and_preserves_leas
         assert cmd[-1] == "-"
         assert call["cwd"] == repo
         assert call["stdin"] == subprocess.PIPE
+        assert call["stdout"] == subprocess.PIPE
+        assert call["stderr_name"] is not None
+        assert call["stderr_name"].endswith("/stderr.log")
         assert call["text"] is True
     assert (active / "codex_runs" / "reviewer" / "prompt.md").exists()
     leases = json.loads((active / "leases.json").read_text(encoding="utf-8"))

--- a/tests/test_agent_loop_quota.py
+++ b/tests/test_agent_loop_quota.py
@@ -1,0 +1,493 @@
+"""Tests for issue #1656 — quota-aware agent-mix rebalancing.
+
+Covers the agentcat-payload parser, the config-file fallback, the burn-rate
+target rebalancer, and the integration helper that mutates the policy dict.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop_quota as quota  # noqa: E402
+
+
+def _now_utc() -> datetime:
+    return datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _epoch(dt: datetime) -> int:
+    return int(dt.timestamp())
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BIDMATE_AGENT_LOOP_QUOTA_OFF", raising=False)
+    monkeypatch.delenv("BIDMATE_AGENTCAT", raising=False)
+
+
+# ---------- _parse_agentcat_payload ---------------------------------------
+
+
+def test_parse_agentcat_payload_extracts_weekly_signals() -> None:
+    now = _now_utc()
+    reset_claude = now + timedelta(days=5)
+    reset_codex = now + timedelta(days=4)
+    payload = {
+        "providers": {
+            "claude": {
+                "limits": {
+                    "weeklyResetAt": _epoch(reset_claude),
+                    "quotas": [
+                        {"id": "claude:five_hour", "remainingPercent": 99.0, "resetAt": _epoch(now + timedelta(hours=4))},
+                        {"id": "claude:seven_day", "remainingPercent": 71.0, "resetAt": _epoch(reset_claude)},
+                    ],
+                }
+            },
+            "codex": {
+                "limits": {
+                    "weeklyResetAt": _epoch(reset_codex),
+                    "quotas": [
+                        {"id": "codex:5h", "remainingPercent": 95.0, "resetAt": _epoch(now + timedelta(hours=5))},
+                        {"id": "codex:7d", "remainingPercent": 42.0, "resetAt": _epoch(reset_codex)},
+                    ],
+                }
+            },
+        }
+    }
+    out = quota._parse_agentcat_payload(payload)
+    assert isinstance(out["claude"], quota.QuotaState)
+    assert isinstance(out["codex"], quota.QuotaState)
+    assert out["claude"].remaining_pct == 71.0
+    assert out["claude"].source == "agentcat"
+    assert out["codex"].remaining_pct == 42.0
+    # Reset time matches the 7-day entry, not the 5-hour entry.
+    assert out["claude"].reset_at == reset_claude
+    assert out["codex"].reset_at == reset_codex
+
+
+def test_parse_agentcat_payload_uses_weeklyResetAt_when_quota_resetAt_missing() -> None:
+    now = _now_utc()
+    weekly_reset = now + timedelta(days=3)
+    payload = {
+        "providers": {
+            "claude": {
+                "limits": {
+                    "weeklyResetAt": _epoch(weekly_reset),
+                    "quotas": [
+                        {"id": "claude:seven_day", "remainingPercent": 50.0, "resetAt": None},
+                    ],
+                }
+            }
+        }
+    }
+    out = quota._parse_agentcat_payload(payload)
+    assert isinstance(out["claude"], quota.QuotaState)
+    assert out["claude"].reset_at == weekly_reset
+
+
+def test_parse_agentcat_payload_skips_missing_provider() -> None:
+    payload = {"providers": {"claude": None}}
+    out = quota._parse_agentcat_payload(payload)
+    assert out["claude"] is None
+    assert out["codex"] is None
+
+
+def test_parse_agentcat_payload_skips_when_pct_invalid() -> None:
+    payload = {
+        "providers": {
+            "claude": {
+                "limits": {
+                    "weeklyResetAt": _epoch(_now_utc() + timedelta(days=5)),
+                    "quotas": [{"id": "claude:seven_day", "remainingPercent": None, "resetAt": None}],
+                }
+            }
+        }
+    }
+    out = quota._parse_agentcat_payload(payload)
+    assert out["claude"] is None
+
+
+def test_parse_agentcat_payload_handles_non_dict() -> None:
+    assert quota._parse_agentcat_payload([]) == {"claude": None, "codex": None}
+    assert quota._parse_agentcat_payload("nope") == {"claude": None, "codex": None}
+
+
+# ---------- _read_config_signals -------------------------------------------
+
+
+def test_read_config_signals_computes_pct_from_limit_minus_used(tmp_path: Path) -> None:
+    config = tmp_path / "quota_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "claude": {
+                    "weekly_limit_units": 1000,
+                    "used_this_week_units": 250,
+                    "reset_dow": "mon",
+                    "reset_hour_utc": 0,
+                },
+                "codex": {
+                    "weekly_limit_units": 500,
+                    "used_this_week_units": 400,
+                    "reset_dow": "mon",
+                    "reset_hour_utc": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    now = _now_utc()  # 2026-05-28 = Thursday 12:00 UTC
+    out = quota._read_config_signals(config, now=now)
+    assert isinstance(out["claude"], quota.QuotaState)
+    assert out["claude"].remaining_pct == pytest.approx(75.0)
+    assert out["claude"].source == "config"
+    # Next Monday 00:00 UTC after a Thursday is 4 days away.
+    expected_reset = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+    assert out["claude"].reset_at == expected_reset
+    assert out["codex"].remaining_pct == pytest.approx(20.0)
+
+
+def test_read_config_signals_missing_file_returns_none(tmp_path: Path) -> None:
+    out = quota._read_config_signals(tmp_path / "missing.json", now=_now_utc())
+    assert out == {"claude": None, "codex": None}
+
+
+def test_read_config_signals_malformed_skips(tmp_path: Path) -> None:
+    config = tmp_path / "broken.json"
+    config.write_text("{not json", encoding="utf-8")
+    out = quota._read_config_signals(config, now=_now_utc())
+    assert out == {"claude": None, "codex": None}
+
+
+def test_read_config_signals_zero_limit_skips(tmp_path: Path) -> None:
+    config = tmp_path / "zero.json"
+    config.write_text(
+        json.dumps({"claude": {"weekly_limit_units": 0, "used_this_week_units": 0, "reset_dow": "mon"}}),
+        encoding="utf-8",
+    )
+    out = quota._read_config_signals(config, now=_now_utc())
+    assert out["claude"] is None
+
+
+# ---------- read_quota_signals (priority order) ---------------------------
+
+
+def test_read_quota_signals_agentcat_wins(tmp_path: Path) -> None:
+    config = tmp_path / "quota_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "claude": {
+                    "weekly_limit_units": 100,
+                    "used_this_week_units": 50,
+                    "reset_dow": "mon",
+                    "reset_hour_utc": 0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    now = _now_utc()
+    snapshot = json.dumps(
+        {
+            "providers": {
+                "claude": {
+                    "limits": {
+                        "weeklyResetAt": _epoch(now + timedelta(days=2)),
+                        "quotas": [
+                            {"id": "claude:seven_day", "remainingPercent": 88.0, "resetAt": _epoch(now + timedelta(days=2))}
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    out = quota.read_quota_signals(
+        config_path=config,
+        now=now,
+        snapshot_runner=lambda exe: snapshot,
+    )
+    assert out["claude"].source == "agentcat"
+    assert out["claude"].remaining_pct == 88.0  # agentcat, not config (50%)
+
+
+def test_read_quota_signals_config_fills_gaps(tmp_path: Path) -> None:
+    config = tmp_path / "quota_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "codex": {
+                    "weekly_limit_units": 1000,
+                    "used_this_week_units": 300,
+                    "reset_dow": "mon",
+                    "reset_hour_utc": 0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    now = _now_utc()
+    snapshot = json.dumps(
+        {
+            "providers": {
+                "claude": {
+                    "limits": {
+                        "weeklyResetAt": _epoch(now + timedelta(days=4)),
+                        "quotas": [
+                            {"id": "claude:seven_day", "remainingPercent": 60.0, "resetAt": _epoch(now + timedelta(days=4))}
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    out = quota.read_quota_signals(
+        config_path=config,
+        now=now,
+        snapshot_runner=lambda exe: snapshot,
+    )
+    assert out["claude"].source == "agentcat"
+    assert out["codex"].source == "config"
+    assert out["codex"].remaining_pct == pytest.approx(70.0)
+
+
+def test_read_quota_signals_both_unknown(tmp_path: Path) -> None:
+    out = quota.read_quota_signals(
+        config_path=tmp_path / "absent.json",
+        now=_now_utc(),
+        snapshot_runner=lambda exe: "",
+    )
+    assert out == {"claude": None, "codex": None}
+
+
+def test_read_quota_signals_handles_runner_exception(tmp_path: Path) -> None:
+    def boom(_exe: str) -> str:
+        raise RuntimeError("agentcat crashed")
+
+    out = quota.read_quota_signals(
+        config_path=tmp_path / "absent.json",
+        now=_now_utc(),
+        snapshot_runner=boom,
+    )
+    assert out == {"claude": None, "codex": None}
+
+
+# ---------- compute_dynamic_target -----------------------------------------
+
+
+def test_compute_dynamic_target_default_when_no_signals() -> None:
+    default = {"claude": 5, "codex": 5}
+    new_target, explanation = quota.compute_dynamic_target(
+        default,
+        {"claude": None, "codex": None},
+        now=_now_utc(),
+    )
+    assert new_target == default
+    assert "none available" in explanation.lower() or "default" in explanation.lower()
+
+
+def test_compute_dynamic_target_balances_when_one_provider_has_more_slack() -> None:
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(
+            remaining_pct=90.0,
+            reset_at=now + timedelta(hours=140),
+            source="agentcat",
+        ),
+        "codex": quota.QuotaState(
+            remaining_pct=40.0,
+            reset_at=now + timedelta(hours=120),
+            source="agentcat",
+        ),
+    }
+    new_target, explanation = quota.compute_dynamic_target(
+        {"claude": 5, "codex": 5}, signals, now=now
+    )
+    assert sum(new_target.values()) == 10
+    assert new_target["claude"] > new_target["codex"]
+    assert "effective=" in explanation
+    assert "claude=" in explanation
+    assert "codex=" in explanation
+
+
+def test_compute_dynamic_target_preserves_min_one_per_lane() -> None:
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(remaining_pct=99.0, reset_at=now + timedelta(hours=160), source="agentcat"),
+        "codex": quota.QuotaState(remaining_pct=1.0, reset_at=now + timedelta(hours=160), source="agentcat"),
+    }
+    new_target, _ = quota.compute_dynamic_target(
+        {"claude": 5, "codex": 5}, signals, now=now
+    )
+    assert new_target["codex"] >= 1
+    assert new_target["claude"] >= 1
+    assert sum(new_target.values()) == 10
+
+
+def test_compute_dynamic_target_partial_tilts_when_one_has_slack() -> None:
+    """Claude at 95% but only 60h until reset — way more cushion than flat burn → tilt to claude."""
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(
+            remaining_pct=95.0,
+            reset_at=now + timedelta(hours=60),
+            source="agentcat",
+        ),
+        "codex": None,
+    }
+    new_target, explanation = quota.compute_dynamic_target(
+        {"claude": 5, "codex": 5}, signals, now=now
+    )
+    assert new_target["claude"] == 6
+    assert new_target["codex"] == 4
+    assert "partial" in explanation
+
+
+def test_compute_dynamic_target_partial_reverses_when_one_depleted() -> None:
+    """Claude at 10% with 160h to go — way under flat-burn cushion → tilt away from claude."""
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(
+            remaining_pct=10.0,
+            reset_at=now + timedelta(hours=160),
+            source="agentcat",
+        ),
+        "codex": None,
+    }
+    new_target, _ = quota.compute_dynamic_target(
+        {"claude": 5, "codex": 5}, signals, now=now
+    )
+    assert new_target["claude"] == 4
+    assert new_target["codex"] == 6
+
+
+def test_compute_dynamic_target_partial_no_tilt_when_on_flat_burn() -> None:
+    """Claude at 95% with 160h left (~expected) → no tilt, default 5:5 preserved."""
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(
+            remaining_pct=95.0,
+            reset_at=now + timedelta(hours=160),
+            source="agentcat",
+        ),
+        "codex": None,
+    }
+    new_target, _ = quota.compute_dynamic_target(
+        {"claude": 5, "codex": 5}, signals, now=now
+    )
+    assert new_target == {"claude": 5, "codex": 5}
+
+
+def test_compute_dynamic_target_zero_default_unchanged() -> None:
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(remaining_pct=50.0, reset_at=now + timedelta(hours=100), source="agentcat"),
+        "codex": quota.QuotaState(remaining_pct=50.0, reset_at=now + timedelta(hours=100), source="agentcat"),
+    }
+    new_target, _ = quota.compute_dynamic_target({"claude": 0, "codex": 0}, signals, now=now)
+    assert new_target == {"claude": 0, "codex": 0}
+
+
+def test_compute_dynamic_target_zero_hours_left_falls_back() -> None:
+    now = _now_utc()
+    signals = {
+        "claude": quota.QuotaState(remaining_pct=50.0, reset_at=now - timedelta(hours=1), source="agentcat"),
+        "codex": quota.QuotaState(remaining_pct=50.0, reset_at=now - timedelta(hours=2), source="agentcat"),
+    }
+    new_target, _ = quota.compute_dynamic_target({"claude": 5, "codex": 5}, signals, now=now)
+    assert new_target == {"claude": 5, "codex": 5}
+
+
+# ---------- apply_quota_aware_target ---------------------------------------
+
+
+def test_apply_quota_aware_target_writes_explanation_field(tmp_path: Path) -> None:
+    policy = {"target": {"claude": 5, "codex": 5}}
+    snapshot = json.dumps(
+        {
+            "providers": {
+                "claude": {
+                    "limits": {
+                        "weeklyResetAt": _epoch(_now_utc() + timedelta(days=5)),
+                        "quotas": [
+                            {
+                                "id": "claude:seven_day",
+                                "remainingPercent": 70.0,
+                                "resetAt": _epoch(_now_utc() + timedelta(days=5)),
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    new_policy, explanation = quota.apply_quota_aware_target(
+        policy,
+        now=_now_utc(),
+        repo_root=tmp_path,
+        snapshot_runner=lambda exe: snapshot,
+    )
+    assert "quota_explanation" in new_policy
+    assert new_policy["quota_explanation"] == explanation
+    assert "claude=" in explanation
+    # Codex was unknown — partial-signal path.
+    assert "partial" in explanation
+
+
+def test_apply_quota_aware_target_off_env_disables(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUOTA_OFF", "1")
+    policy = {"target": {"claude": 5, "codex": 5}}
+    new_policy, explanation = quota.apply_quota_aware_target(
+        policy,
+        now=_now_utc(),
+        repo_root=tmp_path,
+        snapshot_runner=lambda exe: "should-not-be-called",
+    )
+    assert new_policy["target"] == {"claude": 5, "codex": 5}
+    assert "disabled" in explanation
+
+
+def test_apply_quota_aware_target_keeps_target_when_no_signals(tmp_path: Path) -> None:
+    policy = {"target": {"claude": 5, "codex": 5}, "window": {"size": 20}}
+    new_policy, _ = quota.apply_quota_aware_target(
+        policy,
+        now=_now_utc(),
+        repo_root=tmp_path,
+        snapshot_runner=lambda exe: "",
+    )
+    assert new_policy["target"] == {"claude": 5, "codex": 5}
+    # quota_explanation still attached for observability.
+    assert "quota_explanation" in new_policy
+
+
+# ---------- _next_weekly_reset ---------------------------------------------
+
+
+def test_next_weekly_reset_advances_to_following_monday_midnight() -> None:
+    # 2026-05-28 is a Thursday.
+    now = datetime(2026, 5, 28, 12, 0, tzinfo=timezone.utc)
+    nxt = quota._next_weekly_reset(reset_dow=0, reset_hour_utc=0, now=now)
+    assert nxt == datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_next_weekly_reset_handles_same_day_after_hour() -> None:
+    # Thursday at 13:00 UTC, reset is Thursday at 09:00 UTC → next week.
+    now = datetime(2026, 5, 28, 13, 0, tzinfo=timezone.utc)
+    nxt = quota._next_weekly_reset(reset_dow=3, reset_hour_utc=9, now=now)
+    assert nxt == datetime(2026, 6, 4, 9, 0, tzinfo=timezone.utc)
+
+
+def test_next_weekly_reset_handles_same_day_before_hour() -> None:
+    # Thursday at 08:00 UTC, reset is Thursday at 09:00 UTC → same day.
+    now = datetime(2026, 5, 28, 8, 0, tzinfo=timezone.utc)
+    nxt = quota._next_weekly_reset(reset_dow=3, reset_hour_utc=9, now=now)
+    assert nxt == datetime(2026, 5, 28, 9, 0, tzinfo=timezone.utc)

--- a/tests/test_agent_loop_streaming.py
+++ b/tests/test_agent_loop_streaming.py
@@ -1,0 +1,247 @@
+"""Tests for issue #1654 — agent-loop live progress streaming.
+
+Covers the JSONL → emoji summary formatter, the env-gated progress emitter,
+and the reader-thread tee for codex subprocess stdout.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_stream_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BIDMATE_AGENT_LOOP_QUIET", raising=False)
+    monkeypatch.delenv("BIDMATE_AGENT_LOOP_RAW", raising=False)
+
+
+def test_stream_enabled_default_true() -> None:
+    assert agent_loop._agent_loop_stream_enabled() is True
+
+
+def test_stream_enabled_quiet_env_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("1", "true", "yes", "ON"):
+        monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", value)
+        assert agent_loop._agent_loop_stream_enabled() is False
+
+
+def test_stream_enabled_quiet_blank_still_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "0")
+    assert agent_loop._agent_loop_stream_enabled() is True
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "")
+    assert agent_loop._agent_loop_stream_enabled() is True
+
+
+def test_emit_progress_writes_and_flushes(capsys: pytest.CaptureFixture[str]) -> None:
+    agent_loop._emit_progress("[active-start] hello world")
+    captured = capsys.readouterr()
+    assert captured.out == "[active-start] hello world\n"
+
+
+def test_emit_progress_noop_when_quiet(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "1")
+    agent_loop._emit_progress("should not appear")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_emit_progress_skips_empty() -> None:
+    # Must not raise / not write — no capsys check needed beyond no exception.
+    agent_loop._emit_progress("")
+
+
+def test_format_jsonl_summary_agent_message() -> None:
+    line = json.dumps({"type": "agent_message", "content": "Reading rag_core.py to understand structure..."})
+    result = agent_loop._format_codex_jsonl_summary("claude-impl", line)
+    assert result.startswith("[claude-impl] 💬 ")
+    assert "Reading rag_core.py" in result
+
+
+def test_format_jsonl_summary_agent_message_nested_msg() -> None:
+    line = json.dumps({"msg": {"type": "agent_message", "content": "Hello from codex"}})
+    result = agent_loop._format_codex_jsonl_summary("codex-review", line)
+    assert "💬" in result
+    assert "Hello from codex" in result
+
+
+def test_format_jsonl_summary_tool_use_extracts_args() -> None:
+    line = json.dumps(
+        {
+            "type": "tool_use",
+            "name": "Read",
+            "input": {"path": "rag_core.py", "limit": 100},
+        }
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "🔧" in result
+    assert "Read(" in result
+    assert "path" in result
+
+
+def test_format_jsonl_summary_exec_command() -> None:
+    line = json.dumps(
+        {"type": "exec_command_begin", "command": ["git", "diff", "--stat"]}
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "⚙" in result
+    assert "git diff" in result
+
+
+def test_format_jsonl_summary_task_complete() -> None:
+    line = json.dumps(
+        {"type": "task_complete", "exit_code": 0, "duration_s": 42.3}
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "✓" in result
+    assert "rc=0" in result
+    assert "42.3" in result
+
+
+def test_format_jsonl_summary_error() -> None:
+    line = json.dumps({"type": "error", "message": "auth required"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "❌" in result
+    assert "auth required" in result
+
+
+def test_format_jsonl_summary_unknown_type_uses_questionmark() -> None:
+    line = json.dumps({"type": "novel_event_v99", "content": "future schema"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "❔" in result
+    assert "novel_event_v99" in result
+
+
+def test_format_jsonl_summary_parse_failure_uses_warn() -> None:
+    result = agent_loop._format_codex_jsonl_summary("impl", "not-a-json-line {{{")
+    assert "⚠" in result
+    assert "not-a-json-line" in result
+
+
+def test_format_jsonl_summary_non_dict_payload() -> None:
+    result = agent_loop._format_codex_jsonl_summary("impl", '"just a string"')
+    assert "⚠" in result
+
+
+def test_format_jsonl_summary_empty_line_returns_empty() -> None:
+    assert agent_loop._format_codex_jsonl_summary("impl", "") == ""
+    assert agent_loop._format_codex_jsonl_summary("impl", "   \n") == ""
+
+
+def test_format_jsonl_summary_raw_env_returns_raw(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_RAW", "1")
+    line = json.dumps({"type": "agent_message", "content": "hi"})
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert result.startswith("[impl] ")
+    # When RAW=1 the unparsed line is returned, so the literal JSON should appear.
+    assert "agent_message" in result
+    assert "💬" not in result
+
+
+def test_format_jsonl_summary_message_segments_list() -> None:
+    # Codex sometimes sends content as a list of segments.
+    line = json.dumps(
+        {
+            "type": "agent_message",
+            "content": [
+                {"text": "Found bug in"},
+                {"text": "retrieve_candidates"},
+            ],
+        }
+    )
+    result = agent_loop._format_codex_jsonl_summary("impl", line)
+    assert "Found bug in" in result
+    assert "retrieve_candidates" in result
+
+
+def test_spawn_codex_reader_thread_writes_file_and_emits(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stream = io.StringIO(
+        json.dumps({"type": "task_started"}) + "\n"
+        + json.dumps({"type": "agent_message", "content": "hello"}) + "\n"
+        + json.dumps({"type": "task_complete", "exit_code": 0}) + "\n"
+    )
+
+    class FakeProc:
+        def __init__(self, stream_: io.StringIO) -> None:
+            self.stdout = stream_
+
+    proc = FakeProc(stream)
+    stdout_path = tmp_path / "session" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "test-session", stdout_path)
+    assert thread is not None
+    thread.join(timeout=5.0)
+    assert not thread.is_alive()
+
+    written = stdout_path.read_text(encoding="utf-8")
+    assert '"task_started"' in written
+    assert '"agent_message"' in written
+    assert '"task_complete"' in written
+
+    captured = capsys.readouterr()
+    assert "▶" in captured.out
+    assert "💬 hello" in captured.out
+    assert "✓ rc=0" in captured.out
+
+
+def test_spawn_codex_reader_thread_none_stdout_creates_empty_file(tmp_path: Path) -> None:
+    class FakeProc:
+        stdout = None
+
+    proc = FakeProc()
+    stdout_path = tmp_path / "no-stdout" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "x", stdout_path)
+    assert thread is None
+    assert stdout_path.exists()
+    assert stdout_path.read_text(encoding="utf-8") == ""
+
+
+def test_spawn_codex_reader_thread_quiet_env_no_stdout_but_file_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("BIDMATE_AGENT_LOOP_QUIET", "1")
+    stream = io.StringIO(json.dumps({"type": "agent_message", "content": "secret"}) + "\n")
+
+    class FakeProc:
+        def __init__(self, stream_: io.StringIO) -> None:
+            self.stdout = stream_
+
+    proc = FakeProc(stream)
+    stdout_path = tmp_path / "quiet" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "q", stdout_path)
+    assert thread is not None
+    thread.join(timeout=5.0)
+    captured = capsys.readouterr()
+    # File contract preserved even when stdout muted.
+    assert "secret" in stdout_path.read_text(encoding="utf-8")
+    # Nothing emitted to stdout under QUIET mode.
+    assert captured.out == ""
+
+
+def test_spawn_codex_reader_thread_no_readline_attr_creates_file(tmp_path: Path) -> None:
+    class FakeStream:
+        # No readline attribute — reader should bail and touch the file.
+        def __repr__(self) -> str:
+            return "<no-readline>"
+
+    class FakeProc:
+        stdout = FakeStream()
+
+    proc = FakeProc()
+    stdout_path = tmp_path / "nopen" / "stdout.jsonl"
+    thread = agent_loop._spawn_codex_reader_thread(proc, "x", stdout_path)
+    assert thread is None
+    assert stdout_path.exists()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`agent-mix "claude=5,codex=5"` 가 정적 50:50 이라 Claude/Codex 둘 중 하나의 주간 한도가 먼저 소진되면 나머지가 리셋 시 그대로 증발한다. agentcat snapshot 의 `providers.<provider>.limits.quotas` 가 weekly remaining_percent + resetAt 을 노출함을 확인 (2026-05-28) — 이걸 읽어서 burn-rate 기반으로 target 을 동적 재가중. **둘 다 리셋 전에 평탄 소진**이 자연스러운 정책.

Closes #1656

Stacked on #1655 (issue-1654-agent-loop-live-progress) — 같은 `scripts/agent_loop.py` 변경 부분 충돌 방지.

## 2. 영향 파일

- `scripts/agent_loop_quota.py` — **신규** (+312 LOC). agentcat 1순위 → config 폴백 → unknown 시 default 5:5
- `scripts/agent_loop.py` — `_resolve_agent_mix_for_cli` 헬퍼 추가 + 3개 CLI 호출 사이트 교체 + `write_agent_mix_report` 에 `quota_explanation` 행 추가 (+33 LOC)
- `tests/test_agent_loop_quota.py` — **신규** (+483 LOC, 27 test): payload 파서 / config 폴백 / 우선순위 / burn-rate / partial-signal / drift 분배 / 환경변수 off 스위치
- `scripts/agent_loop_quota.example.json` — **신규** 설정 템플릿 (런타임 `quota_config.json` 은 사용자 로컬, gitignored)

Load-bearing 파일 없음 (`scripts/agent_loop.py` / `scripts/agent_loop_quota.py` 둘 다 LOAD_BEARING_PATHS 미포함).

## 3. 리스크

- **agentcat schema 드리프트**: 현재 weekly ID 는 `claude:seven_day` / `codex:7d` 로 하드코딩 (`_AGENTCAT_WEEKLY_IDS`). 이름이 바뀌면 weekly 신호 미검출 → config 폴백 → 둘 다 unknown 시 default 5:5 (기존 동작). 즉 schema 깨져도 **새 동작 잃고 기존 동작 유지** — 회귀 없음.
- **agentcat 부재**: `shutil.which` 가 None 이면 runner 가 빈 문자열 반환 → config 폴백.
- **agentcat 응답 지연/실패**: `subprocess.run timeout=5s`. 실패 시 빈 문자열 → 폴백.
- **drift 분배 무한루프**: `while drift != 0` 루프에 `if not candidates: break` 가드 — 모든 lane 이 min=1 이면 빠져나옴 (테스트 `test_compute_dynamic_target_preserves_min_one_per_lane` 보장).
- **취소 스위치**: `BIDMATE_AGENT_LOOP_QUOTA_OFF=1` 로 모든 동적 조절 차단 (정적 50:50 보장) — 디버그/긴급용.

## 4. 테스트

`tests/test_agent_loop_quota.py` 27개 추가, 전체 `tests/test_agent_loop*.py` 222 PASS:

- `_parse_agentcat_payload`: 정상 weekly 추출 / `resetAt=None` 시 `weeklyResetAt` 폴백 / 잘못된 payload skip / 비-dict skip
- `_read_config_signals`: `used / limit` → remaining_pct 계산 / `_next_weekly_reset` 요일+시각 정확 (월요일/같은 요일 전·후)
- `read_quota_signals` 우선순위: agentcat win / config 가 빈자리 보충 / 둘 다 unknown / runner 예외 graceful
- `compute_dynamic_target` 시나리오: 신호 없음→default / 양쪽 known→burn-rate 가중 / min=1 lane 보장 / partial-tilt 양방향 (slack +/-) / flat burn 시 변동 없음 / 0-default 통과 / 음수 hours
- `apply_quota_aware_target`: `quota_explanation` 필드 기록 / `BIDMATE_AGENT_LOOP_QUOTA_OFF=1` 차단

## 5. Eval 영향

RAG/eval surface 미접촉. `scripts/agent_loop.py` 와 신규 `scripts/agent_loop_quota.py` 둘 다 orchestration CLI.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. agent-loop orchestration CLI 변경 — 평가/색인/문서 backend 미접촉.

## 6. 하위 호환

- 새 CLI flag 없음. `--agent-mix` 사양 동일. `_parse_agent_mix` signature 미변경.
- `quota_config.json` 미존재 + agentcat 미설치 시 → 기존 default 5:5 동작 보존.
- `agent_mix.json` policy 직렬화 schema 에 새 키 `quota_explanation` 추가 — 기존 reader (`_load_active_agent_mix`) 가 dict 전체 읽으므로 호환. ADR 0003 답변 계약 미접촉.
- 신규 환경변수 `BIDMATE_AGENT_LOOP_QUOTA_OFF` — opt-in.

## 7. 범위 외

- **`used_this_week_units` 자동 갱신** — config 폴백 모드에서 사용자가 수동 유지. 향후 `agent_mix.json` ledger 의 주간 합산으로 자동화 가능하나 PR 분리.
- **agentcat 자동 설치** — 사용자가 별도 설치. `shutil.which` 미발견 시 빈 문자열 → 폴백.
- **5h 윈도우 신호** — agentcat 가 `claude:five_hour` / `codex:5h` 도 노출하나 본 PR 은 **weekly** 만 다룸 (사용자 요구: "특히 일주일한도").
