### PR TITLE
test(gate3): verify main AR3 code-owner block (probe, NOT for merge)

### DIFF
--- a/scripts/_staging_ship.py
+++ b/scripts/_staging_ship.py
@@ -667,3 +667,8 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
+
+# Gate-3 e2e probe (issue #1714, NOT for merge): exercises main-branch AR3
+# (require_code_owner_reviews on this constitutional file) — verifies the
+# autonomous loop / PR author cannot self-approve a constitutional change.
+# This PR is closed after the code-owner block is observed.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Gate-3 e2e probe — main 의 AR3(`require_code_owner_reviews`, ADR 0091) 라이브 검증. constitutional 파일 `scripts/_staging_ship.py` no-op 주석 변경 PR 을 main base 로 열어, code-owner(@hskim-solv) approve 없이 머지가 차단되는지 확인. **검증 후 close — 머지하지 않음.**

Closes #1714. Part of #1703 (Gate-3 e2e).

## 2. 영향 파일

`scripts/_staging_ship.py`: 파일 끝 no-op 주석 1개 (실행 경로 무관).

## 3. 리스크

없음 — 머지 안 함, code-owner block 관찰 후 close. 의도적으로 머지 차단됨을 검증하는 probe.

## 4. 테스트

`reviewDecision` / `mergeable` 로 code-owner review 강제(REVIEW_REQUIRED) 확인.

## 5. Eval 영향

N/A — load-bearing/eval 표면 무관, RAG 동작 byte-identical.

## 6. 하위 호환

N/A — 주석만.

## 7. 범위 외

실제 동작 변경 아님 — enforcement 검증 probe (close 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)