### PR TITLE
fix(agent-loop): codex login status를 stdout+stderr 결합에서 검사

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -11951,7 +11951,7 @@ def _active_codex_auth_check(
     summary = _sanitize_inline_text(combined.splitlines()[0] if combined.splitlines() else f"rc={rc}")
     if rc != 0:
         return summary, [f"codex login status failed for ChatGPT auth guard (rc={rc}): {summary}"], []
-    if "Logged in using ChatGPT" not in stdout:
+    if "Logged in using ChatGPT" not in combined:
         return summary, [f"Codex auth mode requires ChatGPT login; got: {summary}"], []
     return "Logged in using ChatGPT", [], []
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3775,6 +3775,36 @@ def test_active_codex_runner_execute_fails_closed_without_codex(tmp_path: Path) 
     assert calls == []
 
 
+def test_active_codex_runner_accepts_chatgpt_login_on_stderr(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+
+    class DummyProc:
+        stdin = None
+        pid = 7100
+
+        def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+            return 0
+
+    def stderr_chatgpt_auth(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="Logged in using ChatGPT\n")
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        repo_root=repo,
+        popen_factory=lambda cmd, **kwargs: calls.append(list(cmd)) or DummyProc(),  # type: ignore[arg-type]
+        which_func=lambda exe: "/bin/codex",
+        auth_runner=stderr_chatgpt_auth,
+    )
+
+    assert result.decision == "completed"
+    assert calls
+    state = json.loads(result.state_path.read_text(encoding="utf-8"))
+    assert state["auth_status"] == "Logged in using ChatGPT"
+    assert not any("requires ChatGPT login" in blocker for blocker in result.blockers)
+
+
 def test_active_codex_runner_requires_chatgpt_login_by_default(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     _write_expanded_active_runner_fixture(repo)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`codex-cli 0.132.0`이 `codex login status`의 "Logged in using ChatGPT" 메시지를 stderr로 출력하는데, 오늘(2026-05-28) #1646 (커밋 `1b370e2`)이 추가한 `_active_codex_auth_check`가 stdout만 검사해 인증 정상(rc=0)인 경우에도 항상 blocker가 추가됨. 결과: `make 시작` (agent-loop-active-codex-runner)이 항상 `Error 1`로 차단되어 active-loop 진입 불가.

수정: stdout 검사를 `combined` (이미 동일 함수 11950 라인에서 stdout+stderr로 계산되어 summary 추출에 사용 중)으로 변경. 1줄. stdout/stderr 출력 위치 변화에 강건해짐.

Closes #1659

## 2. 영향 파일

- `scripts/agent_loop.py:11954` — 1줄 (`stdout` → `combined`). Not load-bearing (`scripts/_governance.py --is-load-bearing` rc=1).
- `tests/test_agent_loop.py` — `test_active_codex_runner_accepts_chatgpt_login_on_stderr` 회귀 테스트 신규 (+30 LOC).

## 3. 리스크

- `combined`가 stdout+stderr 결합이므로, 미래 CLI가 stderr에 다른 컨텍스트 (예: 경고)를 출력하더라도 magic string "Logged in using ChatGPT"이 포함되면 통과 — 의도된 동작. ChatGPT 로그인 여부 판정에 stderr 검사를 추가한 것이라 false-negative만 줄이고 false-positive 위험 없음.
- API key login 케이스(`"Logged in using API key"`)는 여전히 차단 (기존 `test_active_codex_runner_requires_chatgpt_login_by_default` 통과).
- 로그인 실패 (rc != 0) 케이스도 그대로 차단 (기존 `test_active_codex_runner_blocks_when_login_status_fails` 통과).

## 4. 테스트

- 신규 회귀: `tests/test_agent_loop.py::test_active_codex_runner_accepts_chatgpt_login_on_stderr` — stderr에 magic string이 있는 실 CLI 동작 모킹, `decision == "completed"` 확인.
- 타겟 suite: `pytest tests/test_agent_loop.py -k "active_codex_runner" -q` → 11 passed (기존 10 + 신규 1).
- 로컬 게이트: `make test-fast` — 2957 passed, 12 failed (전부 `tests/test_langgraph_orchestrator_regression.py` + `tests/test_langgraph_performance_profile.py` 의 stage_latency / orchestrator JSON 비교 — 두 파일 모두 본 PR에서 미수정, `git log main..HEAD -- <files>` 빈 결과. 본 PR scope 외 사전 회귀로 판단, 별도 follow-up). FlagEmbedding 설치 환경의 real-model fallback 사용 — `make test-fast` 결과는 CI 전체 통과를 보장하지 않으며 머지는 CI green hard-gate.

## 5. Eval 영향

N/A — retrieval/answer/verifier path 무관, agent-loop orchestration 수정.

### 5b. Real-data delta

N/A — `scripts/agent_loop.py`는 load-bearing path 아님 (`scripts/_governance.py --is-load-bearing scripts/agent_loop.py` rc=1).

## 6. 하위 호환

깨짐 없음. 동일 함수의 success/blocker tuple 반환 계약 유지, auth_status state JSON 키 유지. CLI가 미래에 stdout으로 돌아와도 `combined` 검사라 그대로 통과.

## 7. 범위 외

- `codex login status`의 stdout/stderr 거동을 codex-cli 측에 보고 (별 PR 범위)
- 사전 LangGraph stage_latency 테스트 실패 12건 (별 이슈)