### PR TITLE
fix(codex-gate): verdict cache key ignores review policy (attempts/min_frequency/timeout)

### DIFF
--- a/scripts/run_codex_adversarial_precommit.py
+++ b/scripts/run_codex_adversarial_precommit.py
@@ -696,15 +696,18 @@ def _run_pass(
     )
 
 
-# --- diff-fingerprint cache (issue #1699) -----------------------------------
+# --- diff-fingerprint cache (issue #1699, policy-aware: issue #1710) ---------
 # A re-commit of the IDENTICAL staged diff (same sha256 of `git diff --cached
-# --binary`) should reuse the prior verdict and spawn ZERO codex passes — the
-# single biggest source of broker accumulation is re-running 8 passes on an
-# unchanged diff. Any change to the staged diff yields a fresh digest = fresh
-# review. A corrupt/unreadable cache entry is treated as a miss (fail-open to a
-# real review, never crash).
+# --binary`) under the SAME review policy should reuse the prior verdict and
+# spawn ZERO codex passes — the single biggest source of broker accumulation is
+# re-running 8 passes on an unchanged diff. Any change to the staged diff OR to
+# the review policy (attempts / min_frequency / timeout) yields a cache miss =
+# fresh review. A corrupt/unreadable cache entry is treated as a miss
+# (fail-open to a real review, never crash).
 _CACHE_SUBDIR = "cache"
-_CACHE_SCHEMA_VERSION = 1
+# Bumped to 2: policy parameters (attempts/min_frequency/timeout_sec) are now
+# part of the cache key and stored in the payload for validation (issue #1710).
+_CACHE_SCHEMA_VERSION = 2
 
 
 def _staged_diff_digest() -> str | None:
@@ -722,20 +725,50 @@ def _staged_diff_digest() -> str | None:
     return hashlib.sha256(proc.stdout or b"").hexdigest()
 
 
