### PR TITLE
test(hooks): isolate memory-lines fire-log + add MultiEdit case (closes #1685)

### DIFF
--- a/tests/test_hook_pretooluse_memory_lines.py
+++ b/tests/test_hook_pretooluse_memory_lines.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the memory-lines PreToolUse hook (issue #1683).
+"""Regression coverage for the memory-lines PreToolUse hook (issue #1683, #1685).
 
 The hook (`scripts/claude-hooks/pretooluse-memory-lines.sh`) must gate the
 MEMORY.md auto-memory index on the *resulting* line count, not the existing
@@ -6,10 +6,18 @@ one. The historical bug: Edit/MultiEdit payloads carry old_string/new_string
 (not `content`), so the hook fell back to counting the existing file and
 blocked even edits that shrink the index under the cap — making the
 consolidate-memory remedy it asks for impossible to apply via Edit.
+
+Each test runs a COPY of the hook under a throwaway REPO_ROOT (the hook +
+_governance.py mirrored into a temp tree, the bash-guard test isolation
+pattern). That keeps the hook's ``--emit-fire`` telemetry writes inside the
+temp ``.claude/.hook-fires.log`` instead of polluting the developer's real
+axis-#5 self-review fire log (issue #1685).
 """
 
 import json
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -43,9 +51,26 @@ def _index_lines(n: int) -> str:
 class MemoryLinesHookTest(unittest.TestCase):
     """Exit-code contract for the memory-lines PreToolUse hook."""
 
+    def setUp(self) -> None:
+        # Mirror the production layout (scripts/claude-hooks/ under a repo
+        # root) so the hook's REPO_ROOT resolution and `.hook-fires.log`
+        # telemetry writes target this temp tree, not the developer's real
+        # axis-#5 fire log (issue #1685). Same isolation pattern as the
+        # bash-guard test.
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmpdir.name) / "repo"
+        (self.repo / ".claude").mkdir(parents=True)
+        (self.repo / "scripts" / "claude-hooks").mkdir(parents=True)
+        self.hook = self.repo / "scripts" / "claude-hooks" / HOOK.name
+        shutil.copy(HOOK, self.hook)
+        shutil.copy(GOVERNANCE, self.repo / "scripts" / "_governance.py")
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
     def _run(self, payload: dict) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [str(HOOK)],
+            [str(self.hook)],
             input=json.dumps(payload),
             capture_output=True,
             text=True,
@@ -53,18 +78,10 @@ class MemoryLinesHookTest(unittest.TestCase):
         )
 
     def _write_index(self, n: int) -> Path:
-        path = Path(self.tmp) / "MEMORY.md"
+        """Create the temp-tree MEMORY.md with `n` index lines and return it."""
+        path = self.repo / "MEMORY.md"
         path.write_text(_index_lines(n), encoding="utf-8")
         return path
-
-    def setUp(self) -> None:
-        import tempfile
-
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.tmp = self._tmpdir.name
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     # --- Write -------------------------------------------------------------
 
@@ -92,7 +109,7 @@ class MemoryLinesHookTest(unittest.TestCase):
 
     def test_write_new_file_over_cap_blocked(self) -> None:
         """A brand-new index created over the cap is BLOCKED."""
-        path = Path(self.tmp) / "MEMORY.md"  # does not exist yet
+        path = self.repo / "MEMORY.md"  # does not exist yet
         proc = self._run(
             {
                 "tool_name": "Write",
@@ -146,6 +163,27 @@ class MemoryLinesHookTest(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 2, proc.stderr)
 
+    # --- MultiEdit (issue #1685 coverage gap) -----------------------------
+
+    def test_multiedit_shrink_under_cap_allowed(self) -> None:
+        """MultiEdit deleting two lines from a cap-sized index is ALLOWED.
+
+        Guards the MultiEdit branch of the resulting-count reconstruction,
+        which is otherwise uncovered by the Write/Edit cases.
+        """
+        path = self._write_index(BLOCK)
+        edits = [
+            {"old_string": f"- [entry {i}](file_{i}.md) — hook for entry {i}\n", "new_string": ""}
+            for i in (BLOCK - 1, BLOCK)
+        ]
+        proc = self._run(
+            {
+                "tool_name": "MultiEdit",
+                "tool_input": {"file_path": str(path), "edits": edits},
+            }
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
     # --- Shrink that is still over cap ------------------------------------
 
     def test_shrink_still_over_cap_allowed(self) -> None:
@@ -163,7 +201,7 @@ class MemoryLinesHookTest(unittest.TestCase):
 
     def test_non_memory_file_ignored(self) -> None:
         """A non-MEMORY.md path is never gated, regardless of size."""
-        path = Path(self.tmp) / "NOTES.md"
+        path = self.repo / "NOTES.md"
         proc = self._run(
             {
                 "tool_name": "Write",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가
Closes #1685. Follow-up to #1683/#1684 (리뷰 지적, 비차단). 새 memory-lines 테스트가 실제 `.claude/.hook-fires.log`를 오염시키던 것을 temp REPO_ROOT 격리로 해결 + MultiEdit 케이스 추가.

## 2. 영향 파일
- `tests/test_hook_pretooluse_memory_lines.py` (test-only). load-bearing 아님.

## 3. 리스크
없음 — 테스트 전용, 프로덕션 코드 무변경. fire-log 격리 검증: 풀런 전후 실제 로그 줄 수 216=216 불변.

## 4. 테스트
`python3 -m pytest tests/test_hook_pretooluse_memory_lines.py -q` → 8 passed. before=after=216 (격리 성공).

## 5. Eval 영향
N/A — `tests/`만 변경, `LOAD_BEARING_PATHS` 무관.

## 6. 하위 호환
영향 없음.

## 7. 범위 외
프로덕션 훅 로직은 #1684에서 이미 머지됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)