### PR TITLE
fix(codex-gate): codex 적대 pre-commit 세션 누적 차단 + 게이트 우회 2건 (issue #1699)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -402,8 +402,15 @@ fi
 # Guard: local Codex adversarial review for load-bearing staged changes
 # (ADR 0066). This intentionally runs after the ADR 0005 path boundary above
 # so private eval files cannot be passed into the Codex review prompt.
+#
+# Uses its OWN ACMRD discovery (not the ACMR $staged above): deleting a
+# load-bearing contract is as risky as modifying it, so the deletion must reach
+# --any-match or the gate is silently skipped on that commit. The ADR 0005 path
+# scan above deliberately stays ACMR — removing a private file from the index is
+# a legitimate deletion, not a boundary violation (codex review of #1698 — AR2).
+staged_for_codex=$(git diff --cached --name-only --diff-filter=ACMRD 2>/dev/null || true)
 if [[ -z "${BIDMATE_SKIP_CODEX_ADVERSARIAL_PRECOMMIT:-}" ]]; then
-  if hit=$(printf '%s\n' "$staged" | python3 scripts/_governance.py --any-match 2>/dev/null); then
+  if hit=$(printf '%s\n' "$staged_for_codex" | python3 scripts/_governance.py --any-match 2>/dev/null); then
     echo "Running Codex adversarial pre-commit review for load-bearing change: $hit" >&2
     if ! python3 scripts/run_codex_adversarial_precommit.py; then
       exit 1

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
-.PHONY: ship-start ship-arm ship-run codex-ship ship-disarm ship-status ship-review-gate worktree-cleanup-dry-run worktree-cleanup
+.PHONY: ship-start ship-arm ship-run codex-ship codex-reap ship-disarm ship-status ship-review-gate worktree-cleanup-dry-run worktree-cleanup
 
 # Self-review (quarterly meta-feedback loop). Combines 4-axis portfolio
 # rubric + 5-axis Claude collaboration rubric. See SKILL at
@@ -1507,6 +1507,13 @@ ship-run:
 	  --use-existing-arm "$(USE_EXISTING_ARM)"
 
 codex-ship: ship-run
+
+# Selectively reap orphaned/stale codex adversarial-review brokers (issue #1699).
+# Only touches the `cxc-*` broker run-dirs under the OS temp dir whose pid is dead
+# or orphaned (ppid==1); live, parented sessions and the desktop Codex.app are
+# left untouched. Operator/manual cleanup of the current backlog.
+codex-reap:
+	@$(PYTHON) scripts/run_codex_adversarial_precommit.py --reap-only
 
 ship-disarm:
 	@rm -f .claude/.ship-armed .claude/.ship-running.pid

--- a/scripts/run_codex_adversarial_precommit.py
+++ b/scripts/run_codex_adversarial_precommit.py
@@ -16,10 +16,14 @@ block — this structurally prevents the recommit storm.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import signal
 import subprocess
 import sys
+import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -52,7 +56,12 @@ def _run_git(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
 
 
 def staged_files() -> list[str]:
-    proc = _run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    # Include deletions (D) alongside add/copy/modify/rename: deleting a
+    # load-bearing contract (rag_core.py, an ADR, the answer schema) is at least
+    # as risky as modifying it, so the deleted path must still reach the
+    # load-bearing check or the adversarial gate is silently skipped on the
+    # commit that drops it (codex adversarial review of #1698 — AR2).
+    proc = _run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMRD"])
     if proc.returncode != 0:
         raise RuntimeError((proc.stderr or proc.stdout or "git diff --cached failed").strip())
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
@@ -124,26 +133,290 @@ def build_focus(*, hits: Sequence[str], changed_files: Sequence[str], attempt: i
 _GIT_ENV_PREFIX = "GIT_"
 _DROP_ENV_EXACT = frozenset({"CODEX_COMPANION_APP_SERVER_ENDPOINT"})
 
+# Ship-pipeline secrets (merge tokens etc.) that the auto-ship Stop-hook exports
+# while a commit is created. They must NOT reach the Codex review subprocess: the
+# adversarial reviewer is a third-party model server and the diff/focus prompt is
+# user-controlled, so an inherited BIDMATE_SHIP_MERGE_TOKEN would be exfiltratable.
+# The canonical helper scripts/_ship_env.strip_ship_secret_env lands on main via
+# the D-minus PR (#1698); dedupe to a single import once both are on main (follow-up).
+_SHIP_SECRET_ENV_PREFIX = "BIDMATE_SHIP_"
+
 
 def sanitized_env(base: dict[str, str] | None = None) -> dict[str, str]:
-    """Return os.environ minus inherited git-hook vars and the broker endpoint."""
+    """Return os.environ minus git-hook vars, the broker endpoint, and ship secrets."""
     source = os.environ if base is None else base
     return {
         k: v
         for k, v in source.items()
-        if not k.startswith(_GIT_ENV_PREFIX) and k not in _DROP_ENV_EXACT
+        if not k.startswith(_GIT_ENV_PREFIX)
+        and not k.startswith(_SHIP_SECRET_ENV_PREFIX)
+        and k not in _DROP_ENV_EXACT
     }
 
 
+def _killpg(pid: int, sig: int) -> None:
+    """Best-effort kill of the whole process group led by ``pid``.
+
+    The companion spawns its broker / app-server children with `detached:true` +
+    `unref()` (no file lock), so reaping only the `node codex-companion.mjs`
+    process leaves the broker + `codex app-server` descendants alive. Spawning
+    the companion in its OWN session (`start_new_session=True`) lets us signal
+    the entire group here so no descendant survives. Robust against the group
+    already being gone. (issue #1699 / ADR 0066.)
+    """
+    try:
+        os.killpg(os.getpgid(pid), sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        # Group already reaped, never created, or not signallable — nothing to do.
+        pass
+
+
 def _default_runner(cmd: Sequence[str], timeout_sec: int) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        cmd,
-        capture_output=True,
+    """Run the companion in its own session and reap the whole process group.
+
+    Equivalent to ``subprocess.run(..., timeout=timeout_sec, env=sanitized_env())``
+    for the happy path, but built on ``Popen(start_new_session=True)`` so that on
+    timeout — or normal completion — we can ``killpg`` the companion's detached
+    broker/app-server descendants instead of orphaning them (issue #1699).
+    Returns a ``subprocess.CompletedProcess`` with ``.returncode/.stdout/.stderr``;
+    raises ``subprocess.TimeoutExpired`` on timeout, preserving the existing
+    contract that ``_run_pass`` already handles.
+    """
+    proc = subprocess.Popen(  # noqa: S603 - cmd is built internally, not user input
+        list(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        check=False,
-        timeout=timeout_sec,
         env=sanitized_env(),
+        start_new_session=True,
     )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        # Kill the whole group, drain the pipes, then re-raise with partial output
+        # so _run_pass can record the timeout (rc=124) as today.
+        _killpg(proc.pid, signal.SIGTERM)
+        try:
+            stdout, stderr = proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            _killpg(proc.pid, signal.SIGKILL)
+            stdout, stderr = proc.communicate()
+        raise subprocess.TimeoutExpired(
+            cmd=list(cmd), timeout=timeout_sec, output=stdout, stderr=stderr
+        )
+    finally:
+        # Normal completion still ensures no detached child of the companion
+        # survives: SIGTERM the (now likely empty) group, best-effort.
+        _killpg(proc.pid, signal.SIGTERM)
+    return subprocess.CompletedProcess(
+        args=list(cmd), returncode=proc.returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# --- selective orphan-broker reaper (issue #1699) ---------------------------
+# The codex companion's broker writes its run-dir under the OS temp dir using
+# the `cxc-` prefix (see openai-codex broker-lifecycle.mjs createBrokerSessionDir
+# / broker-endpoint.mjs): `<tmpdir>/cxc-*/broker.{pid,sock,log}`. Brokers do NOT
+# all live under one tmp root: a hook run with `TMPDIR=/tmp/claude-501` drops its
+# brokers there, while the desktop Codex.app / a no-TMPDIR shell uses the macOS
+# per-user default (`/var/folders/.../T`). Scoping to a single
+# `tempfile.gettempdir()` therefore MISSES brokers in the other root (live
+# observation: orphans accumulated under /var/folders while the reaper only
+# scanned /tmp/claude-501). So we scan a deduped SET of candidate roots. The
+# safety boundary is NOT the tmp root — it is the per-broker liveness check:
+# we only ever touch a LIVE broker when it is orphaned (ppid == 1, its companion
+# parent is gone), never a parented one (codex review of #1698 — AR3).
+_BROKER_DIR_PREFIX = "cxc-"
+_BROKER_PID_FILE = "broker.pid"
+# macOS confstr name for the per-user temp dir (`/var/folders/.../T`). Python's
+# tempfile uses this when TMPDIR is unset; we resolve it explicitly so we still
+# cover that root even when a hook run has overridden TMPDIR. Numeric fallback
+# (_CS_DARWIN_USER_TEMP_DIR == 65537) for builds whose os.confstr_names omits it.
+_DARWIN_USER_TEMP_CONFSTR_NAME = "CS_DARWIN_USER_TEMP_DIR"
+_DARWIN_USER_TEMP_CONFSTR_INT = 65537
+
+
+def _macos_default_temp_dir() -> str | None:
+    """Return the macOS per-user temp dir (`/var/folders/.../T`), or None.
+
+    Best-effort: not macOS, no confstr, or any lookup failure → None.
+    """
+    confstr = getattr(os, "confstr", None)
+    if confstr is None:
+        return None
+    for key in (_DARWIN_USER_TEMP_CONFSTR_NAME, _DARWIN_USER_TEMP_CONFSTR_INT):
+        try:
+            value = confstr(key)  # type: ignore[arg-type]
+        except (ValueError, OSError):
+            continue
+        if value:
+            return value
+    return None
+
+
+def _broker_base_dirs(
+    base_dir: str | os.PathLike[str] | None = None,
+    base_dirs: Sequence[str | os.PathLike[str]] | None = None,
+) -> list[Path]:
+    """Resolve the deduped set of dirs that may contain `cxc-*` broker run-dirs.
+
+    Resolution order (first non-None wins):
+
+    - ``base_dirs`` (explicit injection for tests / multi-root callers).
+    - ``base_dir`` (single dir — preserves the prior single-root call shape).
+    - default production set: ``tempfile.gettempdir()`` + ``$TMPDIR`` + the macOS
+      per-user default (`/var/folders/.../T`), deduped (order-preserving).
+    """
+    if base_dirs is not None:
+        raw: list[str | os.PathLike[str] | None] = list(base_dirs)
+    elif base_dir is not None:
+        raw = [base_dir]
+    else:
+        raw = [
+            tempfile.gettempdir(),
+            (os.environ.get("TMPDIR") or "").rstrip("/") or None,
+            _macos_default_temp_dir(),
+        ]
+    seen: set[str] = set()
+    resolved: list[Path] = []
+    for entry in raw:
+        if not entry:
+            continue
+        path = Path(entry)
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(path)
+    return resolved
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if ``pid`` names a live process (seam for deterministic tests)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — treat as alive (never our orphan).
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _pid_ppid(pid: int) -> int | None:
+    """Return the parent pid of ``pid`` (seam for deterministic tests).
+
+    Uses `ps -o ppid= -p <pid>`; returns None when it cannot be determined so
+    the caller can fail safe (leave the broker alone).
+    """
+    try:
+        proc = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    out = (proc.stdout or "").strip()
+    if not out:
+        return None
+    try:
+        return int(out.split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def _read_broker_pid(pid_file: Path) -> int | None:
+    try:
+        raw = pid_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        return int(raw.split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def _remove_broker_dir(broker_dir: Path) -> None:
+    """Best-effort recursive removal of a single broker run-dir."""
+    try:
+        for child in broker_dir.iterdir():
+            try:
+                child.unlink()
+            except OSError:
+                pass
+        broker_dir.rmdir()
+    except OSError:
+        pass
+
+
+def _reap_in_base(base: Path, counts: dict[str, int]) -> None:
+    """Scan one base dir for `cxc-*` brokers, mutating ``counts`` in place.
+
+    The liveness/safety logic is identical regardless of which tmp root the
+    broker lives under (see :func:`reap_orphaned_brokers`). Best-effort: an
+    unscannable base is skipped, never raised.
+    """
+    try:
+        candidates = sorted(base.glob(f"{_BROKER_DIR_PREFIX}*"))
+    except OSError:
+        return
+    for broker_dir in candidates:
+        if not broker_dir.is_dir():
+            continue
+        pid_file = broker_dir / _BROKER_PID_FILE
+        if not pid_file.exists():
+            # No pid file at all (e.g. half-torn-down dir) → stale, remove.
+            _remove_broker_dir(broker_dir)
+            counts["stale"] += 1
+            continue
+        pid = _read_broker_pid(pid_file)
+        if pid is None or not _pid_alive(pid):
+            _remove_broker_dir(broker_dir)
+            counts["stale"] += 1
+            continue
+        # Live pid: only reap when it is an orphan (parent gone → ppid==1).
+        ppid = _pid_ppid(pid)
+        if ppid == 1:
+            _killpg(pid, signal.SIGTERM)
+            _remove_broker_dir(broker_dir)
+            counts["orphaned"] += 1
+        else:
+            # Parented (live companion) or ppid unknown → safe: leave it alone.
+            counts["kept"] += 1
+
+
+def reap_orphaned_brokers(
+    base_dir: str | os.PathLike[str] | None = None,
+    base_dirs: Sequence[str | os.PathLike[str]] | None = None,
+) -> dict[str, int]:
+    """Selectively reap stale/orphaned codex broker run-dirs across tmp roots.
+
+    Scans ``<base>/cxc-*/broker.pid`` for every ``base`` in the resolved candidate
+    set (see :func:`_broker_base_dirs`: explicit ``base_dirs``, single ``base_dir``,
+    or the default ``tempfile.gettempdir()`` + ``$TMPDIR`` + macOS ``/var/folders``
+    set). For each broker run-dir:
+
+    - pid is dead (or pid file malformed/empty) → remove the stale dir.
+    - pid is alive AND its ppid == 1 (orphaned, the companion parent is gone) →
+      SIGTERM the broker, then remove the dir.
+    - pid is alive AND still parented → LEAVE it untouched (a live session, e.g.
+      the active shared-session broker under /var/folders).
+
+    Returns counts ``{"stale": ..., "orphaned": ..., "kept": ...}`` summed across
+    all scanned roots. NEVER does a broad `pkill 'codex app-server'` — that would
+    kill the desktop Codex.app and other worktrees' live sessions. Best-effort:
+    never raises.
+    """
+    counts = {"stale": 0, "orphaned": 0, "kept": 0}
+    for base in _broker_base_dirs(base_dir, base_dirs):
+        _reap_in_base(base, counts)
+    return counts
 
 
 def _parse_payload(stdout: str) -> dict[str, object] | None:
@@ -420,6 +693,78 @@ def _run_pass(
     )
 
 
+# --- diff-fingerprint cache (issue #1699) -----------------------------------
+# A re-commit of the IDENTICAL staged diff (same sha256 of `git diff --cached
+# --binary`) should reuse the prior verdict and spawn ZERO codex passes — the
+# single biggest source of broker accumulation is re-running 8 passes on an
+# unchanged diff. Any change to the staged diff yields a fresh digest = fresh
+# review. A corrupt/unreadable cache entry is treated as a miss (fail-open to a
+# real review, never crash).
+_CACHE_SUBDIR = "cache"
+_CACHE_SCHEMA_VERSION = 1
+
+
+def _staged_diff_digest() -> str | None:
+    """sha256 hex of the staged diff (`git diff --cached --binary`), or None."""
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--cached", "--binary"],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return hashlib.sha256(proc.stdout or b"").hexdigest()
+
+
+def _cache_path(out_dir: Path, digest: str) -> Path:
+    return out_dir / _CACHE_SUBDIR / f"{digest}.json"
+
+
+def _load_cached_result(out_dir: Path, digest: str | None) -> int | None:
+    """Return the cached rc for ``digest`` if present and valid, else None (miss)."""
+    if not digest:
+        return None
+    path = _cache_path(out_dir, digest)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    rc = payload.get("rc")
+    if not isinstance(rc, int) or isinstance(rc, bool):
+        return None
+    return rc
+
+
+def _write_cached_result(out_dir: Path, digest: str | None, *, rc: int, union: dict) -> None:
+    """Persist the review verdict under the staged-diff digest (best-effort)."""
+    if not digest:
+        return
+    path = _cache_path(out_dir, digest)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": _CACHE_SCHEMA_VERSION,
+                    "digest": digest,
+                    "timestamp": time.time(),
+                    "rc": rc,
+                    "result": union,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
 def run_precommit_review(
     *,
     attempts: int,
@@ -437,6 +782,11 @@ def run_precommit_review(
 
     Returns 0 (commit allowed) unless a critical/high finding reproduced across
     at least `min_frequency` distinct passes. All-error passes return 1.
+
+    Two resource-hygiene layers wrap the gate (contract unchanged, issue #1699):
+    a staged-diff fingerprint cache that short-circuits an identical re-commit to
+    0 codex passes, and an auto-reap of orphaned brokers in a `finally` so each
+    review cleans up its own leftovers.
     """
     if attempts < 1:
         raise ValueError("--attempts must be >= 1")
@@ -449,6 +799,55 @@ def run_precommit_review(
         )
     if timeout_sec < 1:
         raise ValueError("--timeout-sec must be >= 1")
+
+    digest = _staged_diff_digest()
+    try:
+        cached_rc = _load_cached_result(out_dir, digest)
+        if cached_rc is not None:
+            short = (digest or "")[:8]
+            print(
+                f"[codex-adversarial] diff-cache hit ({short}) — reusing prior "
+                f"verdict, 0 codex passes",
+                file=sys.stderr,
+            )
+            return cached_rc
+        return _run_precommit_passes(
+            attempts=attempts,
+            base=base,
+            scope=scope,
+            companion=companion,
+            changed_files=changed_files,
+            hits=hits,
+            out_dir=out_dir,
+            timeout_sec=timeout_sec,
+            min_frequency=min_frequency,
+            runner=runner,
+            digest=digest,
+        )
+    finally:
+        # Each review cleans up its own leftover orphan brokers. Best-effort —
+        # never let cleanup escape the gate (issue #1699).
+        try:
+            reap_orphaned_brokers()
+        except Exception:  # pragma: no cover - defensive: reaper is best-effort
+            pass
+
+
+def _run_precommit_passes(
+    *,
+    attempts: int,
+    base: str,
+    scope: str,
+    companion: Path,
+    changed_files: Sequence[str],
+    hits: Sequence[str],
+    out_dir: Path,
+    timeout_sec: int,
+    min_frequency: int,
+    runner: Runner,
+    digest: str | None,
+) -> int:
+    """Cache-miss path: run the N passes, gate, persist the verdict to the cache."""
     changed_set = set(changed_files)
 
     with ThreadPoolExecutor(max_workers=attempts) as executor:
@@ -486,6 +885,8 @@ def run_precommit_review(
             f"problem, not a code finding). See {out_dir}.",
             file=sys.stderr,
         )
+        # Do NOT cache a fail-closed (companion-outage) verdict: it is an
+        # environment problem, not a property of the diff. Retry on next commit.
         return 1
 
     collected: list[tuple[int, dict[str, object]]] = []
@@ -496,6 +897,12 @@ def run_precommit_review(
     clusters = cluster_findings(collected)
     blocking = [c for c in clusters if is_blocking(c, min_frequency=min_frequency)]
 
+    union = {
+        "attempts": attempts,
+        "error_passes": error_passes,
+        "min_frequency": min_frequency,
+        "clusters": [_cluster_to_dict(c, attempts=attempts) for c in clusters],
+    }
     union_md = render_union_markdown(
         clusters=clusters,
         attempts=attempts,
@@ -505,16 +912,7 @@ def run_precommit_review(
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "union.md").write_text(union_md, encoding="utf-8")
     (out_dir / "union.json").write_text(
-        json.dumps(
-            {
-                "attempts": attempts,
-                "error_passes": error_passes,
-                "min_frequency": min_frequency,
-                "clusters": [_cluster_to_dict(c, attempts=attempts) for c in clusters],
-            },
-            ensure_ascii=False,
-            indent=2,
-        ),
+        json.dumps(union, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
 
@@ -526,6 +924,7 @@ def run_precommit_review(
             f"See {out_dir / 'union.md'}.",
             file=sys.stderr,
         )
+        _write_cached_result(out_dir, digest, rc=1, union=union)
         return 1
     print(
         f"Codex adversarial pre-commit review passed "
@@ -533,6 +932,7 @@ def run_precommit_review(
         f"See {out_dir / 'union.md'}.",
         file=sys.stderr,
     )
+    _write_cached_result(out_dir, digest, rc=0, union=union)
     return 0
 
 
@@ -550,7 +950,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--scope", default="branch")
     parser.add_argument("--companion", default=None)
     parser.add_argument("--out-dir", type=Path, default=None)
+    parser.add_argument(
+        "--reap-only",
+        action="store_true",
+        help="Only reap orphaned/stale codex brokers and print the counts, then exit.",
+    )
     args = parser.parse_args(argv)
+
+    if args.reap_only:
+        counts = reap_orphaned_brokers()
+        print(
+            f"[codex-adversarial] reaped brokers: stale={counts['stale']} "
+            f"orphaned={counts['orphaned']} kept={counts['kept']}",
+            file=sys.stderr,
+        )
+        return 0
 
     try:
         files = staged_files()

--- a/tests/test_codex_adversarial_precommit.py
+++ b/tests/test_codex_adversarial_precommit.py
@@ -65,6 +65,34 @@ def test_load_bearing_hits_reuses_governance_paths():
     ]
 
 
+def test_staged_files_includes_deletions(monkeypatch):
+    # A commit that DELETES a load-bearing contract (e.g. an ADR or rag_core.py)
+    # must still reach the load-bearing gate, so the discovery filter is ACMRD
+    # (includes D), not ACMR. Mocked git runner keeps it deterministic — no real
+    # load-bearing file required (AR2).
+    captured: dict[str, object] = {}
+
+    def fake_run_git(args):
+        captured["args"] = list(args)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="docs/adr/0001-preserve-naive-baseline.md\nrag_core.py\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(precommit, "_run_git", fake_run_git)
+
+    files = precommit.staged_files()
+
+    # The filter must request deletions.
+    assert "--diff-filter=ACMRD" in captured["args"]
+    # The (mock) deleted load-bearing path is surfaced and the load-bearing
+    # filter recognises it → the gate would be invoked.
+    assert "docs/adr/0001-preserve-naive-baseline.md" in files
+    assert "docs/adr/0001-preserve-naive-baseline.md" in precommit.load_bearing_hits(files)
+
+
 def test_default_out_dir_uses_actual_git_dir(monkeypatch):
     def fake_run_git(args):
         assert args == ["rev-parse", "--git-dir"]
@@ -523,20 +551,56 @@ def test_sanitized_env_strips_git_and_broker():
     assert "CODEX_COMPANION_APP_SERVER_ENDPOINT" not in out
 
 
+def test_sanitized_env_strips_ship_secrets_from_os_environ(monkeypatch):
+    # The auto-ship Stop-hook can export BIDMATE_SHIP_* (merge tokens etc.) while
+    # a commit is created. sanitized_env() — which feeds the third-party Codex
+    # review subprocess — must drop every BIDMATE_SHIP_* key while preserving the
+    # benign env (PATH/HOME) and keeping the existing GIT_*/endpoint drops (AR1).
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "tok-secret")
+    monkeypatch.setenv("BIDMATE_SHIP_AUTO_PR", "1")
+    monkeypatch.setenv("GIT_DIR", "/x/.git")
+    monkeypatch.setenv("CODEX_COMPANION_APP_SERVER_ENDPOINT", "unix:/tmp/sock")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", "/home/u")
+
+    out = precommit.sanitized_env()  # reads os.environ
+
+    assert not any(k.startswith("BIDMATE_SHIP_") for k in out)
+    assert "BIDMATE_SHIP_MERGE_TOKEN" not in out
+    # Benign env survives and the existing GIT_*/endpoint drops still hold.
+    assert out["PATH"] == "/usr/bin"
+    assert out["HOME"] == "/home/u"
+    assert not any(k.startswith("GIT_") for k in out)
+    assert "CODEX_COMPANION_APP_SERVER_ENDPOINT" not in out
+
+
 def test_default_runner_passes_sanitized_env(monkeypatch):
+    # _default_runner now uses Popen(start_new_session=True) so it can reap the
+    # companion's detached broker/app-server process group (issue #1699). The
+    # sanitized-env contract is unchanged: no inherited GIT_* vars reach Codex.
     captured: dict[str, object] = {}
 
-    def fake_run(cmd, **kwargs):
+    class _FakeProc:
+        pid = 4321
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("{}", "")
+
+    def fake_popen(cmd, **kwargs):
         captured["env"] = kwargs.get("env")
-        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+        captured["start_new_session"] = kwargs.get("start_new_session")
+        return _FakeProc()
 
     monkeypatch.setenv("GIT_DIR", "/x/.git")
     monkeypatch.setenv("GIT_INDEX_FILE", "/x/.git/index")
-    monkeypatch.setattr(precommit.subprocess, "run", fake_run)
+    monkeypatch.setattr(precommit.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(precommit, "_killpg", lambda *a, **k: None)
     precommit._default_runner(["node", "companion"], 10)
     env = captured["env"]
     assert isinstance(env, dict)
     assert not any(k.startswith("GIT_") for k in env)
+    assert captured["start_new_session"] is True
 
 
 def test_run_precommit_review_rejects_min_frequency_above_attempts(tmp_path: Path):

--- a/tests/test_codex_adversarial_precommit_reap.py
+++ b/tests/test_codex_adversarial_precommit_reap.py
@@ -1,0 +1,455 @@
+"""Resource-hygiene tests for the codex adversarial pre-commit gate (issue #1699).
+
+Covers the three additions that keep the gate contract unchanged while stopping
+broker/app-server accumulation:
+
+- (C) `reap_orphaned_brokers` — selectively removes stale/orphaned `cxc-*` broker
+  run-dirs and NEVER touches a live, parented session.
+- (A) diff-fingerprint cache — an identical staged diff reuses the prior verdict
+  with 0 codex passes; a corrupt cache entry falls back to a real run.
+- (B) `_default_runner` — on timeout, the whole process group is killed (killpg),
+  exercised through a fake Popen/os.killpg seam (no real codex spawned).
+"""
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import run_codex_adversarial_precommit as precommit
+
+
+# --------------------------------------------------------------------------- #
+# (C) reap_orphaned_brokers
+# --------------------------------------------------------------------------- #
+
+
+def _make_broker_dir(base: Path, name: str, pid_text: str | None) -> Path:
+    d = base / name
+    d.mkdir()
+    (d / "broker.log").write_text("", encoding="utf-8")
+    (d / "broker.sock").write_text("", encoding="utf-8")
+    if pid_text is not None:
+        (d / "broker.pid").write_text(pid_text, encoding="utf-8")
+    return d
+
+
+def test_reap_removes_dead_keeps_live_parented_and_removes_malformed(tmp_path, monkeypatch):
+    # (a) dead pid → removed; (b) live + parented → kept; (c) empty pid → removed.
+    dead = _make_broker_dir(tmp_path, "cxc-dead", "1111")
+    live = _make_broker_dir(tmp_path, "cxc-live", "2222")
+    empty = _make_broker_dir(tmp_path, "cxc-empty", "")
+    # A non-cxc dir must never be scanned/removed.
+    unrelated = tmp_path / "not-a-broker"
+    unrelated.mkdir()
+
+    alive = {1111: False, 2222: True}
+    ppids = {2222: 4242}  # live broker has a live companion parent → keep
+
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: alive.get(pid, False))
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: ppids.get(pid))
+    # Safety: the reaper must not signal a parented (kept) broker.
+    monkeypatch.setattr(
+        precommit, "_killpg", lambda *a, **k: pytest.fail("must not killpg a kept broker")
+    )
+
+    counts = precommit.reap_orphaned_brokers(base_dir=tmp_path)
+
+    assert counts == {"stale": 2, "orphaned": 0, "kept": 1}
+    assert not dead.exists()
+    assert not empty.exists()
+    assert live.exists()  # live, parented session preserved (safety)
+    assert unrelated.exists()  # non-cxc dir untouched
+
+
+def test_reap_terminates_orphaned_broker(tmp_path, monkeypatch):
+    # Live broker whose parent is gone (ppid == 1) → SIGTERM + dir removed.
+    orphan = _make_broker_dir(tmp_path, "cxc-orphan", "3333")
+    killed: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: pid == 3333)
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: 1)
+    monkeypatch.setattr(precommit, "_killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    counts = precommit.reap_orphaned_brokers(base_dir=tmp_path)
+
+    assert counts == {"stale": 0, "orphaned": 1, "kept": 0}
+    assert killed == [(3333, signal.SIGTERM)]
+    assert not orphan.exists()
+
+
+def test_reap_keeps_broker_when_ppid_unknown(tmp_path, monkeypatch):
+    # ppid cannot be determined → fail safe: do NOT kill, keep the dir.
+    keep = _make_broker_dir(tmp_path, "cxc-unknown", "4444")
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: None)
+    monkeypatch.setattr(
+        precommit, "_killpg", lambda *a, **k: pytest.fail("must not killpg on unknown ppid")
+    )
+
+    counts = precommit.reap_orphaned_brokers(base_dir=tmp_path)
+
+    assert counts == {"stale": 0, "orphaned": 0, "kept": 1}
+    assert keep.exists()
+
+
+def test_reap_missing_pid_file_is_stale(tmp_path, monkeypatch):
+    half = _make_broker_dir(tmp_path, "cxc-nopid", pid_text=None)
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: 1)
+
+    counts = precommit.reap_orphaned_brokers(base_dir=tmp_path)
+
+    assert counts["stale"] == 1
+    assert not half.exists()
+
+
+def test_reap_missing_base_dir_returns_zero_counts(tmp_path):
+    counts = precommit.reap_orphaned_brokers(base_dir=tmp_path / "does-not-exist")
+    assert counts == {"stale": 0, "orphaned": 0, "kept": 0}
+
+
+def test_reap_default_base_dirs_cover_tmpdir_and_macos_default(monkeypatch):
+    # With no base_dir, the reaper scans a deduped SET of candidate roots —
+    # tempfile.gettempdir() + $TMPDIR + the macOS /var/folders default — so a
+    # broker under EITHER root is reachable (AR3). Single-root scoping missed
+    # orphans accumulating in the other tmp root.
+    import tempfile
+
+    globbed: list[Path] = []
+
+    def fake_glob(self, pattern):  # noqa: ANN001
+        assert pattern == "cxc-*"
+        globbed.append(self)
+        return []
+
+    monkeypatch.setenv("TMPDIR", "/tmp/claude-501")
+    monkeypatch.setattr(precommit, "_macos_default_temp_dir", lambda: "/var/folders/ab/cd/T")
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    precommit.reap_orphaned_brokers()  # no base_dir → default candidate set
+
+    assert Path(tempfile.gettempdir()) in globbed
+    assert Path("/var/folders/ab/cd/T") in globbed
+    # Deduped: /tmp/claude-501 appears once even though gettempdir() == $TMPDIR here.
+    assert globbed.count(Path("/tmp/claude-501")) == 1
+
+
+def test_reap_default_base_dirs_deduped_when_no_macos_default(monkeypatch):
+    # gettempdir() == $TMPDIR and no macOS default available → a single scan.
+    import tempfile
+
+    globbed: list[Path] = []
+
+    def fake_glob(self, pattern):  # noqa: ANN001
+        globbed.append(self)
+        return []
+
+    monkeypatch.setenv("TMPDIR", tempfile.gettempdir())
+    monkeypatch.setattr(precommit, "_macos_default_temp_dir", lambda: None)
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    precommit.reap_orphaned_brokers()
+
+    assert globbed == [Path(tempfile.gettempdir())]
+
+
+def test_reap_multi_base_scans_all_and_preserves_live_parented(tmp_path, monkeypatch):
+    # AR3 core: base A has a dead-pid broker (stale → removed); base B has a
+    # live, PARENTED broker (e.g. the active shared-session broker under
+    # /var/folders) → it must be KEPT, never signalled, while base A is still
+    # cleaned. Both roots must be scanned in one reap call.
+    base_a = tmp_path / "tmp_root_a"
+    base_b = tmp_path / "var_folders_root_b"
+    base_a.mkdir()
+    base_b.mkdir()
+
+    dead = _make_broker_dir(base_a, "cxc-dead", "1111")  # dead pid → stale
+    live = _make_broker_dir(base_b, "cxc-live-session", "2222")  # alive + parented → keep
+
+    alive = {1111: False, 2222: True}
+    ppids = {2222: 4242}  # live broker has a live companion parent → keep
+
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: alive.get(pid, False))
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: ppids.get(pid))
+    monkeypatch.setattr(
+        precommit,
+        "_killpg",
+        lambda *a, **k: pytest.fail("must not killpg a live-parented broker across bases"),
+    )
+
+    counts = precommit.reap_orphaned_brokers(base_dirs=[base_a, base_b])
+
+    assert counts == {"stale": 1, "orphaned": 0, "kept": 1}
+    assert not dead.exists()  # base A cleaned
+    assert live.exists()  # base B live-parented session preserved (safety)
+
+
+def test_reap_multi_base_terminates_orphan_in_second_root(tmp_path, monkeypatch):
+    # An orphan (alive, ppid==1) sitting in the SECOND candidate root must still
+    # be SIGTERM'd + removed — proving the orphan logic runs per-base, not just
+    # on the first root.
+    base_a = tmp_path / "root_a"
+    base_b = tmp_path / "root_b"
+    base_a.mkdir()
+    base_b.mkdir()
+
+    orphan = _make_broker_dir(base_b, "cxc-orphan", "3333")
+    killed: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(precommit, "_pid_alive", lambda pid: pid == 3333)
+    monkeypatch.setattr(precommit, "_pid_ppid", lambda pid: 1)
+    monkeypatch.setattr(precommit, "_killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    counts = precommit.reap_orphaned_brokers(base_dirs=[base_a, base_b])
+
+    assert counts == {"stale": 0, "orphaned": 1, "kept": 0}
+    assert killed == [(3333, signal.SIGTERM)]
+    assert not orphan.exists()
+
+
+# --------------------------------------------------------------------------- #
+# (A) diff-fingerprint cache
+# --------------------------------------------------------------------------- #
+
+
+def _approve_runner(cmd, timeout_sec):  # noqa: ANN001
+    payload = {
+        "result": {"verdict": "approve", "summary": "ok", "findings": [], "next_steps": []},
+        "parseError": None,
+    }
+    return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def test_diff_cache_hit_runs_zero_passes(tmp_path, monkeypatch):
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: "deadbeef" * 8)
+    calls = {"n": 0}
+
+    def runner(cmd, timeout_sec):  # noqa: ANN001
+        calls["n"] += 1
+        return _approve_runner(cmd, timeout_sec)
+
+    # First run = miss → writes the cache.
+    rc1 = precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=runner,
+    )
+    assert rc1 == 0
+    assert calls["n"] == 2  # 2 passes on a miss
+    assert precommit._cache_path(tmp_path, "deadbeef" * 8).exists()
+
+    # Second run, identical digest = HIT → 0 additional runner invocations.
+    calls["n"] = 0
+    rc2 = precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=runner,
+    )
+    assert rc2 == 0
+    assert calls["n"] == 0  # cache hit: NO codex pass spawned
+
+
+def test_diff_cache_different_digest_is_fresh_run(tmp_path, monkeypatch):
+    digests = iter(["a" * 64, "b" * 64])
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: next(digests))
+    calls = {"n": 0}
+
+    def runner(cmd, timeout_sec):  # noqa: ANN001
+        calls["n"] += 1
+        return _approve_runner(cmd, timeout_sec)
+
+    for _ in range(2):
+        precommit.run_precommit_review(
+            attempts=2,
+            base="HEAD",
+            scope="branch",
+            companion=Path("/tmp/codex-companion.mjs"),
+            changed_files=["rag_core.py"],
+            hits=["rag_core.py"],
+            out_dir=tmp_path,
+            timeout_sec=900,
+            min_frequency=2,
+            runner=runner,
+        )
+    # Both runs missed (distinct digests) → both spawned their passes.
+    assert calls["n"] == 4
+
+
+def test_diff_cache_corrupt_entry_falls_back_to_real_run(tmp_path, monkeypatch):
+    digest = "c" * 64
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: digest)
+    # Pre-seed a corrupt cache entry.
+    cache_path = precommit._cache_path(tmp_path, digest)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text("{ this is not json", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def runner(cmd, timeout_sec):  # noqa: ANN001
+        calls["n"] += 1
+        return _approve_runner(cmd, timeout_sec)
+
+    rc = precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=runner,
+    )
+    assert rc == 0
+    assert calls["n"] == 2  # corrupt entry → real run (fail-open), not a crash
+    # The corrupt entry is overwritten with a valid one.
+    assert isinstance(json.loads(cache_path.read_text(encoding="utf-8")), dict)
+
+
+def test_diff_cache_no_digest_disables_cache(tmp_path, monkeypatch):
+    # When the staged diff digest cannot be computed (None), the cache is a no-op:
+    # every run is fresh and nothing is written.
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: None)
+    calls = {"n": 0}
+
+    def runner(cmd, timeout_sec):  # noqa: ANN001
+        calls["n"] += 1
+        return _approve_runner(cmd, timeout_sec)
+
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=runner,
+    )
+    assert calls["n"] == 2
+    assert not (tmp_path / precommit._CACHE_SUBDIR).exists()
+
+
+def test_run_precommit_review_auto_reaps_on_exit(tmp_path, monkeypatch):
+    # The reaper runs in a finally after every review (hit or miss).
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: None)
+    reaped = {"n": 0}
+    monkeypatch.setattr(
+        precommit,
+        "reap_orphaned_brokers",
+        lambda *a, **k: reaped.__setitem__("n", reaped["n"] + 1) or {"stale": 0, "orphaned": 0, "kept": 0},
+    )
+
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=_approve_runner,
+    )
+    assert reaped["n"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# (B) _default_runner process-group reap
+# --------------------------------------------------------------------------- #
+
+
+class _FakeProc:
+    def __init__(self, *, timeout_then_done: bool):
+        self.pid = 99999
+        self.returncode = 0
+        self._calls = 0
+        self._timeout_then_done = timeout_then_done
+
+    def communicate(self, timeout=None):  # noqa: ANN001
+        self._calls += 1
+        if self._timeout_then_done and self._calls == 1:
+            raise subprocess.TimeoutExpired(cmd=["node"], timeout=timeout)
+        return ("out", "err")
+
+
+def test_default_runner_killpg_on_timeout(monkeypatch):
+    # On the initial communicate() TimeoutExpired, _default_runner must killpg the
+    # whole group (SIGTERM), drain, and re-raise TimeoutExpired — no real codex.
+    fake = _FakeProc(timeout_then_done=True)
+    monkeypatch.setattr(precommit.subprocess, "Popen", lambda *a, **k: fake)
+    killed: list[int] = []
+    monkeypatch.setattr(precommit, "_killpg", lambda pid, sig: killed.append(sig))
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        precommit._default_runner(["node", "companion"], 5)
+
+    # SIGTERM on timeout, plus the finally SIGTERM = at least one SIGTERM issued.
+    assert signal.SIGTERM in killed
+
+
+def test_default_runner_killpg_in_finally_on_success(monkeypatch):
+    # Even a clean completion reaps the (now-empty) group in the finally so no
+    # detached companion child can survive.
+    fake = _FakeProc(timeout_then_done=False)
+    monkeypatch.setattr(precommit.subprocess, "Popen", lambda *a, **k: fake)
+    killed: list[int] = []
+    monkeypatch.setattr(precommit, "_killpg", lambda pid, sig: killed.append(sig))
+
+    result = precommit._default_runner(["node", "companion"], 5)
+
+    assert result.returncode == 0
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+    assert killed == [signal.SIGTERM]  # finally-path reap on success
+
+
+def test_default_runner_spawns_in_new_session_with_sanitized_env(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001
+        captured["start_new_session"] = kwargs.get("start_new_session")
+        captured["env"] = kwargs.get("env")
+        return _FakeProc(timeout_then_done=False)
+
+    monkeypatch.setenv("GIT_DIR", "/x/.git")
+    monkeypatch.setattr(precommit.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(precommit, "_killpg", lambda *a, **k: None)
+
+    precommit._default_runner(["node", "companion"], 5)
+
+    assert captured["start_new_session"] is True
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert not any(k.startswith("GIT_") for k in env)  # sanitized_env preserved
+
+
+def test_killpg_swallows_process_lookup(monkeypatch):
+    # _killpg must never raise when the group is already gone.
+    def boom(pid):  # noqa: ANN001
+        raise ProcessLookupError
+
+    monkeypatch.setattr(precommit.os, "getpgid", boom)
+    precommit._killpg(12345, signal.SIGTERM)  # no exception


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

codex 적대 pre-commit 리뷰(ADR 0066 / #1692, `.githooks/pre-commit`)가 리뷰마다 **detached broker/app-server 세션을 정리하지 않아 누적**됐고(상시 20~30 worktree × 8-pass × 재커밋으로 증폭 — 실측: `/tmp/.../cxc-*/broker.{pid,sock}` 더미 + 고아 `codex app-server` 다수), 추가로 적대리뷰가 **게이트 우회 2건**을 찾았다. 이 PR은 게이트를 hardening한다. **gate 계약(`DEFAULT_ATTEMPTS=8`, `min_frequency=2`)은 불변** — 자원/정확성 위생만.

Closes #1699

## 2. 영향 파일

- `scripts/run_codex_adversarial_precommit.py` — (A) diff-fingerprint 캐시, (B) `_default_runner` process-group reap, (C) `reap_orphaned_brokers` + `--reap-only`, (AR1) `sanitized_env`가 `BIDMATE_SHIP_*` strip, (AR2) `staged_files` `--diff-filter=ACMRD`, (AR3) 멀티 tmp-root reaper.
- `.githooks/pre-commit` — codex-gate staged 탐색에 `ACMRD`(삭제 포함). ADR-0005 경계 스캔은 ACMR 유지(사적 파일 인덱스 제거는 정당한 삭제).
- `Makefile` — `codex-reap` 타겟.
- `tests/test_codex_adversarial_precommit.py`, `tests/test_codex_adversarial_precommit_reap.py`(신규).
- **load-bearing 파일 없음** (LOAD_BEARING_PATHS 미접촉) → 이 PR 커밋 시 codex 적대 리뷰 미발동(의도).

## 3. 리스크

- **reaper가 live broker를 죽임**: liveness가 안전 경계 — dead-pid(stale)만 rm, alive+ppid==1(고아)만 SIGTERM, **live-parented는 보존**. broad `pkill` 금지(데스크톱 Codex.app/타 worktree 보호). 멀티-base 테스트로 live-parented 보존 확인.
- **diff-cache가 stale verdict 재사용**: 캐시 키 = staged diff sha256 → diff가 바뀌면 새 리뷰. corrupt 캐시 → miss(fail-open). blocked verdict도 캐시되지만 동일 diff 재시도라 정당(세션 0).
- **process-group kill이 무관 프로세스 죽임**: `start_new_session=True`로 companion 전용 그룹만 killpg.
- **ACMRD가 false-positive**: 삭제를 load-bearing 게이트에 넣을 뿐, ADR-0005 경계는 ACMR 유지.

## 4. 테스트

`bash scripts/test.sh` → **3161 passed**. 신규: reaper(dead/orphan/live-parented/multi-base/missing-base), diff-cache(hit-0passes/distinct-digest/corrupt→real-run/auto-reap-on-exit), killpg-on-timeout+finally, `sanitized_env` ship-secret strip, `staged_files` ACMRD 삭제 포함.

## 5. Eval 영향

**동작 변화 없음 (RAG/eval 경로 미변경).** governance 도구(codex pre-commit 게이트)만 변경 — rag_*/ingestion/eval/api/build_index 미접촉. CI eval delta: All `·`. real-eval 미실행(사유: RAG 무변경).

## 6. 하위 호환

gate 계약 불변. `.githooks/pre-commit`의 codex 호출(인자 없음) 호환 유지. diff-cache/reaper는 best-effort(실패 시 기존 동작). `make codex-reap`은 신규 opt-in.

## 7. 범위 외 (의도적)

- **(D) adaptive cascade** (8→2-3패스): frequency-gate 계약 변경 → **ADR 0066 갱신 필요** 별도 follow-up.
- **AR1 dedup**: `sanitized_env`의 인라인 `BIDMATE_SHIP_` strip은, #1698(D-minus)가 `scripts/_ship_env.strip_ship_secret_env`를 main에 올리면 단일 import로 dedup (follow-up — 현재 #1699는 main 기반이라 `_ship_env` 부재).
- **AR3(거버넌스)**: staging-self-ship-guard의 `[constitutional-change-ack]`가 author-controlled라 진짜 외부 게이트 아님 + `_ship_env.py` SELF_IMMUTABLE 미포함 → P2.1 별도 (신뢰 신호 CODEOWNERS/admin-label 결정 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