-def _cache_path(out_dir: Path, digest: str) -> Path:
-    return out_dir / _CACHE_SUBDIR / f"{digest}.json"
+def _policy_digest(*, attempts: int, min_frequency: int, timeout_sec: int) -> str:
+    """sha256 hex of the review policy parameters.
+
+    Any change to attempts / min_frequency / timeout_sec produces a different
+    digest, ensuring that a policy change causes a cache miss (issue #1710).
+    """
+    policy_bytes = json.dumps(
+        {"attempts": attempts, "min_frequency": min_frequency, "timeout_sec": timeout_sec},
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(policy_bytes).hexdigest()
 
 
-def _load_cached_result(out_dir: Path, digest: str | None) -> int | None:
-    """Return the cached rc for ``digest`` if present and valid, else None (miss)."""
-    if not digest:
+def _cache_path(out_dir: Path, diff_digest: str, policy_digest: str) -> Path:
+    # Composite key: first 32 chars of diff digest + first 16 chars of policy
+    # digest. Keeps filenames short while keeping diff × policy pairs distinct.
+    composite = f"{diff_digest[:32]}-{policy_digest[:16]}"
+    return out_dir / _CACHE_SUBDIR / f"{composite}.json"
+
+
+def _load_cached_result(
+    out_dir: Path,
+    diff_digest: str | None,
+    policy_dgst: str,
+) -> int | None:
+    """Return the cached rc if present and valid for this diff + policy, else None (miss).
+
+    A cache entry written under a different policy digest is treated as a miss —
+    the review must rerun under the new policy (issue #1710).
+    """
+    if not diff_digest:
         return None
-    path = _cache_path(out_dir, digest)
+    path = _cache_path(out_dir, diff_digest, policy_dgst)
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     if not isinstance(payload, dict):
+        return None
+    # Reject entries written by an older schema that lacks policy fields.
+    if payload.get("schema_version") != _CACHE_SCHEMA_VERSION:
+        return None
+    # Double-check stored policy digest matches current policy (defence-in-depth).
+    if payload.get("policy_digest") != policy_dgst:
         return None
     rc = payload.get("rc")
     if not isinstance(rc, int) or isinstance(rc, bool):
@@ -743,18 +776,34 @@ def _load_cached_result(out_dir: Path, digest: str | None) -> int | None:
     return rc
 
 
-def _write_cached_result(out_dir: Path, digest: str | None, *, rc: int, union: dict) -> None:
-    """Persist the review verdict under the staged-diff digest (best-effort)."""
-    if not digest:
+def _write_cached_result(
+    out_dir: Path,
+    diff_digest: str | None,
+    policy_dgst: str,
+    *,
+    rc: int,
+    union: dict,
+    attempts: int,
+    min_frequency: int,
+    timeout_sec: int,
+) -> None:
+    """Persist the review verdict under the composite diff+policy key (best-effort)."""
+    if not diff_digest:
         return
-    path = _cache_path(out_dir, digest)
+    path = _cache_path(out_dir, diff_digest, policy_dgst)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             json.dumps(
                 {
                     "schema_version": _CACHE_SCHEMA_VERSION,
-                    "digest": digest,
+                    "digest": diff_digest,
+                    "policy_digest": policy_dgst,
+                    "policy": {
+                        "attempts": attempts,
+                        "min_frequency": min_frequency,
+                        "timeout_sec": timeout_sec,
+                    },
                     "timestamp": time.time(),
                     "rc": rc,
                     "result": union,
@@ -804,8 +853,11 @@ def run_precommit_review(
         raise ValueError("--timeout-sec must be >= 1")
 
     digest = _staged_diff_digest()
+    pol_dgst = _policy_digest(
+        attempts=attempts, min_frequency=min_frequency, timeout_sec=timeout_sec
+    )
     try:
-        cached_rc = _load_cached_result(out_dir, digest)
+        cached_rc = _load_cached_result(out_dir, digest, pol_dgst)
         if cached_rc is not None:
             short = (digest or "")[:8]
             print(
@@ -825,7 +877,8 @@ def run_precommit_review(
             timeout_sec=timeout_sec,
             min_frequency=min_frequency,
             runner=runner,
-            digest=digest,
+            diff_digest=digest,
+            pol_dgst=pol_dgst,
         )
     finally:
         # Each review cleans up its own leftover orphan brokers. Best-effort —
@@ -848,7 +901,8 @@ def _run_precommit_passes(
     timeout_sec: int,
     min_frequency: int,
     runner: Runner,
-    digest: str | None,
+    diff_digest: str | None,
+    pol_dgst: str,
 ) -> int:
     """Cache-miss path: run the N passes, gate, persist the verdict to the cache."""
     changed_set = set(changed_files)
@@ -927,7 +981,11 @@ def _run_precommit_passes(
             f"See {out_dir / 'union.md'}.",
             file=sys.stderr,
         )
-        _write_cached_result(out_dir, digest, rc=1, union=union)
+        _write_cached_result(
+            out_dir, diff_digest, pol_dgst,
+            rc=1, union=union,
+            attempts=attempts, min_frequency=min_frequency, timeout_sec=timeout_sec,
+        )
         return 1
     print(
         f"Codex adversarial pre-commit review passed "
@@ -935,7 +993,11 @@ def _run_precommit_passes(
         f"See {out_dir / 'union.md'}.",
         file=sys.stderr,
     )
-    _write_cached_result(out_dir, digest, rc=0, union=union)
+    _write_cached_result(
+        out_dir, diff_digest, pol_dgst,
+        rc=0, union=union,
+        attempts=attempts, min_frequency=min_frequency, timeout_sec=timeout_sec,
+    )
     return 0
 
 

--- a/tests/test_codex_adversarial_precommit.py
+++ b/tests/test_codex_adversarial_precommit.py
@@ -602,6 +602,238 @@ def test_sanitized_env_delegates_ship_strip_to_shared_helper(monkeypatch):
     assert out["PATH"] == "/usr/bin"
 
 
+# ----- policy-aware cache (issue #1710) ------------------------------------
+
+
+def _make_policy_runner(calls: dict[str, int]) -> precommit.Runner:
+    """Runner that records how many times it was invoked and returns an empty payload."""
+
+    def runner(cmd, timeout_sec):
+        calls["n"] = calls.get("n", 0) + 1
+        return _proc(_payload([]))
+
+    return runner
+
+
+def test_policy_digest_differs_on_attempts_change():
+    """Different attempts values must produce different policy digests."""
+    d1 = precommit._policy_digest(attempts=2, min_frequency=1, timeout_sec=900)
+    d2 = precommit._policy_digest(attempts=4, min_frequency=1, timeout_sec=900)
+    assert d1 != d2
+
+
+def test_policy_digest_differs_on_min_frequency_change():
+    """Different min_frequency values must produce different policy digests."""
+    d1 = precommit._policy_digest(attempts=4, min_frequency=1, timeout_sec=900)
+    d2 = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=900)
+    assert d1 != d2
+
+
+def test_policy_digest_differs_on_timeout_change():
+    """Different timeout_sec values must produce different policy digests."""
+    d1 = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=300)
+    d2 = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=900)
+    assert d1 != d2
+
+
+def test_policy_digest_stable_for_same_policy():
+    """Same policy must always produce the same digest."""
+    d1 = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=900)
+    d2 = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=900)
+    assert d1 == d2
+
+
+def test_cache_miss_on_policy_change_triggers_rerun(tmp_path: Path, monkeypatch):
+    """Seeding a cache under policy A then running under policy B (attempts changed)
+    must cause a cache miss and a real review run — not a stale verdict replay
+    (regression for issue #1710).
+    """
+    # Patch _staged_diff_digest to return a fixed digest so the diff is "unchanged".
+    fixed_digest = "a" * 64
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: fixed_digest)
+
+    call_count: dict[str, int] = {}
+
+    # --- First run: policy A (attempts=2, min_frequency=1) ---
+    runner_a = _make_policy_runner(call_count)
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=1,
+        runner=runner_a,
+    )
+    assert call_count.get("n", 0) == 2, "policy A: should have run 2 passes"
+
+    # --- Second run: same diff, same policy A → cache hit, 0 new passes ---
+    call_count.clear()
+    runner_a2 = _make_policy_runner(call_count)
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=1,
+        runner=runner_a2,
+    )
+    assert call_count.get("n", 0) == 0, "policy A repeat: must be a cache hit (0 passes)"
+
+    # --- Third run: same diff, CHANGED policy (attempts=4, min_frequency=2) ---
+    # Despite identical diff, the policy changed → must be a cache miss → rerun.
+    call_count.clear()
+    runner_b = _make_policy_runner(call_count)
+    precommit.run_precommit_review(
+        attempts=4,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=runner_b,
+    )
+    assert call_count.get("n", 0) == 4, (
+        "policy B (attempts changed): must be a cache MISS and run 4 fresh passes"
+    )
+
+
+def test_cache_miss_on_min_frequency_change(tmp_path: Path, monkeypatch):
+    """Changing only min_frequency must bust the cache (issue #1710)."""
+    fixed_digest = "b" * 64
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: fixed_digest)
+
+    call_count: dict[str, int] = {}
+
+    # Seed cache with min_frequency=1.
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=1,
+        runner=_make_policy_runner(call_count),
+    )
+    assert call_count.get("n", 0) == 2
+
+    # Re-run with min_frequency=2 (same diff, same attempts, different threshold).
+    call_count.clear()
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=2,
+        runner=_make_policy_runner(call_count),
+    )
+    assert call_count.get("n", 0) == 2, "min_frequency change must bust the cache"
+
+
+def test_cache_miss_on_timeout_change(tmp_path: Path, monkeypatch):
+    """Changing only timeout_sec must bust the cache (issue #1710)."""
+    fixed_digest = "c" * 64
+    monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: fixed_digest)
+
+    call_count: dict[str, int] = {}
+
+    # Seed cache with timeout_sec=300.
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=300,
+        min_frequency=1,
+        runner=_make_policy_runner(call_count),
+    )
+    assert call_count.get("n", 0) == 2
+
+    # Re-run with timeout_sec=900.
+    call_count.clear()
+    precommit.run_precommit_review(
+        attempts=2,
+        base="HEAD",
+        scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"],
+        hits=["rag_core.py"],
+        out_dir=tmp_path,
+        timeout_sec=900,
+        min_frequency=1,
+        runner=_make_policy_runner(call_count),
+    )
+    assert call_count.get("n", 0) == 2, "timeout_sec change must bust the cache"
+
+
+def test_load_cached_result_rejects_schema_v1_entry(tmp_path: Path):
+    """A cache entry written with schema_version=1 (pre-policy) must be a miss
+    after the schema bump to version 2 (issue #1710).
+    """
+    diff_digest = "d" * 64
+    pol_dgst = precommit._policy_digest(attempts=2, min_frequency=1, timeout_sec=900)
+    # Write a v1-style entry directly (no policy fields).
+    cache_dir = tmp_path / precommit._CACHE_SUBDIR
+    cache_dir.mkdir()
+    # Compute expected composite path to place the stale file there.
+    stale_path = precommit._cache_path(tmp_path, diff_digest, pol_dgst)
+    import json as _json
+    stale_path.write_text(
+        _json.dumps({
+            "schema_version": 1,
+            "digest": diff_digest,
+            "rc": 0,
+        }),
+        encoding="utf-8",
+    )
+    result = precommit._load_cached_result(tmp_path, diff_digest, pol_dgst)
+    assert result is None, "schema_version=1 entry must be treated as a cache miss"
+
+
+def test_load_cached_result_rejects_wrong_policy_digest(tmp_path: Path):
+    """An entry whose stored policy_digest doesn't match the current policy is a miss."""
+    import json as _json
+
+    diff_digest = "e" * 64
+    pol_dgst_a = precommit._policy_digest(attempts=2, min_frequency=1, timeout_sec=900)
+    pol_dgst_b = precommit._policy_digest(attempts=4, min_frequency=2, timeout_sec=900)
+
+    # Write a valid v2 entry under pol_dgst_b's path but with pol_dgst_a as stored value.
+    path = precommit._cache_path(tmp_path, diff_digest, pol_dgst_b)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        _json.dumps({
+            "schema_version": precommit._CACHE_SCHEMA_VERSION,
+            "digest": diff_digest,
+            "policy_digest": pol_dgst_a,  # deliberately mismatched
+            "rc": 0,
+        }),
+        encoding="utf-8",
+    )
+    result = precommit._load_cached_result(tmp_path, diff_digest, pol_dgst_b)
+    assert result is None, "policy_digest mismatch must be treated as a cache miss"
+
+
 def test_default_runner_passes_sanitized_env(monkeypatch):
     # _default_runner now uses Popen(start_new_session=True) so it can reap the
     # companion's detached broker/app-server process group (issue #1699). The

