### PR TITLE
fix(test): use deepcopy_index_safe for Chroma-backed index

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,10 @@
           {
             "type": "command",
             "command": "bash scripts/claude-hooks/stop-agent-loop.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/stop-experiment-report.sh"
           }
         ]
       }

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ ask:
 
 eval:
 	$(PYTHON) eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
+	@$(MAKE) -s experiment-report-html
 
 # Cost-quality Pareto frontier table (and PNG if matplotlib installed)
 # from the latest reports/eval_summary.json. Read-only consumer — see
@@ -128,6 +129,14 @@ pareto:
 # when enough source data is available.
 cost-frontier:
 	$(PYTHON) scripts/plot_cost_frontier.py
+
+# Auto-render paired HTML next to every reports/**/*.aggregate.json,
+# reports/**/eval_summary.json, and reports/retrieval/**/REPORT.md.
+# Idempotent — only stale or missing pairs are rendered. Aggregate-only
+# (ADR 0005); raw_results.json / data_list*.csv / data/private/** denied.
+# Issue #1661. See docs/operations/experiment-report-html.md.
+experiment-report-html:
+	@$(PYTHON) scripts/render_experiment_report_html.py --auto-scan --quiet
 
 # Publish the demo image to GHCR so reviewers can `docker run <image>`
 # without cloning the repo (issue #123). Requires `docker login ghcr.io`
@@ -187,6 +196,7 @@ korean-public-eval: korean-public-fetch
 # guaranteeing `.hook-fires.log` is writable from the first dev action.
 smoke: install-hooks
 	bash scripts/smoke.sh
+	@$(MAKE) -s experiment-report-html
 
 # Cross-machine reproducibility hash. Runs the smoke eval and prints a
 # SHA-256 over the environment-invariant subset of reports/eval_summary.json
@@ -1092,6 +1102,7 @@ real-eval-v2-check:
 	  REAL_EVAL_INDEX_DIR="$(REAL100_V2_INDEX_DIR)" \
 	  REAL_EVAL_REPORT_DIR="$(REAL100_V2_REPORT_DIR)" \
 	  $(PYTHON) scripts/real_eval_paths.py check
+	@$(MAKE) -s experiment-report-html
 
 real-eval-v2-guard:
 	$(PYTHON) scripts/check_real100_v2_only.py
@@ -1156,12 +1167,14 @@ real-eval-delta:
 # dirty-worktree gate for a deliberate dirty baseline (#1148).
 real-eval-baseline-update:
 	$(PYTHON) scripts/write_real_eval_baseline.py $(if $(STRICT),--strict,) $(if $(ALLOW_DIRTY),--allow-dirty,)
+	@$(MAKE) -s experiment-report-html
 
 # Render the chronological real-data history table into
 # docs/real-data/private-100-doc-experiments.md (between the
 # real-eval-history-{start,end} markers). Aggregate-only.
 real-eval-history-render:
 	$(PYTHON) scripts/render_real_eval_history.py
+	@$(MAKE) -s experiment-report-html
 
 # Verify the rendered history table is up to date with committed
 # aggregate snapshots. Suitable for pre-PR gating.

