### PR TITLE
chore(tasks): record staging self-ship P2.2 + follow-up backlog (#1703)

### DIFF
--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -81,6 +81,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 68 | `T-2026-0068` | `backlog` | Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | Knowledge/Graph RAG feasibility for relation-structured RFP evidence. |
 | 69 | `T-2026-0069` | `backlog` | Planner -> Reviewer | Interview and resume evidence pack mapping repo artifacts to target roles. |
 | 70 | `T-2026-0070` | `backlog` | Implementer -> Privacy Auditor -> Reviewer | Portfolio review board refresh after the new positioning artifacts settle. |
+| 71 | `T-2026-0071` | `ready` | Implementer -> Reviewer | issue #1703; staging self-ship P2.0 D-minus landed (#1698/#1700/#1702, ADR 0088/0090/0091). Remaining: operator branch-protection (blocked-on-user), P2.2 autonomous merge orchestration, + 3 follow-ups (AR1 `_ship_env` dedup, codex 8->2-3 cascade ADR 0066, codex pre-commit re-enable). Deep context: issue #1703 + `docs/operations/staging-self-ship.md`. |
 
 ## Examples
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

P2.0 D-minus staging self-ship lane (PR #1698/#1700/#1702, ADR 0088/0090/0091) 의 남은 백로그를 `tasks/queue.md` 에 라우팅 행(T-2026-0071)으로 박제. 지금까지 transcript 에만 있던 후속 작업을 cross-session SSoT 에 기록해 다음 세션이 이어받을 수 있게 함. 코드/동작 변경 없음 (queue 문서 1줄 추가).

Closes #1703

## 2. 영향 파일

- `tasks/queue.md`: T-2026-0071 행 1개 추가 (status `ready`, issue #1703 링크). load-bearing 아님(`scripts/_governance.py` 미포함).
  - blocked-on-user: operator branch-protection (autopilot/integration + Require code-owner review).
  - P2.2: autonomous merge orchestration (manifest emission seam / 라이브 pr create·merge / 권한분리 merge token / cap store / serialized promotion / AR4).
  - 작은 follow-up 3개: AR1 `_ship_env` dedup, codex 8->2-3 cascade (ADR 0066), codex pre-commit 재활성.
- 깊은 맥락: issue #1703 본문 + `docs/operations/staging-self-ship.md` runbook (이미 main).

## 3. 리스크

queue 라우팅 인덱스 단일 행 추가 — 동작 코드 경로 없음. 가장 가능성 높은 깨짐은 멀티 worktree 동시 queue 편집으로 인한 T-ID 충돌이나, 현재 origin/main max=T-2026-0070 확인 후 다음 free ID(0071) 사용. 머지 시 divergence 발생하면 rebase.

## 4. 테스트

문서(라우팅 인덱스) 단일 행 추가 — behavior change 없음 → 신규 테스트 N/A. CI 의 branch-and-issue convention check (ADR 0007) + 기존 governance/parity/doc-link 게이트 통과로 acceptance.

## 5. Eval 영향

N/A — load-bearing 파일 미변경, eval 표면(retrieval/answer/verifier/eval) 무관. queue 문서 라우팅 행 1줄 추가로 RAG 동작 byte-identical. All `·`.

## 6. 하위 호환

N/A — 계약/스키마/CLI flag/answer-contract 변경 없음. 기존 queue 행 포맷 그대로.

## 7. 범위 외

P2.2 실제 구현, AR1 dedup 구현, codex cascade 구현, branch-protection 설정(operator)은 이 PR 범위 밖 — 이 행이 가리키는 후속 작업으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
