### PR TITLE
chore(codex-gate): dedup ship-secret strip into shared _ship_env helper

### DIFF
--- a/scripts/run_codex_adversarial_precommit.py
+++ b/scripts/run_codex_adversarial_precommit.py
@@ -35,6 +35,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from scripts import render_codex_review
 from scripts._governance import is_load_bearing
+from scripts._ship_env import strip_ship_secret_env
 from scripts.agent_loop_codex_turn import resolve_companion
 
 DEFAULT_ATTEMPTS = 8
@@ -137,21 +138,23 @@ _DROP_ENV_EXACT = frozenset({"CODEX_COMPANION_APP_SERVER_ENDPOINT"})
 # while a commit is created. They must NOT reach the Codex review subprocess: the
 # adversarial reviewer is a third-party model server and the diff/focus prompt is
 # user-controlled, so an inherited BIDMATE_SHIP_MERGE_TOKEN would be exfiltratable.
-# The canonical helper scripts/_ship_env.strip_ship_secret_env lands on main via
-# the D-minus PR (#1698); dedupe to a single import once both are on main (follow-up).
-_SHIP_SECRET_ENV_PREFIX = "BIDMATE_SHIP_"
+# The BIDMATE_SHIP_* deny-list is owned by scripts/_ship_env.strip_ship_secret_env
+# (single source of truth, ADR 0090 env-isolation); sanitized_env delegates to it
+# below so the prefix can never drift between this call site and the ship runner.
 
 
 def sanitized_env(base: dict[str, str] | None = None) -> dict[str, str]:
     """Return os.environ minus git-hook vars, the broker endpoint, and ship secrets."""
     source = os.environ if base is None else base
-    return {
+    # GIT_* (index-corruption guard, issue #1691) and the broker endpoint are the
+    # Codex-specific drops handled here; BIDMATE_SHIP_* removal is delegated to the
+    # shared helper so the ship-secret deny-list stays a single source of truth.
+    git_filtered = {
         k: v
         for k, v in source.items()
-        if not k.startswith(_GIT_ENV_PREFIX)
-        and not k.startswith(_SHIP_SECRET_ENV_PREFIX)
-        and k not in _DROP_ENV_EXACT
+        if not k.startswith(_GIT_ENV_PREFIX) and k not in _DROP_ENV_EXACT
     }
+    return strip_ship_secret_env(git_filtered)
 
 
 def _killpg(pid: int, sig: int) -> None:

--- a/tests/test_codex_adversarial_precommit.py
+++ b/tests/test_codex_adversarial_precommit.py
@@ -574,6 +574,34 @@ def test_sanitized_env_strips_ship_secrets_from_os_environ(monkeypatch):
     assert "CODEX_COMPANION_APP_SERVER_ENDPOINT" not in out
 
 
+def test_sanitized_env_delegates_ship_strip_to_shared_helper(monkeypatch):
+    # AR1 dedup (#1703 follow-up): the BIDMATE_SHIP_* deny-list has one source of
+    # truth in scripts/_ship_env.strip_ship_secret_env. Assert sanitized_env routes
+    # ship-secret removal through that shared helper so the prefix can never drift
+    # between this call site and the staging-ship runner.
+    seen: dict[str, dict[str, str]] = {}
+    real_strip = precommit.strip_ship_secret_env
+
+    def spy(env: dict[str, str]) -> dict[str, str]:
+        seen["received"] = dict(env)
+        return real_strip(env)
+
+    monkeypatch.setattr(precommit, "strip_ship_secret_env", spy)
+    base = {
+        "PATH": "/usr/bin",
+        "GIT_DIR": "/x/.git",
+        "BIDMATE_SHIP_MERGE_TOKEN": "tok-secret",
+    }
+    out = precommit.sanitized_env(base)
+
+    # The shared helper was invoked, and GIT_* was already dropped before delegation.
+    assert "received" in seen
+    assert "GIT_DIR" not in seen["received"]
+    # Ship secret removed by the helper; benign env preserved.
+    assert "BIDMATE_SHIP_MERGE_TOKEN" not in out
+    assert out["PATH"] == "/usr/bin"
+
+
 def test_default_runner_passes_sanitized_env(monkeypatch):
     # _default_runner now uses Popen(start_new_session=True) so it can reap the
     # companion's detached broker/app-server process group (issue #1699). The


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

codex adversarial pre-commit 의 `sanitized_env()` 가 #1700 (codex-gate hardening) 에서 인라인으로 들고 있던 `BIDMATE_SHIP_*` prefix strip 을, main 에 이미 있는 공유 헬퍼 `scripts/_ship_env.strip_ship_secret_env` 로 위임. ship-secret deny-list 를 단일 출처화 (ADR 0090 env-isolation). 두 곳에서 prefix 가 drift 하면 codex 서브프로세스로 merge token 이 누출되는 경로가 생기므로 단일 출처가 보안상 중요. `run_codex_adversarial_precommit.py:140` 주석이 명시한 follow-up 정리.

Closes #1705. Part of #1703 (AR1 follow-up).

## 2. 영향 파일

- `scripts/run_codex_adversarial_precommit.py`: 로컬 중복 상수 `_SHIP_SECRET_ENV_PREFIX` 제거, `from scripts._ship_env import strip_ship_secret_env` 추가, `sanitized_env` 가 `GIT_*` + broker endpoint 만 로컬 strip 후 ship-secret 은 공유 헬퍼에 위임. **load-bearing 아님** (LOAD_BEARING_PATHS 미포함).
- `tests/test_codex_adversarial_precommit.py`: dedup 회귀 테스트 1개 추가 (`test_sanitized_env_delegates_ship_strip_to_shared_helper` — 공유 헬퍼 경유 + prefix drift 방지 검증).

## 3. 리스크

ship-secret strip 동작이 바뀌면 third-party codex 서브프로세스에 `BIDMATE_SHIP_MERGE_TOKEN` 이 누출될 수 있음 (exfiltration). → 기존 `test_sanitized_env_strips_ship_secrets_from_os_environ` (AR1 보안 계약) + `test_sanitized_env_strips_git_and_broker` 가 동작 보존을 강제하고, 신규 회귀 테스트가 헬퍼 위임을 강제. 결과 env dict 는 byte-identical (모든 필터 = 교집합, 적용 순서 무관).

## 4. 테스트

`pytest tests/test_codex_adversarial_precommit.py tests/test_codex_adversarial_precommit_reap.py tests/test_agent_loop_ship_env_isolation.py -q` → **63 passed**. 동작 무변경 리팩토링이나 prefix-drift 방지를 위한 회귀 테스트를 신규 추가 (동작 변경 ↔ 테스트 변경 원칙).

## 5. Eval 영향

N/A — load-bearing 파일 미변경, retrieval/answer/verifier/eval 표면 무관. RAG 동작 byte-identical. `make real-eval-delta` 불필요 (동작 무변경 사유로 §5 충족).

## 6. 하위 호환

N/A — `sanitized_env(base=None)` 시그니처/반환 동일, 공개 계약 변경 없음. 제거한 `_SHIP_SECRET_ENV_PREFIX` 는 파일 내부 전용 (외부 참조 0 확인).

## 7. 범위 외

cascade 8->2-3 (ADR 0066, gate-gaming 회피 위해 별도 PR), codex pre-commit 재활성 (operator env toggle), P2.2 autonomous merge orchestration — #1703 의 다른 follow-up 으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)