--- a/docs/operations/experiment-report-html.md
+++ b/docs/operations/experiment-report-html.md
@@ -1,0 +1,93 @@
+# 실험 결과 HTML 자동 생성
+
+실험 산출물(`reports/**/*.aggregate.json`, `reports/**/eval_summary.json`,
+`reports/retrieval/**/REPORT.md`) 옆에 사람이 브라우저로 훑을 수 있는 짝
+`.html` 을 자동 생성한다. CLAUDE.md L51 "AI 가 이어받을 문서는 Markdown,
+사람이 검토할 문서는 HTML" 원칙의 실험 표면 구현.
+
+진입점은 `scripts/render_experiment_report_html.py` (issue #1661). 의존성 0
+— `scripts/html_report.py` 의 4유틸만 재사용한다. ADR 0005 boundary 는
+`scripts/_governance.py` 의 기존 함수/상수를 그대로 재사용해서 pre-commit
+스캐너와 동일하게 강제된다.
+
+## 트리거 경로 (이중화)
+
+| 경로 | 어디서 | 언제 | 비고 |
+|---|---|---|---|
+| **정상** Makefile inline | `eval` / `smoke` / `real-eval-v2-check` / `real-eval-baseline-update` / `real-eval-history-render` 마지막 step | target 실행 직후 | `@$(MAKE) -s experiment-report-html` |
+| **안전망** Stop hook | `scripts/claude-hooks/stop-experiment-report.sh` | 매 Claude Code Stop 이벤트 | ad-hoc `python3 eval/run_eval.py …` 같은 우회 경로 커버 |
+
+두 경로 모두 동일 스크립트를 호출하고 stale/missing 짝만 렌더해서 멱등이다.
+
+## 입력 allowlist
+
+- `reports/**/*.aggregate.json` — 모든 aggregate 표면 (real100, real100_v2,
+  retrieval, rag_pipeline 등)
+- `reports/**/eval_summary.json` — smoke / eval 산출물
+- `reports/retrieval/**/REPORT.md` — retrieval-eval skill phase 보고서
+
+## 입력 denylist (ADR 0005 boundary)
+
+다음은 자동으로 거부된다 (exit 2 `denied`, stderr 에 사유):
+
+- 파일명: `raw_results.json`, `data_list*.csv`
+- 경로 부분: `data/private/`, `outputs/`
+- top-level 키: `chunk_text`, `raw_text`, `answer_text`
+- `reports/retrieval/phase4*` 아래: `_governance.PHASE4_PRIVATE_KEYS`
+  (`query`, `sample_queries`, `gold_agency`, `gold_project`,
+  `extracted_agency`, `extracted_project`)
+- `EVAL_PRIVACY_ARTIFACT_GLOBS` (`reports/retrieval`, `reports/real100`,
+  `reports/real100_v2`) 아래: `_governance.find_eval_private_text`
+  (한글 문자 + 콜론 포함 dict key)
+
+2026-05-21 #1144 (realistic-metadata `raw_results.json` 의 `gold_agency`
+실값 committed 노출 → history-rewrite) 재발 방지가 명시 동기.
+
+## 수동 호출
+
+```bash
+# 단일 파일
+python3 scripts/render_experiment_report_html.py \
+  --input reports/real100_v2/baseline.aggregate.json
+
+# 전체 reports/ 스캔, stale 만 렌더
+python3 scripts/render_experiment_report_html.py --auto-scan
+
+# stale 가 있는지만 확인 (exit 1 if stale, 0 otherwise)
+python3 scripts/render_experiment_report_html.py --check --auto-scan
+
+# Makefile target (auto-scan + quiet 의 thin wrapper)
+make experiment-report-html
+```
+
+## Stop hook escape hatch
+
+```bash
+# 비활성화 (해당 shell session 한정)
+BIDMATE_EXPERIMENT_REPORT_STOP_HOOK=0
+
+# 강제 발화 테스트
+BIDMATE_EXPERIMENT_REPORT_FORCE=1 \
+  bash scripts/claude-hooks/stop-experiment-report.sh
+```
+
+## 큰 파일 가드
+
+5 MB 초과 입력은 자동 skip + stderr 경고. 현재 모든 aggregate 표면이
+200 KB 미만이라 실질적으로 도달하지 않는 보호선.
+
+## Multi-worktree 주의
+
+각 워크트리는 자체 `reports/` 디렉터리를 갖는 게 기본이다. 동일 reports/
+디렉터리를 공유하는 경우 HTML write 가 race 할 수 있어서 atomic write
+(`tempfile.NamedTemporaryFile` + `os.replace`) 로 완화하지만, 동시 실행은
+권장하지 않는다.
+
+## Non-goals
+
+- Markdown → 풍부한 HTML 변환 (헤더/링크/볼드 등). 현재는
+  `<pre class="markdown">` plaintext escape + 첫 `# ` 라인 → title 정도의
+  최소 변환. mistune/markdown 라이브러리 도입은 별 PR.
+- HTML 을 `docs/leaderboard/` 같은 공개 surface 로 배포. 현 PR 은
+  `reports/**/*.html` 로컬/private 용도만.
+- aggregate 산출물 자체의 키 스키마 변경 (view 레이어 only).

