### PR TITLE
chore(git): prevent shared-objectstore index corruption via install-hooks gc/fsync config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,19 @@ setup:
 # ADR 0007 issue-ref check from issue #826).
 install-hooks:
 	git config core.hooksPath .githooks
-	@echo "Activated .githooks/ for this clone. See docs/engineering-governance.md §Hook setup."
+	@# Shared-objectstore (multi-worktree) corruption prevention (issue #1680).
+	@# 20-30 worktrees share one .git/objects; automatic gc/repack/prune races with
+	@# in-flight `git add`/commit and deletes blobs only an uncommitted worktree index
+	@# references -> `fatal: unable to read <blob>` / invalid cache-tree. Disable all
+	@# automatic pruning (run `git gc --no-detach` manually only when no session is active)
+	@# and fsync loose objects so the index never references a not-yet-durable blob.
+	git config gc.auto 0
+	git config gc.autoDetach false
+	git config maintenance.auto false
+	git config fetch.writeCommitGraph false
+	git config core.fsync loose-object
+	git config core.fsyncMethod batch
+	@echo "Activated .githooks/ + shared-objectstore corruption guards for this clone. See docs/engineering-governance.md §Hook setup."
 
 # Ad-hoc validation of the current branch against ADR 0007.
 # Useful before opening a PR; mirrors the CI check.

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -142,6 +142,16 @@ Meta/parent issue (예: #118 포트폴리오, #187 phase 향상 백로그) 는 �
     # 또는:
     git config core.hooksPath .githooks
 
+`make install-hooks` 는 hooksPath 외에 **공유 object-store corruption 가드** (issue #1680)도
+설정한다: 20~30 worktree 가 `.git/objects` 하나를 공유하므로 자동 `git gc`/repack/prune 이
+in-flight `git add`/commit 과 race 해 아직 커밋 안 된 worktree index 만 참조하는 blob 을
+삭제(`fatal: unable to read <blob>` / invalid cache-tree)할 수 있다. 이를 막으려고
+`gc.auto 0` / `gc.autoDetach false` / `maintenance.auto false` / `fetch.writeCommitGraph false`
+로 **자동 pruner 를 전면 비활성**하고, `core.fsync loose-object` + `core.fsyncMethod batch`
+로 loose object durability 를 보장한다. 트레이드오프: loose object 가 쌓이므로 **활성 세션이
+0 일 때만 수동으로** `git gc --no-detach` 를 돌려 pack 한다 (worktree 가 dirty/in-flight commit
+중일 때 gc 금지).
+
 `.githooks/` 의 2개 훅 활성:
 
 - **`pre-commit`** — eval 분리 (ADR 0005) 비공개측 파일 포함 commit 을 **hard-block**. `.gitignore` 정렬, `git add -f` + force-path 잡음. `git commit --no-verify` 우회는 훅 allowlist 가 놓친 aggregate 산출물 의도 commit 시만 + 같은 변경에서 allowlist 수정

--- a/tests/test_git_config_safety_regression.py
+++ b/tests/test_git_config_safety_regression.py
@@ -1,0 +1,45 @@
+"""Regression: `make install-hooks` must set the shared-objectstore corruption guards.
+
+issue #1680 — 20-30 git worktrees share one ``.git/objects`` store. Automatic
+``git gc``/repack/prune races with an in-flight ``git add``/commit and deletes blobs
+that only an uncommitted worktree index references (``fatal: unable to read <blob>`` /
+invalid cache-tree). The fix lives in the ``install-hooks`` make target so every clone
+inherits it; this test pins that the target keeps configuring those guards.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install_hooks_recipe() -> str:
+    lines = (ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("install-hooks:"))
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        # A make recipe is the contiguous tab-indented block under the target.
+        if line and not line.startswith("\t"):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def test_install_hooks_disables_automatic_object_pruning() -> None:
+    recipe = _install_hooks_recipe()
+    # Disabling every automatic pruner is what removes the gc-vs-add race entirely.
+    assert "git config gc.auto 0" in recipe
+    assert "git config gc.autoDetach false" in recipe
+    assert "git config maintenance.auto false" in recipe
+
+
+def test_install_hooks_enables_loose_object_fsync() -> None:
+    recipe = _install_hooks_recipe()
+    # Durability: the index must never reference a not-yet-fsynced loose object.
+    assert "git config core.fsync loose-object" in recipe
+    assert "git config core.fsyncMethod batch" in recipe
+
+
+def test_install_hooks_still_activates_hooks_path() -> None:
+    # The corruption guards are additive; the original hook activation stays.
+    assert "git config core.hooksPath .githooks" in _install_hooks_recipe()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

공유 object-store(24 worktree) 환경에서 반복되던 `.git` index 손상(`fatal: unable to read <blob>` / invalid cache-tree)을 근본적으로 막는다. 자동 `git gc`/repack/prune 이 in-flight `git add`/commit 과 race 해 아직 커밋 안 된 worktree index 만 참조하는 blob 을 prune 하는 것이 원인. `make install-hooks`(clone 당 1회)에 repo-level git config 를 추가해 모든 clone 이 자동 pruner 를 끄고 loose object 를 fsync 하게 한다.

Closes #1680

## 2. 영향 파일

- `Makefile` — `install-hooks` 타깃에 `gc.auto 0`/`gc.autoDetach false`/`maintenance.auto false`/`fetch.writeCommitGraph false`/`core.fsync loose-object`/`core.fsyncMethod batch` idempotent 추가
- `tests/test_git_config_safety_regression.py` — install-hooks 가 가드를 유지하는지 회귀
- `docs/engineering-governance.md` — §훅 설정에 가드 + 수동 gc 운영 노트

## 3. 리스크

가장 가능성 높은 깨짐 = loose object 누적으로 `.git` 비대. 배제: 자동 pruning 만 끄고 수동 `git gc --no-detach`(활성 세션 0 일 때)는 그대로 가능하다고 문서화. config 는 전부 reversible(`git config --unset`). 동작 변경(설정 존재)은 회귀 테스트로 잠금.

## 4. 테스트

`tests/test_git_config_safety_regression.py` 3종: install-hooks 가 (a) 자동 pruner 비활성 config, (b) loose-object fsync config, (c) 기존 hooksPath 활성을 모두 포함하는지 정적 검증. `pytest -q tests/test_git_config_safety_regression.py` → 3 passed.

## 5. Eval 영향

All `·` (no eval delta). git config / 개발 setup 한정으로 retrieval/verifier/answer/eval 런타임 무관. real-eval 미실행(모델 경로 무변경).

## 6. 하위 호환

깨짐 없음. `install-hooks` 는 additive(기존 hooksPath 활성 유지 + config 추가). 기존 clone 은 `make install-hooks` 재실행으로 적용(idempotent). config 는 reversible.

## 7. 범위 외

- 활성 세션 중 자동 pack 부재로 인한 `.git` 비대 관리(수동 gc 스케줄)는 운영 판단으로 남김(문서화만).
- 이미 활성 clone 에는 본 PR 머지 후 `make install-hooks` 재실행 필요(또는 라이브 config 가 이미 적용된 clone 은 그대로).
