### PR TITLE
fix(hooks): register experiment-report in emit-fire hook enum (#1670)

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -101,6 +101,7 @@ KNOWN_HOOKS: set[str] = {
     "delegation-gate",
     "stop-ship",
     "agent-loop",
+    "experiment-report",
 }
 
 

--- a/tests/test_hook_telemetry.py
+++ b/tests/test_hook_telemetry.py
@@ -135,6 +135,7 @@ def test_known_hooks_matches_inventory(gov):
         "bash-guard", "loadbearing", "memory-lines",
         "adr-template", "adr-collision", "plan-slug-race",
         "delegation-gate", "stop-ship", "agent-loop",
+        "experiment-report",
     }
     assert gov.KNOWN_HOOKS == expected
 
@@ -230,6 +231,8 @@ HOOK_EMIT_EXPECTATIONS = [
      "--hook bash-guard", "--outcome blocked"),
     ("scripts/claude-hooks/stop-agent-loop.sh",
      "--hook agent-loop", "--outcome pipeline_end"),
+    ("scripts/claude-hooks/stop-experiment-report.sh",
+     "--hook experiment-report", "--outcome pipeline_end"),
 ]
 
 


### PR DESCRIPTION
## 1. 변경 요약
`stop-experiment-report.sh`(ADR 0060 telemetry, #1661)가 `--hook experiment-report`로 emit-fire를 호출하지만 `scripts/_governance.py`의 `KNOWN_HOOKS` enum에 미등록되어 매 Stop 이벤트에서 telemetry가 **조용히 실패**(`2>/dev/null || true`)했다. enum에 `experiment-report` 추가 + 회귀 가드 2건.

## 2. 관련 이슈
Closes #1670

## 3. 변경 내용
- `scripts/_governance.py`: `KNOWN_HOOKS`에 `"experiment-report"` 추가
- `tests/test_hook_telemetry.py`: ① `test_known_hooks_matches_inventory` expected에 추가, ② `HOOK_EMIT_EXPECTATIONS`에 `stop-experiment-report.sh` 엔트리 추가 (emit 계약 lock-in)

## 4. 테스트
- `pytest tests/test_hook_telemetry.py` → 23 passed (추가 가드 포함)
- emit-fire 실동작 확인: `--hook experiment-report` rc=1(unknown hook) → rc=0, `...|experiment-report|stop-report|reports` 정상 기록
- `ruff check` clean

## 5. Eval 영향
N/A — telemetry/observability only. RAG 파이프라인·답변 계약·eval 표면 변화 없음. HTML 렌더 로직 자체는 이전에도 정상 작동(34 aggregate→html 쌍 생성 확인), 이 PR은 누락된 telemetry 기록만 복구.

## 6. 리스크/롤백
enum 한 항목 추가 + 테스트. 롤백 = revert. 동작 변경 없음(telemetry 기록만 추가).