### PR TITLE
fix(eval): align readiness audit fixture with real100_v2 default

### DIFF
--- a/tests/test_audit_private_data_readiness.py
+++ b/tests/test_audit_private_data_readiness.py
@@ -154,7 +154,11 @@ def _make_fixture(tmp_path: Path) -> Path:
 def _make_legacy_real_config_fixture(tmp_path: Path) -> Path:
     files_dir = tmp_path / "data" / "files"
     index_dir = tmp_path / "data" / "index" / "real100"
-    report_dir = tmp_path / "reports" / "real100"
+    # Audit resolves the eval-summary scan dir from real_eval_paths.resolve_entries,
+    # whose default report_dir is reports/real100_v2 (#1668). The legacy config below
+    # pins index_dir explicitly but leaves the report dir to that default, so the
+    # synthetic eval_summary must live under real100_v2 to be discovered.
+    report_dir = tmp_path / "reports" / "real100_v2"
     eval_dir = tmp_path / "eval"
     files_dir.mkdir(parents=True)
     index_dir.mkdir(parents=True)
@@ -467,7 +471,7 @@ def test_readiness_audit_reports_page_metadata_no_go_by_source(tmp_path: Path) -
         }
     ]
     index_path.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
-    eval_summary_path = tmp_path / "reports" / "real100" / "eval_summary.json"
+    eval_summary_path = tmp_path / "reports" / "real100_v2" / "eval_summary.json"
     eval_summary_path.write_text(
         json.dumps(
             {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#1668(80d9534)이 `scripts/real_eval_paths.py` 의 `resolve_entries` 기본값을 `report_dir: reports/real100 → reports/real100_v2`, `index_dir: data/index/real100 → data/index/real100_v2_checkpoint_minilm_pageaware` 로 전환했다. private-data readiness audit(`scripts/audit_private_data_readiness.py`)는 legacy real_config(`real_config_local_cases` 포맷)에서 `output_dir` 미지정 시 그 resolver 의 `report_dir` 로 eval-summary 스캔 경로를 결정한다. 따라서 audit 은 real100_v2 를 스캔하는데, 테스트 fixture `_make_legacy_real_config_fixture` 는 합성 eval_summary 를 `reports/real100` 에 써서 불일치 → eval_summary 미발견 → baseline metrics / citation_page_relationship 계산 실패. 이 때문에 세 테스트가 깨지고 #1668 머지 후 main CI 가 red 가 됐다.

수정: 합성 eval_summary 를 `reports/real100_v2` 로 옮겨 새 기본 경로에서 발견되도록 정렬. audit production 코드는 불변(canonical path resolver 를 올바르게 따르고 있음) — stale 테스트 fixture 정렬뿐이다.

Closes #1673

## 2. 영향 파일

- `tests/test_audit_private_data_readiness.py` — fixture/테스트 전용. **load-bearing 아님.** `_make_legacy_real_config_fixture` 의 `report_dir` 와 no-go 테스트의 eval_summary 경로를 `reports/real100` → `reports/real100_v2` 로 정렬 (+근거 주석).

## 3. 리스크

가장 가능성 높은 깨짐 경로: real100_v2 전환이 의도가 아니라 `resolve_entries` 회귀였다면 fixture 가 아니라 audit/resolver 를 고쳐야 한다. 배제 근거: #1668 은 `resolve_entries` 기본값을 의도적으로 v2 로 옮기며 전용 테스트(`test_default_index_dir_is_checkpoint_minilm_pageaware`)까지 추가했고 그 테스트는 통과한다 → v2 가 canonical 방향. audit 은 그 resolver 를 따를 뿐이라 코드 수정 불필요. 또한 fixture 의 `index_dir` 은 config 에 명시 고정돼 있어 영향 없음 — eval_summary 스캔 경로(report_dir)만 기본값에 의존.

## 4. 테스트

변경 전 3 fail / 변경 후 pass:
- `test_readiness_audit_accepts_legacy_real_config_local_cases`
- `test_readiness_audit_reports_page_metadata_go_fixture`
- `test_readiness_audit_reports_page_metadata_no_go_by_source`

`pytest tests/test_audit_private_data_readiness.py` 12/12 pass, `tests/test_real_eval_paths.py` 10/10 pass. 신규 production 동작 변경이 없어 회귀 테스트는 기존 3 테스트가 곧 회귀 가드 역할.

## 5. Eval 영향

All `·`. 테스트 fixture 경로 정렬뿐 — 검색/검증/답변 path, eval 메트릭 계산 로직 변화 없음.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path 미변경(`tests/` 만 수정). private real-data 미접촉 — fixture 는 tmp_path 합성 데이터(ADR 0005 경계 준수).

| metric | delta |
|---|---|
| retrieval | no change (path-only fixture edit) |
| verification | no change |
| answer | no change |

## 6. 하위 호환

영향 없음. 답변 계약(ADR 0003)/스키마/CLI flag/doc link 미변경. audit summary 스키마 불변(`schema_version: 1`).

## 7. 범위 외

전체 real100_v2 전환(다른 fixture/docs/실제 인덱스 경로 마이그레이션)은 별도 작업. 이 PR 은 #1668 회귀로 깨진 3 테스트 green 복구만 다룬다. 로컬 venv 의 `chromadb` 미설치로 인한 184 테스트 fail/error 는 이 변경과 무관한 환경 이슈(CI 에는 chromadb 설치됨).