--- a/scripts/claude-hooks/stop-experiment-report.sh
+++ b/scripts/claude-hooks/stop-experiment-report.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook — experiment-result HTML safety net (issue #1661).
+#
+# Enforcement: pipeline (local report refresh only; not a tool-call gate).
+# Classification rationale: Stop-hook fires after the assistant reply ends and
+# only writes paired .html files alongside existing aggregate/markdown reports
+# under reports/. It never refuses tool use, never mutates git, and never
+# performs shipping side-effects.
+#
+# Why this exists: Makefile targets render the paired HTML inline, but ad-hoc
+# `python3 eval/run_eval.py ...` paths bypass that. This hook is the safety net
+# that catches stale/missing pairs on the next Stop event.
+#
+# Disable per-shell with:   BIDMATE_EXPERIMENT_REPORT_STOP_HOOK=0
+# Force-run for testing:    BIDMATE_EXPERIMENT_REPORT_FORCE=1
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+FIRE_LOG="$REPO_ROOT/.claude/.hook-fires.log"
+
+if [[ "${BIDMATE_EXPERIMENT_REPORT_STOP_HOOK:-1}" != "1" ]]; then
+  exit 0
+fi
+
+cd "$REPO_ROOT" || exit 0
+
+if [[ ! -d reports ]]; then
+  exit 0
+fi
+
+# Fast path: if nothing is stale, exit silently. Render only the diff.
+if python3 scripts/render_experiment_report_html.py --check --auto-scan --quiet 2>/dev/null; then
+  : # 0 stale — no-op
+else
+  # Exit code 1 from --check means stale pairs exist; render them now.
+  python3 scripts/render_experiment_report_html.py --auto-scan 2>&1 || true
+fi
+
+python3 scripts/_governance.py --emit-fire \
+  --outcome pipeline_end --hook experiment-report --category stop-report \
+  --path reports \
+  --fire-log "$FIRE_LOG" 2>/dev/null || true
+
+exit 0

--- a/scripts/render_experiment_report_html.py
+++ b/scripts/render_experiment_report_html.py
@@ -1,0 +1,417 @@
+"""Auto-render experiment-result HTML pairs alongside aggregate/markdown reports.
+
+CLI surface (issue #1661):
+
+    python3 scripts/render_experiment_report_html.py --auto-scan
+    python3 scripts/render_experiment_report_html.py --input reports/real100_v2/baseline.aggregate.json
+    python3 scripts/render_experiment_report_html.py --check --auto-scan --quiet
+
+Boundary: aggregate-only. Denylist (filename / path / JSON keys / values) is
+delegated to scripts/_governance.py so the gate matches the existing ADR 0005
+pre-commit scanner exactly. No raw_results.json, no data_list*.csv,
+no data/private/**, no PHASE4_PRIVATE_KEYS, no PRIVATE_REDACTED_FORBIDDEN_KEYS,
+no Hangul values in eval aggregates.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# Reuse: presentation-only HTML helpers (zero deps, escapes at boundary).
+from html_report import (  # noqa: E402  (sys.path injection above)
+    html_text,
+    render_badge,
+    render_document,
+    render_status_card,
+    render_table,
+)
+
+# Reuse: same boundary functions the pre-commit ADR 0005 scanner uses.
+import _governance as _gov  # noqa: E402
+
+ALLOW_AGGREGATE_SUFFIX = ".aggregate.json"
+ALLOW_EVAL_SUMMARY = "eval_summary.json"
+ALLOW_REPORT_MD = "REPORT.md"
+
+DENY_FILENAMES = frozenset({"raw_results.json"})
+DENY_FILENAME_PREFIXES = ("data_list",)
+DENY_PATH_SEGMENTS = ("data/private/", "outputs/")
+
+VALUE_TRUNCATE_CHARS = 2000
+MAX_INPUT_BYTES = 5 * 1024 * 1024  # 5 MB skip gate
+HUMAN_KEY_BLOCKLIST = frozenset(
+    {
+        # Defensive extra layer above _governance.PRIVATE_REDACTED_FORBIDDEN_KEYS:
+        # any of these in a top-level aggregate JSON means the value almost
+        # certainly leaks private RFP content rather than aggregate metrics.
+        "chunk_text",
+        "raw_text",
+        "answer_text",
+    }
+)
+
+EXIT_OK = 0
+EXIT_STALE = 1  # used only by --check to mark "needs render"
+EXIT_DENIED = 2
+EXIT_BAD_INPUT = 3
+
+
+# ---------------------------------------------------------------------------
+# Discovery + stale detection
+
+
+def _iter_candidates(reports_root: Path) -> Iterable[Path]:
+    """Yield every allowlisted experiment artifact under reports/."""
+    if not reports_root.is_dir():
+        return
+    for path in reports_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if _is_denied_path(path):
+            continue
+        if path.name.endswith(ALLOW_AGGREGATE_SUFFIX):
+            yield path
+        elif path.name == ALLOW_EVAL_SUMMARY:
+            yield path
+        elif path.name == ALLOW_REPORT_MD and "retrieval" in path.parts:
+            yield path
+
+
+def _is_denied_path(path: Path) -> bool:
+    name = path.name
+    if name in DENY_FILENAMES:
+        return True
+    if any(name.startswith(prefix) for prefix in DENY_FILENAME_PREFIXES):
+        return True
+    posix = path.as_posix()
+    return any(seg in posix for seg in DENY_PATH_SEGMENTS)
+
+
+def _paired_html(input_path: Path) -> Path:
+    if input_path.name.endswith(ALLOW_AGGREGATE_SUFFIX):
+        stem = input_path.name[: -len(".json")]
+        return input_path.with_name(f"{stem}.html")
+    if input_path.name == ALLOW_EVAL_SUMMARY:
+        return input_path.with_name("eval_summary.html")
+    if input_path.name == ALLOW_REPORT_MD:
+        return input_path.with_name("REPORT.html")
+    return input_path.with_suffix(".html")
+
+
+def stale_pairs(reports_root: Path) -> list[Path]:
+    """Return inputs whose paired .html is missing or older than the source."""
+    out: list[Path] = []
+    for src in _iter_candidates(reports_root):
+        dst = _paired_html(src)
+        if not dst.exists() or dst.stat().st_mtime < src.stat().st_mtime:
+            out.append(src)
+    return sorted(out)
+
+
+# ---------------------------------------------------------------------------
+# Boundary checks (delegated to _governance.py)
+
+
+def _violates_boundary(input_path: Path, payload: object) -> str | None:
+    """Return None if safe, otherwise a short reason string.
+
+    Scoping mirrors scripts/_governance.py exactly so we never raise a
+    false-positive that the pre-commit ADR 0005 scanner wouldn't also raise:
+
+    - filename/path denylist applies everywhere
+    - HUMAN_KEY_BLOCKLIST (chunk_text / raw_text / answer_text) applies
+      everywhere — these never belong in an aggregate
+    - find_private_keys (PHASE4_PRIVATE_KEYS) applies only under
+      reports/retrieval/phase4*
+    - find_eval_private_text (Hangul / colon-keys) applies only under
+      EVAL_PRIVACY_ARTIFACT_GLOBS (reports/retrieval, real100, real100_v2)
+    - find_redacted_summary_forbidden_fields applies only to the single
+      redacted summary path, which is NOT in our allowlist anyway
+    """
+    if _is_denied_path(input_path):
+        return f"denied filename/path: {input_path.name}"
+    if not isinstance(payload, dict):
+        return None
+    for key in payload:
+        if key in HUMAN_KEY_BLOCKLIST:
+            return f"top-level key '{key}' suggests raw content, not aggregate"
+    posix = input_path.as_posix()
+    if "reports/retrieval/phase4" in posix:
+        phase4_hits = _gov.find_private_keys(payload)
+        if phase4_hits:
+            return f"PHASE4_PRIVATE_KEYS hit: {sorted(phase4_hits)}"
+    if any(g in posix for g in _gov.EVAL_PRIVACY_ARTIFACT_GLOBS):
+        private_text = _gov.find_eval_private_text(payload)
+        if private_text:
+            return f"eval-privacy text hit: {sorted(private_text)}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+
+
+def _truncate(value: object) -> str:
+    s = str(value)
+    if len(s) > VALUE_TRUNCATE_CHARS:
+        return s[:VALUE_TRUNCATE_CHARS] + f"… [truncated {len(s)} chars]"
+    return s
+
+
+def _tone_for_metric(name: str, mean: float) -> str:
+    name_l = name.lower()
+    if "accuracy" in name_l or "recall" in name_l or "precision" in name_l:
+        if mean >= 0.7:
+            return "ok"
+        if mean >= 0.4:
+            return "warn"
+        return "danger"
+    return "neutral"
+
+
+def _render_ci_table(ci: dict) -> str:
+    rows = []
+    for metric, stats in sorted(ci.items()):
+        if not isinstance(stats, dict):
+            continue
+        mean = stats.get("mean")
+        lo = stats.get("ci_lo")
+        hi = stats.get("ci_hi")
+        n = stats.get("n")
+        mean_str = f"{mean:.4f}" if isinstance(mean, (int, float)) else _truncate(mean)
+        ci_str = (
+            f"[{lo:.4f}, {hi:.4f}]"
+            if isinstance(lo, (int, float)) and isinstance(hi, (int, float))
+            else "—"
+        )
+        tone = _tone_for_metric(metric, mean) if isinstance(mean, (int, float)) else "neutral"
+        rows.append((metric, render_badge(mean_str, tone=tone), ci_str, n if n is not None else "—"))
+    return render_table(
+        ["metric", "mean", "95% CI", "n"],
+        [(html_text(r[0]), r[1], html_text(r[2]), html_text(r[3])) for r in rows],
+        empty_message="no CI block",
+    )
+
+
+def _render_kv_grid(d: dict) -> str:
+    cards: list[str] = []
+    for key, value in d.items():
+        if isinstance(value, (dict, list)):
+            continue
+        cards.append(render_status_card(key, _truncate(value)))
+    if not cards:
+        return ""
+    return f'<section class="panel"><div class="grid">{"".join(cards)}</div></section>'
+
+
+def _render_generic_table(d: dict) -> str:
+    rows = [(html_text(k), html_text(_truncate(v))) for k, v in sorted(d.items())]
+    return render_table(["key", "value"], rows, empty_message="empty")
+
+
+def _render_aggregate_body(payload: dict) -> str:
+    sections: list[str] = []
+
+    # Top-level scalars (e.g. ablation_full mean values).
+    sections.append(_render_kv_grid(payload))
+
+    for key in sorted(payload):
+        value = payload[key]
+        if not isinstance(value, dict):
+            continue
+        if key == "ci":
+            sections.append('<section class="panel"><h2>CI (95%)</h2>')
+            sections.append(_render_ci_table(value))
+            sections.append("</section>")
+            continue
+        scalars = {k: v for k, v in value.items() if not isinstance(v, (dict, list))}
+        nested_ci = value.get("ci") if isinstance(value.get("ci"), dict) else None
+        nested_outcomes = (
+            value.get("abstention_outcomes")
+            if isinstance(value.get("abstention_outcomes"), dict)
+            else None
+        )
+        sections.append(f'<section class="panel"><h2>{html_text(key)}</h2>')
+        if scalars:
+            sections.append(_render_kv_grid(scalars))
+        if nested_outcomes:
+            sections.append("<h3>abstention outcomes</h3>")
+            sections.append(_render_generic_table(nested_outcomes))
+        if nested_ci:
+            sections.append("<h3>CI (95%)</h3>")
+            sections.append(_render_ci_table(nested_ci))
+        sections.append("</section>")
+
+    return "\n".join(s for s in sections if s)
+
+
+def _render_markdown_body(text: str) -> tuple[str, str]:
+    """Return (title, body_html). Plaintext-escape; no library."""
+    title = "REPORT.md"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            title = stripped[2:].strip() or title
+            break
+    return title, (
+        '<section class="panel">'
+        f'<pre class="markdown" style="white-space:pre-wrap;overflow-wrap:anywhere;'
+        f'font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;'
+        f'font-size:13px;">{html_text(text)}</pre>'
+        "</section>"
+    )
+
+
+def _rel_path(p: Path) -> Path:
+    try:
+        return p.relative_to(REPO_ROOT) if p.is_absolute() else p
+    except ValueError:
+        return p
+
+
+def render_html(input_path: Path) -> str:
+    if input_path.stat().st_size > MAX_INPUT_BYTES:
+        raise ValueError(f"input exceeds {MAX_INPUT_BYTES} bytes: {input_path}")
+    footer = (
+        f"rendered {_dt.datetime.now(_dt.timezone.utc).isoformat(timespec='seconds')} "
+        f"by scripts/render_experiment_report_html.py — aggregate-only (ADR 0005)"
+    )
+    subtitle = f"source: {_rel_path(input_path)}"
+    if input_path.suffix == ".json":
+        payload = json.loads(input_path.read_text(encoding="utf-8"))
+        violation = _violates_boundary(input_path, payload)
+        if violation:
+            raise PermissionError(violation)
+        if not isinstance(payload, dict):
+            raise ValueError(f"top-level JSON must be dict, got {type(payload).__name__}")
+        body = _render_aggregate_body(payload)
+        return render_document(
+            title=f"{input_path.name}",
+            subtitle=subtitle,
+            body=body,
+            footer=footer,
+        )
+    text = input_path.read_text(encoding="utf-8")
+    title, body = _render_markdown_body(text)
+    return render_document(
+        title=title,
+        subtitle=subtitle,
+        body=body,
+        footer=footer,
+    )
+
+
+def _atomic_write(dst: Path, content: str) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".html-render-", dir=str(dst.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp, dst)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def _render_one(input_path: Path, *, quiet: bool) -> int:
+    try:
+        html = render_html(input_path)
+    except PermissionError as exc:
+        print(f"DENIED {input_path}: {exc}", file=sys.stderr)
+        return EXIT_DENIED
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"SKIP {input_path}: {exc}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+    dst = _paired_html(input_path)
+    _atomic_write(dst, html)
+    if not quiet:
+        print(f"rendered {_rel_path(dst)}")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="Single allowlisted artifact")
+    parser.add_argument(
+        "--auto-scan",
+        action="store_true",
+        help="Walk reports/ and render every stale or missing pair",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero (1) if any pair is stale; do not render",
+    )
+    parser.add_argument("--quiet", action="store_true")
+    parser.add_argument(
+        "--reports-root", type=Path, default=REPO_ROOT / "reports",
+        help="Override reports root (mainly for tests)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input and not args.auto_scan:
+        parser.error("one of --input or --auto-scan is required")
+
+    if args.input:
+        if not args.input.exists():
+            print(f"input not found: {args.input}", file=sys.stderr)
+            return EXIT_BAD_INPUT
+        if _is_denied_path(args.input):
+            print(
+                f"DENIED {args.input}: filename/path denied by ADR 0005 boundary",
+                file=sys.stderr,
+            )
+            return EXIT_DENIED
+        return _render_one(args.input, quiet=args.quiet)
+
+    stale = stale_pairs(args.reports_root)
+    if args.check:
+        if stale:
+            if not args.quiet:
+                print(f"{len(stale)} stale HTML pair(s)")
+                for src in stale:
+                    print(f"  stale: {_rel_path(src)}")
+            return EXIT_STALE
+        if not args.quiet:
+            print("0 stale HTML pairs")
+        return EXIT_OK
+
+    if not stale:
+        if not args.quiet:
+            print("0 stale HTML pairs — nothing to render")
+        return EXIT_OK
+
+    rendered = 0
+    failed = 0
+    for src in stale:
+        rc = _render_one(src, quiet=True)
+        if rc == EXIT_OK:
+            rendered += 1
+        else:
+            failed += 1
+    summary = f"rendered {rendered} HTML reports"
+    if failed:
+        summary += f" ({failed} failed — see stderr)"
+    if not args.quiet:
+        print(summary)
+    return EXIT_OK if failed == 0 else EXIT_BAD_INPUT
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_chroma_safe_clone.py
+++ b/tests/_chroma_safe_clone.py
@@ -1,0 +1,38 @@
+"""Deep-copy an index dict without crashing on the Chroma SWIG native handle.
+
+After #1635 made Chroma the canonical baseline backend, `load_index()`'s
+return dict carries `_vector_store` = `chromadb.PersistentClient`, whose
+internal `builtins.Bindings` cannot be pickled by `copy.deepcopy`. Tests
+that previously used `copy.deepcopy(index)` for per-run isolation now hit
+`TypeError: cannot pickle 'builtins.Bindings' object`.
+
+The store handle is read-only on the test path (search only, no writes), so
+sharing one handle between original and clone is safe. Only the mutable
+Python state (chunks, documents, metadata, _vector_store_backend label)
+needs isolation.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+_SHARED_HANDLE_KEYS: tuple[str, ...] = ("_vector_store",)
+_SHARED_LABEL_KEYS: tuple[str, ...] = ("_vector_store_backend",)
+
+
+def deepcopy_index_safe(index: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of `index` with the native vector-store handle shared.
+
+    The original `index` is not mutated.
+    """
+    extracted: dict[str, Any] = {}
+    skeleton: dict[str, Any] = {}
+    shared = _SHARED_HANDLE_KEYS + _SHARED_LABEL_KEYS
+    for key, value in index.items():
+        if key in shared:
+            extracted[key] = value
+        else:
+            skeleton[key] = value
+    cloned = copy.deepcopy(skeleton)
+    cloned.update(extracted)
+    return cloned

--- a/tests/test_langgraph_orchestrator_regression.py
+++ b/tests/test_langgraph_orchestrator_regression.py
@@ -14,13 +14,13 @@ local install), the regression runs.
 
 from __future__ import annotations
 
-import copy
 import json
-import os
 import unittest
 from pathlib import Path
 
 import pytest
+
+from tests._chroma_safe_clone import deepcopy_index_safe
 
 # Skip the whole module if langgraph isn't installed. The graph module
 # imports langgraph lazily, but the dispatch test pretends to use it,
@@ -107,7 +107,7 @@ def test_langgraph_orchestrator_json_identical_to_direct(
 
     monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "direct")
     direct_result = rag_core.run_rag_query(
-        copy.deepcopy(index),
+        deepcopy_index_safe(index),
         query,
         pipeline=pipeline,
     )
@@ -117,7 +117,7 @@ def test_langgraph_orchestrator_json_identical_to_direct(
 
     monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "langgraph")
     graph_result = rag_core.run_rag_query(
-        copy.deepcopy(index),
+        deepcopy_index_safe(index),
         query,
         pipeline=pipeline,
     )
@@ -149,7 +149,7 @@ def test_naive_baseline_skips_langgraph_dispatch(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "langgraph")
     result = rag_core.run_rag_query(
-        copy.deepcopy(index),
+        deepcopy_index_safe(index),
         "기관 A의 AI 요구사항을 알려줘",
         pipeline="naive_baseline",
     )
@@ -230,7 +230,7 @@ def test_phase_analyze_short_circuits_for_context_clarification(monkeypatch: pyt
     # triggers ``needs_clarification`` — the analyze phase emits the
     # context-clarification result without entering retrieval.
     ctx = rag_core._build_run_context(
-        copy.deepcopy(index),
+        deepcopy_index_safe(index),
         "그건 어떻게 돼?",
         top_k=None,
         context_entities=None,

--- a/tests/test_langgraph_performance_profile.py
+++ b/tests/test_langgraph_performance_profile.py
@@ -15,7 +15,6 @@ Run with ``-s`` to see median timings printed:
 """
 from __future__ import annotations
 
-import copy
 import os
 import statistics
 import time
@@ -23,6 +22,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
+from tests._chroma_safe_clone import deepcopy_index_safe
 
 pytest.importorskip("langgraph")
 
@@ -54,7 +55,7 @@ def _has_local_index() -> bool:
 def _run(index: Any, orchestrator: str, *, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setenv("BIDMATE_ORCHESTRATOR", orchestrator)
     monkeypatch.setattr(rag_core, "_PROCESS_WARM", False, raising=False)
-    return rag_core.run_rag_query(copy.deepcopy(index), _QUERY, pipeline=_PIPELINE)
+    return rag_core.run_rag_query(deepcopy_index_safe(index), _QUERY, pipeline=_PIPELINE)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_render_experiment_report_html.py
+++ b/tests/test_render_experiment_report_html.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/render_experiment_report_html.py (issue #1661).
+
+Covers:
+  1. Normal aggregate.json → HTML with HTML-escape of hostile values.
+  2. raw_results.json filename → denied.
+  3. data_list*.csv filename → denied.
+  4. stale_pairs() detects missing OR older paired HTML.
+  5. --auto-scan walks reports/ and renders every stale candidate.
+  6. top-level forbidden key (chunk_text) → denied even outside private globs.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import render_experiment_report_html as r  # noqa: E402
+
+
+@pytest.fixture
+def reports_root(tmp_path: Path) -> Path:
+    root = tmp_path / "reports"
+    root.mkdir()
+    return root
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_renders_aggregate_and_escapes_html(reports_root: Path) -> None:
+    src = _write_json(
+        reports_root / "real100_v2" / "metric_suite.aggregate.json",
+        {
+            "ablation_full": {
+                "accuracy": 0.42,
+                "ci": {
+                    "accuracy": {"mean": 0.42, "ci_lo": 0.35, "ci_hi": 0.49, "n": 100},
+                },
+            },
+            "evil_key_<script>alert(1)</script>": "value_<img src=x>",
+        },
+    )
+    rc = r.main(["--input", str(src), "--quiet"])
+    assert rc == r.EXIT_OK
+    dst = src.with_name("metric_suite.aggregate.html")
+    assert dst.exists()
+    html = dst.read_text(encoding="utf-8")
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "&lt;img src=x&gt;" in html
+
+
+def test_raw_results_filename_is_denied(reports_root: Path) -> None:
+    src = _write_json(
+        reports_root / "retrieval" / "phase4_x" / "raw_results.json",
+        {"ablation_full": {"accuracy": 0.5}},
+    )
+    rc = r.main(["--input", str(src), "--quiet"])
+    assert rc == r.EXIT_DENIED
+    assert not src.with_suffix(".html").exists()
+
+
+def test_data_list_prefix_is_denied(tmp_path: Path) -> None:
+    src = tmp_path / "data_list.csv"
+    src.write_text("qid,gold_agency\n", encoding="utf-8")
+    rc = r.main(["--input", str(src), "--quiet"])
+    assert rc == r.EXIT_DENIED
+
+
+def test_stale_pairs_detects_missing_and_older(reports_root: Path) -> None:
+    a = _write_json(reports_root / "a.aggregate.json", {"x": 1})
+    b = _write_json(reports_root / "b.aggregate.json", {"x": 2})
+    # Render a → HTML, leave b unrendered.
+    rc = r.main(["--input", str(a), "--quiet"])
+    assert rc == r.EXIT_OK
+    stale = r.stale_pairs(reports_root)
+    assert b in stale
+    assert a not in stale
+    # Touch a so its mtime jumps past the rendered HTML.
+    time.sleep(0.01)
+    os.utime(a, None)
+    stale = r.stale_pairs(reports_root)
+    assert a in stale and b in stale
+
+
+def test_auto_scan_renders_every_stale(reports_root: Path) -> None:
+    _write_json(reports_root / "x" / "one.aggregate.json", {"m": 0.1})
+    _write_json(reports_root / "y" / "two.aggregate.json", {"m": 0.2})
+    (reports_root / "retrieval" / "phase2_x").mkdir(parents=True)
+    (reports_root / "retrieval" / "phase2_x" / "REPORT.md").write_text(
+        "# Phase 2 chunking\n\nbody\n", encoding="utf-8"
+    )
+    rc = r.main(["--auto-scan", "--quiet", "--reports-root", str(reports_root)])
+    assert rc == r.EXIT_OK
+    assert (reports_root / "x" / "one.aggregate.html").exists()
+    assert (reports_root / "y" / "two.aggregate.html").exists()
+    assert (reports_root / "retrieval" / "phase2_x" / "REPORT.html").exists()
+    # Idempotent: second pass renders nothing new.
+    assert r.stale_pairs(reports_root) == []
+
+
+def test_top_level_chunk_text_key_is_denied(reports_root: Path) -> None:
+    src = _write_json(
+        reports_root / "rogue.aggregate.json",
+        {"chunk_text": "supposed raw RFP content"},
+    )
+    rc = r.main(["--input", str(src), "--quiet"])
+    assert rc == r.EXIT_DENIED
+    assert not src.with_suffix(".html").exists()


### PR DESCRIPTION
## Summary
- PR #1635 가 Chroma 를 canonical baseline backend 로 만든 뒤 `load_index()` 의 반환 dict 가 `_vector_store = PersistentClient` 를 보유. `copy.deepcopy` 가 SWIG-backed native binding (`builtins.Bindings`) 에서 pickle 실패해서 13 test 가 `TypeError` 로 fail
- 벡터 스토어 핸들은 검색 read-only → 원본/clone 사이 공유 안전. helper `tests/_chroma_safe_clone.py::deepcopy_index_safe(index)` 추가, `_vector_store` / `_vector_store_backend` 만 분리해서 핸들 재할당, 나머지 mutable Python state 만 deepcopy
- 두 테스트 파일 5 호출지 모두 helper 로 교체. prod 코드 (`rag_indexing.py` / `rag_core.py` / ADR 0001 baseline / Chroma 정책) 미변경

## Why
PR #1662 의 `bash scripts/test.sh` 실행 중 발견된 pre-existing 회귀. 13 fail 모두 동일 root cause:

```
File "tests/test_langgraph_performance_profile.py", line 57, in _run
    return rag_core.run_rag_query(copy.deepcopy(index), _QUERY, …)
…
File "copy.py", line 161, in deepcopy
    rv = reductor(4)
TypeError: cannot pickle 'builtins.Bindings' object
```

## 변경 파일 (3, +47 −8)
| 파일 | 역할 |
|---|---|
| `tests/_chroma_safe_clone.py` (신규, ~40 LOC) | helper. 원본 index mutation 없이 native handle 만 공유 후 나머지 deepcopy |
| `tests/test_langgraph_orchestrator_regression.py` (4 호출 + import 정리) | helper 사용으로 전환 |
| `tests/test_langgraph_performance_profile.py` (1 호출 + import 정리) | helper 사용으로 전환 |

## Test plan
- [x] `pytest tests/test_langgraph_orchestrator_regression.py tests/test_langgraph_performance_profile.py -v` → **18 passed** (이전 13 fail 회복 + 기존 5 유지)
- [x] helper 자체 sanity: `from tests._chroma_safe_clone import deepcopy_index_safe; deepcopy_index_safe({'a': [1,2], '_vector_store': object()})` → 원본 mutation 없음, 핸들 공유 확인
- [x] prod 코드 미변경 — `git diff --stat rag_*.py scripts/` = 0

## Stacked PR
Base = `feat/issue-1661-experiment-report-html` (PR #1662). PR #1662 가 먼저 머지되면 본 PR base 가 자동으로 `main` 으로 swap 됨. 본 fix 의 3 변경 파일은 #1662 의 6 파일과 disjoint 이라 머지 순서 관계없이 충돌 0.

## Non-goals
- Chroma backend 정책 변경 (ADR 0001 baseline + #1635 결정 유지)
- prod 코드의 `__deepcopy__` 정의 (test-only helper 가 scope 적합)
- 다른 native handle (예: 향후 추가될 reranker model) regression 가드 — 새 케이스 발생 시 별 PR

closes #1663