--- a/tests/test_codex_adversarial_precommit_reap.py
+++ b/tests/test_codex_adversarial_precommit_reap.py
@@ -247,7 +247,8 @@ def test_diff_cache_hit_runs_zero_passes(tmp_path, monkeypatch):
     )
     assert rc1 == 0
     assert calls["n"] == 2  # 2 passes on a miss
-    assert precommit._cache_path(tmp_path, "deadbeef" * 8).exists()
+    pol_dgst = precommit._policy_digest(attempts=2, min_frequency=2, timeout_sec=900)
+    assert precommit._cache_path(tmp_path, "deadbeef" * 8, pol_dgst).exists()
 
     # Second run, identical digest = HIT → 0 additional runner invocations.
     calls["n"] = 0
@@ -296,8 +297,9 @@ def test_diff_cache_different_digest_is_fresh_run(tmp_path, monkeypatch):
 def test_diff_cache_corrupt_entry_falls_back_to_real_run(tmp_path, monkeypatch):
     digest = "c" * 64
     monkeypatch.setattr(precommit, "_staged_diff_digest", lambda: digest)
-    # Pre-seed a corrupt cache entry.
-    cache_path = precommit._cache_path(tmp_path, digest)
+    # Pre-seed a corrupt cache entry using the same policy as run_precommit_review below.
+    pol_dgst = precommit._policy_digest(attempts=2, min_frequency=2, timeout_sec=900)
+    cache_path = precommit._cache_path(tmp_path, digest, pol_dgst)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text("{ this is not json", encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/run_codex_adversarial_precommit.py`의 diff-fingerprint cache(issue #1699)가 cache key를 staged diff sha256만으로 계산했다. `BIDMATE_CODEX_ADVERSARIAL_ATTEMPTS` / `MIN_FREQUENCY` / `TIMEOUT_SEC` env var를 변경한 뒤 동일 diff를 재commit하면 stale verdict(rc)를 재생—정책 강화가 묵살되는 버그. policy 파라미터를 cache key와 payload validation에 포함시켜 정책 변경 시 cache miss → rerun이 되도록 수정한다.

Closes #1710

## 2. 영향 파일

- `scripts/run_codex_adversarial_precommit.py` — cache 로직 수정 (load-bearing 아님: governance 스크립트)
- `tests/test_codex_adversarial_precommit.py` — 9개 회귀 테스트 추가

## 3. 리스크

**기존 cache 파일 무효화(의도된 동작):** `_CACHE_SCHEMA_VERSION` 1→2 bump로 기존 cache 항목이 자동으로 miss 처리된다. 이는 버그 수정의 일부이며, 단순히 한 번 더 실행되는 것뿐이다. 새 cache 파일명 포맷(`{diff[:32]}-{policy[:16]}.json`)으로 구 파일과 충돌하지 않으므로 stale 파일은 자연 소멸한다.

**최악 시나리오:** cache hit을 기대했던 re-commit이 실제 Codex pass를 실행한다—이는 이 PR 이전의 올바른 동작이며, cache의 fail-open 계약(corrupt = miss → rerun) 범위 내다.

## 4. 테스트

신규 9개 regression 테스트 (`tests/test_codex_adversarial_precommit.py` 끝에 추가):

| 테스트 | 검증 내용 |
|--------|-----------|
| `test_policy_digest_differs_on_attempts_change` | attempts 변경 시 digest 불일치 |
| `test_policy_digest_differs_on_min_frequency_change` | min_frequency 변경 시 digest 불일치 |
| `test_policy_digest_differs_on_timeout_change` | timeout_sec 변경 시 digest 불일치 |
| `test_policy_digest_stable_for_same_policy` | 동일 정책 = 동일 digest |
| `test_cache_miss_on_policy_change_triggers_rerun` | **핵심**: policy A 시드 → policy B 재실행이 rerun(0 pass x→ 4 pass) |
| `test_cache_miss_on_min_frequency_change` | min_frequency 변경만으로 cache bust |
| `test_cache_miss_on_timeout_change` | timeout_sec 변경만으로 cache bust |
| `test_load_cached_result_rejects_schema_v1_entry` | schema_version=1 항목은 miss |
| `test_load_cached_result_rejects_wrong_policy_digest` | policy_digest 불일치는 miss |

기존 35개 테스트 포함 44개 통과 (`python3 -m pytest tests/test_codex_adversarial_precommit.py -q` → `44 passed in 0.39s`).

## 5. Eval 영향

동작 변화 없음. `scripts/run_codex_adversarial_precommit.py`는 governance 스크립트로 load-bearing 경로(`rag_core.py` / `eval/` / `api/` 등)가 아님. RAG 파이프라인·답변 계약·eval 지표에 영향 없음.

## 6. 하위 호환

- **Cache 파일 포맷 변경:** schema_version 1→2, 파일명 포맷 변경(의도된 breaking). 기존 cache 항목은 schema_version 불일치로 miss → 자동 rerun. 사람·스크립트가 cache 파일을 직접 파싱하는 경우는 없음(ADR 0066 §5: artifact는 local-only, 검사용).
- CLI interface(`--attempts` / `--min-frequency` / `--timeout-sec`)는 변경 없음.
- `_diff_digest` fingerprint 계약(issue #1699)은 유지됨.

## 7. 범위 외

- 기존 stale cache 파일(schema v1)의 능동적 정리: 파일명이 달라 자연 공존 후 소멸. 적극 cleanup은 이 PR 범위 외.
- cache TTL / 만료 정책: 기존과 동일(없음). 별도 이슈 가능.