### PR TITLE
feat(agent-loop): lane autotune effort actuate (PR2, ADR 0092)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,14 +515,18 @@ ACTIVE_WRITE_AGENT ?= auto
 # today (ADR 0001). `omc` delegates to `omc team` and additionally requires
 # ACTIVE_OMC_RUNNER_ACK=1 (uncontrolled workers relax the ADR 0005 boundary).
 ACTIVE_RUNNER ?= codex
-# ADR 0092 (PR1, opt-in): per-(role,agent) lane adaptive autotune. PR1 is sense + detect +
-# recommendation-only (NO effort actuation — that is PR2). Default empty == OFF == byte-identical
-# (no per-lane elapsed_s recorded, no recommendations emitted, controller never invoked).
+# ADR 0092 (opt-in): per-(role,agent) lane adaptive autotune. PR1 = sense + detect +
+# recommendation. PR2 = actuate: the controller steps the lane effort (claude --effort /
+# codex -c model_reasoning_effort) on the next iteration, clamped to the per-agent ladder,
+# with COOLDOWN iterations of suppression after each adjustment. Default empty == OFF ==
+# byte-identical (no per-lane elapsed_s, no recommendations, no effort override, controller
+# never invoked).
 ACTIVE_LANE_AUTOTUNE ?=
 ACTIVE_LANE_AUTOTUNE_K ?= 2.0
 ACTIVE_LANE_AUTOTUNE_FAIL_WINDOW ?= 3
 ACTIVE_LANE_AUTOTUNE_FAIL_MIN_SAMPLE ?= 2
 ACTIVE_LANE_AUTOTUNE_FAIL_THRESHOLD ?= 0.5
+ACTIVE_LANE_AUTOTUNE_COOLDOWN ?= 2
 ACTIVE_CODEX_RECORD_GATE_HEARTBEATS ?= 1
 ACTIVE_CODEX_EXECUTE ?=
 HUMAN_GATED_ACTION ?=
@@ -1091,7 +1095,7 @@ agent-loop-active-auto-loop:
 	  --timeout-seconds "$(ACTIVE_CODEX_TIMEOUT_SECONDS)" \
 	  --max-commands-per-session "$(ACTIVE_CODEX_MAX_COMMANDS_PER_SESSION)" \
 	  --model "$(ACTIVE_CODEX_MODEL)" \
-	  $(if $(filter 1 true yes on,$(ACTIVE_LANE_AUTOTUNE)),--lane-autotune --lane-autotune-k "$(ACTIVE_LANE_AUTOTUNE_K)" --lane-autotune-fail-window "$(ACTIVE_LANE_AUTOTUNE_FAIL_WINDOW)" --lane-autotune-fail-min-sample "$(ACTIVE_LANE_AUTOTUNE_FAIL_MIN_SAMPLE)" --lane-autotune-fail-threshold "$(ACTIVE_LANE_AUTOTUNE_FAIL_THRESHOLD)",) \
+	  $(if $(filter 1 true yes on,$(ACTIVE_LANE_AUTOTUNE)),--lane-autotune --lane-autotune-k "$(ACTIVE_LANE_AUTOTUNE_K)" --lane-autotune-fail-window "$(ACTIVE_LANE_AUTOTUNE_FAIL_WINDOW)" --lane-autotune-fail-min-sample "$(ACTIVE_LANE_AUTOTUNE_FAIL_MIN_SAMPLE)" --lane-autotune-fail-threshold "$(ACTIVE_LANE_AUTOTUNE_FAIL_THRESHOLD)" --lane-autotune-cooldown "$(ACTIVE_LANE_AUTOTUNE_COOLDOWN)",) \
 	  --state "$(ACTIVE_AUTO_LOOP_STATE)" \
 	  --out "$(ACTIVE_AUTO_LOOP_OUT)"
 

--- a/docs/adr/0092-lane-adaptive-autotune.md
+++ b/docs/adr/0092-lane-adaptive-autotune.md
@@ -84,11 +84,16 @@ codex 명령(`-c model_reasoning_effort` 미주입)과 `auto_loop_state.json` �
 
 ## Deferred / follow-up
 
-- **effort actuation (PR2).** claude `--effort` / codex `-c model_reasoning_effort` threading +
-  per-agent ladder clamp + cooldown. 별도 issue, 이 PR1 위 stacked.
+- **effort actuation (PR2 — landed).** claude `--effort` / codex `-c model_reasoning_effort`
+  threading (positional `-` 이전 삽입) + per-agent ladder clamp + cooldown. controller가
+  `compute_lane_autotune(prior_lane_stats, cooldown_state, config) ->
+  (effort_overrides, recommendations, new_cooldown_state, events)`로 확장됨. codex effort 가드는
+  controller ladder-clamp 단독(`_validate_effort_for_model`은 claude lane 전용 — 오인용 금지).
+- **codex `xhigh` rung.** controller 사다리는 `high` 상한; `~/.codex/config.toml`이 `xhigh`를
+  쓰더라도 PR2 사다리는 `high`까지만 → 필요 시 후속 검토.
 - **model-swap actuation.** blast radius·비용 가드 필요 → deferred.
 - **cross-agent 정규화 비교.** claude 오버헤드 보정 후 교차 비교 → 별도 측정 작업.
-- **claude `max` rung.** 코드 profile 상한이 `xhigh`라 `max`는 제외; 필요 시 PR2 smoke
+- **claude `max` rung.** 코드 profile 상한이 `xhigh`라 `max`는 제외(코드 부재); 필요 시 smoke
   (`claude --effort max`) 후 추가.
 
 ## Verification
@@ -107,4 +112,6 @@ git diff --check
 <!-- verifies-key: scripts/agent_loop.py:_resolve_lane_autotune_config -->
 <!-- verifies-key: scripts/agent_loop.py:_resolve_lane_autotune_config_for_cli -->
 <!-- verifies-key: scripts/agent_loop.py:_LANE_AUTOTUNE_FAILURE_STATUSES -->
+<!-- verifies-key: scripts/agent_loop.py:_resolve_lane_effort_override -->
+<!-- verifies-key: scripts/agent_loop.py:_step_lane_effort -->
 <!-- verifies-key: Makefile:ACTIVE_LANE_AUTOTUNE -->

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Iterable, Sequence
+from typing import Callable, Iterable, Sequence
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -281,22 +281,26 @@ LANE_AUTOTUNE_K_ENV = "ACTIVE_LANE_AUTOTUNE_K"
 LANE_AUTOTUNE_FAIL_WINDOW_ENV = "ACTIVE_LANE_AUTOTUNE_FAIL_WINDOW"
 LANE_AUTOTUNE_FAIL_MIN_SAMPLE_ENV = "ACTIVE_LANE_AUTOTUNE_FAIL_MIN_SAMPLE"
 LANE_AUTOTUNE_FAIL_THRESHOLD_ENV = "ACTIVE_LANE_AUTOTUNE_FAIL_THRESHOLD"
+LANE_AUTOTUNE_COOLDOWN_ENV = "ACTIVE_LANE_AUTOTUNE_COOLDOWN"
 
 
 @dataclass(frozen=True)
 class LaneAutotuneConfig:
-    """Resolved knobs for the lane-autotune controller (ADR 0092, PR1).
+    """Resolved knobs for the lane-autotune controller (ADR 0092, PR1 + PR2).
 
     ``k`` is the within-agent slowness multiplier (flag a lane whose ``elapsed_s``
     exceeds ``k * median`` of the same agent's active lanes). ``fail_window`` /
     ``fail_min_sample`` / ``fail_threshold`` drive the fail_rate signal over the last
-    W iterations. Held as a frozen value so the controller stays a pure function.
+    W iterations. ``cooldown`` (PR2) is how many iterations a just-actuated lane is held
+    before it can be re-adjusted (AC13). Held as a frozen value so the controller stays a
+    pure function.
     """
 
     k: float = 2.0
     fail_window: int = 3
     fail_min_sample: int = 2
     fail_threshold: float = 0.5
+    cooldown: int = 2
 
 
 def _lane_autotune_enabled() -> bool:
@@ -339,6 +343,7 @@ def _resolve_lane_autotune_config() -> LaneAutotuneConfig | None:
         fail_window=_int(LANE_AUTOTUNE_FAIL_WINDOW_ENV, 3),
         fail_min_sample=_int(LANE_AUTOTUNE_FAIL_MIN_SAMPLE_ENV, 2),
         fail_threshold=_float(LANE_AUTOTUNE_FAIL_THRESHOLD_ENV, 0.5),
+        cooldown=_int(LANE_AUTOTUNE_COOLDOWN_ENV, 2),
     )
 
 
@@ -437,6 +442,52 @@ def _validate_effort_for_model(model: str, effort: str) -> str:
     if effort == "xhigh" and not re.match(r"^claude-opus-4-(?:7|8)(?:\b|[-_])", model):
         return "high"
     return effort
+
+
+# ADR 0092 (PR2): per-agent effort ladder for autotune actuation. Ordered low→high.
+# claude tops out at ``xhigh`` (the code profile ceiling; ``max`` is absent from
+# _CLAUDE_ROLE_PROFILE so it is intentionally excluded — a ``max`` rung is a smoke-gated
+# follow-up). codex tops out at ``high`` (``~/.codex/config.toml`` may use ``xhigh``, but
+# the controller ladder caps at ``high``; an ``xhigh`` rung is a follow-up). These ladders
+# are the SINGLE clamp guard for codex effort — _validate_effort_for_model is claude-only
+# (it would no-op on codex effort, so calling it there would be misuse, AC11).
+_CLAUDE_EFFORT_LADDER: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+_CODEX_EFFORT_LADDER: tuple[str, ...] = ("minimal", "low", "medium", "high")
+
+
+def _lane_effort_ladder(agent: str) -> tuple[str, ...]:
+    return _CLAUDE_EFFORT_LADDER if agent == "claude" else _CODEX_EFFORT_LADDER
+
+
+def _step_lane_effort(agent: str, effort: str, delta: int) -> str | None:
+    """Step ``effort`` ±1 along the agent's ladder, clamped to its bounds (AC11/AC12).
+
+    Returns the clamped neighbour, or ``None`` when ``effort`` is not on the agent's ladder
+    (an off-ladder value — e.g. a custom env override — is left for the lane to resolve
+    rather than guessed at). Clamping at a bound returns the same rung (idempotent), so the
+    controller still records a recommendation even when no further step is possible.
+    """
+    ladder = _lane_effort_ladder(agent)
+    try:
+        idx = ladder.index(effort)
+    except ValueError:
+        return None
+    new_idx = max(0, min(len(ladder) - 1, idx + delta))
+    return ladder[new_idx]
+
+
+def _resolve_lane_effort_override(agent: str, role: str, requested_effort: str | None) -> str:
+    """Apply an autotune effort override, falling back to the role-table effort (ADR 0092).
+
+    Symmetric with ``_resolve_lane_model_override``: when ``requested_effort`` is provided
+    (the controller's per-lane decision) it wins; when ``None`` this returns exactly
+    ``_resolve_lane_effort(agent, role)`` so the off path / non-flagged lanes stay
+    byte-identical to today (AC14). No clamping here — the controller is the single ladder
+    guard (AC11); this resolver only chooses between the override and the baseline.
+    """
+    if requested_effort:
+        return requested_effort
+    return _resolve_lane_effort(agent, role)
 
 
 def _dual_lane_adversarial_enabled() -> bool:
@@ -10182,11 +10233,12 @@ def _load_active_lane_stats(state_path: Path) -> tuple[list[list[dict[str, objec
     Returns ``(history, meta)`` where ``history`` is a list of per-iteration lane
     observation batches in cycle order (oldest first); each batch is a list of
     ``{"role", "agent", "elapsed_s", "status"}`` dicts. ``meta`` carries
-    ``{"warnings": [...]}`` and the prior recommendations under
-    ``{"recommendations": [...]}`` (for audit continuity). Missing / unreadable /
-    autotune-off state yields an empty history so the caller no-ops cleanly.
+    ``{"warnings": [...]}``, the prior recommendations under ``{"recommendations": [...]}``
+    (for audit continuity), and the prior cooldown_state under ``{"cooldown_state": {...}}``
+    (ADR 0092 PR2, so a just-actuated lane stays suppressed across runs). Missing /
+    unreadable / autotune-off state yields an empty history so the caller no-ops cleanly.
     """
-    meta: dict[str, object] = {"warnings": [], "recommendations": []}
+    meta: dict[str, object] = {"warnings": [], "recommendations": [], "cooldown_state": {}}
     if not state_path.exists():
         return [], meta
     try:
@@ -10226,6 +10278,13 @@ def _load_active_lane_stats(state_path: Path) -> tuple[list[list[dict[str, objec
     raw_recs = payload.get("lane_autotune_recommendations")
     if isinstance(raw_recs, list):
         meta["recommendations"] = [rec for rec in raw_recs if isinstance(rec, dict)]
+    raw_cooldown = payload.get("lane_autotune_cooldown")
+    if isinstance(raw_cooldown, dict):
+        meta["cooldown_state"] = {
+            str(key): val
+            for key, val in raw_cooldown.items()
+            if isinstance(val, int) and not isinstance(val, bool) and val > 0
+        }
     return history, meta
 
 
@@ -10472,9 +10531,20 @@ def write_active_auto_loop(
     # spans prior runs, not just this run's iterations. Only read when autotune is ON.
     prior_lane_stats: list[list[dict[str, object]]] = []
     lane_autotune_recommendations: list[dict[str, object]] = []
+    # ADR 0092 (PR2): cooldown_state persists across iterations AND runs; pending_effort_overrides
+    # carries the controller's decision from iteration N to the runner call at iteration N+1.
+    lane_autotune_cooldown: dict[str, int] = {}
+    pending_effort_overrides: dict[tuple[str, str], str] = {}
     if lane_autotune_config is not None:
         prior_lane_stats, lane_stats_meta = _load_active_lane_stats(state_path)
         warnings.extend(str(w) for w in lane_stats_meta.get("warnings", []) if w)
+        prior_cooldown = lane_stats_meta.get("cooldown_state")
+        if isinstance(prior_cooldown, dict):
+            lane_autotune_cooldown = {
+                str(key): val
+                for key, val in prior_cooldown.items()
+                if isinstance(val, int) and not isinstance(val, bool) and val > 0
+            }
     max_iterations, limit_reason = _resolve_active_auto_loop_limit(
         max_iterations,
         auto_cap=auto_max_iterations_cap,
@@ -10549,10 +10619,11 @@ def write_active_auto_loop(
             "blockers": _dedupe_preserve_order(blockers),
             "warnings": _dedupe_preserve_order(warnings),
         }
-        # ADR 0092 (AC8): only emit the recommendations key when autotune is ON, so the
-        # checkpoint payload is byte-identical to today when the feature is OFF.
+        # ADR 0092 (AC8/AC13): only emit the recommendations + cooldown_state keys when
+        # autotune is ON, so the checkpoint payload is byte-identical to today when OFF.
         if lane_autotune_config is not None:
             checkpoint_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
+            checkpoint_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
         state_path.parent.mkdir(parents=True, exist_ok=True)
         state_path.write_text(
             json.dumps(_sanitize_json_value(checkpoint_payload), indent=2, sort_keys=True) + "\n",
@@ -10640,6 +10711,9 @@ def write_active_auto_loop(
                 task_id=task.task_id,
                 state=DEFAULT_ACTIVE_AUTO_REPAIR_STATE,
                 out=DEFAULT_ACTIVE_AUTO_REPAIR,
+                # ADR 0092 (PR2): apply the controller's Implementer effort override (if any)
+                # to the repair patch lane too. Reads the loop-level mutable at call time.
+                effort_overrides=pending_effort_overrides or None,
             )
 
         repair = run_patch(write_agent)
@@ -10852,6 +10926,9 @@ def write_active_auto_loop(
             record_gate_heartbeats=record_gate_heartbeats,
             task_id=task.task_id,
             repo_root=repo_root,
+            # ADR 0092 (PR2, AC9/AC10): apply the controller's effort overrides from the PRIOR
+            # iteration to this iteration's lanes. Empty when OFF or before any actuation.
+            effort_overrides=pending_effort_overrides or None,
         )
         cycle["runner_decision"] = runner.decision
         cycle["runner_report"] = _repo_path(runner.report_path, repo_root)
@@ -10869,9 +10946,10 @@ def write_active_auto_loop(
                 for session in runner.sessions
                 if isinstance(session, dict)
             ]
-            # AC4/AC5/AC8: feed the full history (prior runs + this run's earlier cycles +
-            # this cycle) to the PURE controller and record its recommendations. PR1 is
-            # recommendation-only — no effort override is applied to any lane (that is PR2).
+            # AC4/AC5/AC9-AC13: feed the full history (prior runs + this run's earlier cycles +
+            # this cycle) and the carried cooldown_state to the PURE controller. PR2 returns the
+            # effort overrides to apply on the NEXT iteration's runner call + the decremented
+            # cooldown_state, both threaded forward via the loop-level mutables below.
             history = [
                 *prior_lane_stats,
                 *(
@@ -10880,10 +10958,23 @@ def write_active_auto_loop(
                     if isinstance(prior_cycle.get("lane_stats"), list)
                 ),
             ]
-            recommendations, autotune_events = compute_lane_autotune(history, lane_autotune_config)
+            (
+                next_effort_overrides,
+                recommendations,
+                lane_autotune_cooldown,
+                autotune_events,
+            ) = compute_lane_autotune(history, lane_autotune_cooldown, lane_autotune_config)
+            # Apply on the next iteration (AC9/AC10). Serialize tuple keys to "role||agent" for
+            # the audit payload; the in-process override dict keeps the tuple keys.
+            pending_effort_overrides = dict(next_effort_overrides)
             cycle["lane_autotune"] = {
                 "recommendations": recommendations,
                 "events": autotune_events,
+                "effort_overrides": {
+                    _lane_cooldown_key(role, agent): effort
+                    for (role, agent), effort in next_effort_overrides.items()
+                },
+                "cooldown_state": dict(lane_autotune_cooldown),
             }
             for rec in recommendations:
                 lane_autotune_recommendations.append(
@@ -11088,10 +11179,13 @@ def write_active_auto_loop(
         "blockers": _dedupe_preserve_order(blockers),
         "warnings": _dedupe_preserve_order(warnings),
     }
-    # ADR 0092 (AC8): emit recommendations on the terminal state write too (this block, not
-    # write_cycle_checkpoint, is the final state file). Gated so off-mode stays byte-identical.
+    # ADR 0092 (AC8/AC13): emit recommendations + cooldown_state on the terminal state write
+    # too (this block, not write_cycle_checkpoint, is the final state file). The persisted
+    # cooldown_state is what _load_active_lane_stats reads on the NEXT run so a just-actuated
+    # lane stays suppressed across runs. Gated so off-mode stays byte-identical.
     if lane_autotune_config is not None:
         state_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
+        state_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
     rendered = render_active_auto_loop(
@@ -11494,11 +11588,13 @@ def _resolve_lane_autotune_config_for_cli(args: argparse.Namespace) -> "LaneAuto
     fail_window = getattr(args, "lane_autotune_fail_window", None)
     fail_min_sample = getattr(args, "lane_autotune_fail_min_sample", None)
     fail_threshold = getattr(args, "lane_autotune_fail_threshold", None)
+    cooldown = getattr(args, "lane_autotune_cooldown", None)
     return LaneAutotuneConfig(
         k=base.k if k is None else float(k),
         fail_window=base.fail_window if fail_window is None or int(fail_window) <= 0 else int(fail_window),
         fail_min_sample=base.fail_min_sample if fail_min_sample is None or int(fail_min_sample) <= 0 else int(fail_min_sample),
         fail_threshold=base.fail_threshold if fail_threshold is None else float(fail_threshold),
+        cooldown=base.cooldown if cooldown is None or int(cooldown) < 0 else int(cooldown),
     )
 
 
@@ -11647,17 +11743,41 @@ def _lane_autotune_median(values: Sequence[float]) -> float:
     return (ordered[mid - 1] + ordered[mid]) / 2.0
 
 
+def _lane_cooldown_key(role: str, agent: str) -> str:
+    """JSON-safe cooldown_state key for a ``(role, agent)`` lane (ADR 0092, PR2)."""
+    return f"{role}||{agent}"
+
+
 def compute_lane_autotune(
     prior_lane_stats: Sequence[Sequence[dict[str, object]]],
+    cooldown_state: "dict[str, object] | None",
     config: "LaneAutotuneConfig",
-) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
-    """Pure decision function for opt-in lane autotune (ADR 0092, PR1).
+    *,
+    effort_resolver: "Callable[[str, str], str]" = _resolve_lane_effort,
+) -> tuple[
+    dict[tuple[str, str], str],
+    list[dict[str, object]],
+    dict[str, int],
+    list[dict[str, object]],
+]:
+    """Pure decision function for opt-in lane autotune (ADR 0092, PR1 sense + PR2 actuate).
 
-    Recommendation-only — this NEVER applies an effort override (that is PR2). Given
-    ``prior_lane_stats`` (per-iteration observation batches, oldest first; each batch a
-    list of ``{"role", "agent", "elapsed_s", "status"}`` dicts), it senses *within-agent*
-    bottlenecks on the most recent batch and emits per-lane recommendations + diagnostic
-    events. No I/O, no env reads, no clock — fully deterministic for testing.
+    Given ``prior_lane_stats`` (per-iteration observation batches, oldest first; each batch a
+    list of ``{"role", "agent", "elapsed_s", "status"}`` dicts) and the prior
+    ``cooldown_state`` (``{"role||agent": remaining_iterations}``), it senses *within-agent*
+    bottlenecks on the most recent batch, resolves a stepped effort override per flagged lane,
+    and returns the cooldown-suppressed actuation. No I/O, no env reads, no clock — the only
+    seam is ``effort_resolver`` (defaults to the env-aware ``_resolve_lane_effort``; tests
+    inject a pure fake) so the function stays deterministic given its inputs.
+
+    Returns ``(effort_overrides, recommendations, new_cooldown_state, events)``:
+      * ``effort_overrides`` — ``{(role, agent): effort}`` to apply on the NEXT iteration. A
+        lane in cooldown, or whose stepped effort would not move (off-ladder, or already
+        clamped at a bound), is omitted (no actuation that iteration).
+      * ``recommendations`` — per-flagged-lane audit rows (the PR1 shape, now carrying the
+        actuation outcome: ``actuated`` / ``effort_from`` / ``effort_to`` / cooldown state).
+      * ``new_cooldown_state`` — carryover entries decremented by 1 (dropped at 0); freshly
+        actuated lanes (re)set to ``config.cooldown``.
 
     Signals:
       * elapsed (AC4): on the newest batch ("active lanes"), group by ``agent``; for an
@@ -11672,16 +11792,31 @@ def compute_lane_autotune(
         role's agent flips (``read_agent=auto``), the new lane is a fresh key, so the prior
         agent's observations for that role do not leak into the new lane's window.
 
-    Direction (AC8, previewing AC12): a flagged lane whose fail_rate exceeds
-    ``config.fail_threshold`` (with min-sample met) is recommended to *strengthen* (PR2
-    would step effort +1); otherwise *accelerate* (PR2 would step -1). PR1 records the
-    direction only — no concrete effort level is resolved here.
+    Direction (AC12): a flagged lane whose fail_rate exceeds ``config.fail_threshold`` (with
+    min-sample met) *strengthens* (effort +1); otherwise *accelerates* (effort -1). The step
+    is clamped to the agent's ladder (AC11) — the controller is the SINGLE codex guard.
+    Cooldown (AC13): a just-actuated lane is held ``config.cooldown`` iterations before it can
+    be re-adjusted.
     """
     batches: list[list[dict[str, object]]] = [list(batch) for batch in prior_lane_stats]
     events: list[dict[str, object]] = []
     recommendations: list[dict[str, object]] = []
+    effort_overrides: dict[tuple[str, str], str] = {}
+
+    # --- cooldown bookkeeping (AC13) ---
+    # ``incoming`` maps a lane key to its remaining cooldown from the prior iteration; a lane
+    # with remaining > 0 cannot be re-adjusted this iteration. ``new_cooldown_state`` starts as
+    # the decremented carryover (entries dropped at 0); a freshly actuated lane overwrites its
+    # entry with the full cooldown so it is NOT decremented the same iteration it actuates.
+    incoming: dict[str, int] = {}
+    if isinstance(cooldown_state, dict):
+        for raw_key, raw_val in cooldown_state.items():
+            if isinstance(raw_val, int) and not isinstance(raw_val, bool) and raw_val > 0:
+                incoming[str(raw_key)] = raw_val
+    new_cooldown_state: dict[str, int] = {key: val - 1 for key, val in incoming.items() if val - 1 > 0}
+
     if not batches:
-        return recommendations, events
+        return effort_overrides, recommendations, new_cooldown_state, events
 
     # --- fail_rate per (role, agent) lane over the last W batches (AC5/AC6) ---
     window = batches[-config.fail_window :] if config.fail_window > 0 else batches
@@ -11755,8 +11890,35 @@ def compute_lane_autotune(
             fail_rate, fail_sample = _lane_fail_signal(role, agent)
             if fail_rate is not None and fail_rate > config.fail_threshold:
                 direction = "strengthen"
+                delta = 1
             else:
                 direction = "accelerate"
+                delta = -1
+            # --- actuate (AC11/AC12/AC13): step the baseline effort along the agent ladder,
+            # clamped, unless the lane is still cooling down. ``effort_resolver`` is the seam
+            # that keeps this function pure (tests inject a fake; the loop passes the env-aware
+            # default). A step that would not move (off-ladder, or already at the bound) records
+            # the recommendation but actuates nothing. ---
+            cooldown_key = _lane_cooldown_key(role, agent)
+            cooling = incoming.get(cooldown_key, 0)
+            effort_from = effort_resolver(agent, role)
+            effort_to: str | None = None
+            actuated = False
+            actuate_reason = ""
+            if cooling > 0:
+                actuate_reason = f"in cooldown ({cooling} iteration(s) remaining)"
+            else:
+                stepped = _step_lane_effort(agent, effort_from, delta)
+                if stepped is None:
+                    actuate_reason = f"effort '{effort_from}' is off the {agent} ladder; not stepped"
+                elif stepped == effort_from:
+                    actuate_reason = f"already clamped at ladder bound '{effort_from}'"
+                else:
+                    effort_to = stepped
+                    actuated = True
+                    actuate_reason = f"effort {effort_from} -> {effort_to}"
+                    effort_overrides[(role, agent)] = effort_to
+                    new_cooldown_state[cooldown_key] = config.cooldown
             recommendations.append(
                 {
                     "role": role,
@@ -11771,14 +11933,15 @@ def compute_lane_autotune(
                     "fail_threshold": config.fail_threshold,
                     "fail_signal": "no-signal" if fail_rate is None else "observed",
                     "direction": direction,
-                    "actuated": False,
-                    "note": (
-                        "recommendation-only (PR1); PR2 would "
-                        + ("raise effort +1 (strengthen)" if direction == "strengthen" else "lower effort -1 (accelerate)")
-                    ),
+                    "effort_from": effort_from,
+                    "effort_to": effort_to,
+                    "actuated": actuated,
+                    "cooldown_remaining": cooling,
+                    "cooldown_set": config.cooldown if actuated else None,
+                    "note": actuate_reason,
                 }
             )
-    return recommendations, events
+    return effort_overrides, recommendations, new_cooldown_state, events
 
 
 def choose_agent(role: str, *, agent_mix: dict[str, object], rolling: dict[str, object]) -> str:
@@ -11993,6 +12156,7 @@ def _run_agent_lane(
     codex_runner=None,
     prior_artifact: dict | None = None,
     timeout_seconds: int | None = None,
+    effort_override: str | None = None,
 ) -> dict[str, object]:
     """Dispatch one read-only lane and return the shared review-artifact core.
 
@@ -12001,6 +12165,12 @@ def _run_agent_lane(
     is active (BIDMATE_DUAL_LANE_ADVERSARIAL=1), so this lane can challenge it. The
     returned core also exposes ``_lane_meta`` with the model/effort actually used so the
     caller can persist it into the artifact + events.jsonl heartbeat.
+
+    ADR 0092 (PR2, AC9): ``effort_override`` is the opt-in lane-autotune effort for this
+    ``(role, agent)`` lane on this iteration. ``None`` (the default / off path) resolves the
+    role-table effort unchanged (byte-identical). It only affects the claude lane's
+    ``--effort`` — the codex adversarial-review subcommand still does not consume effort, so
+    its ``effort_applied`` stays False regardless.
     """
     try:
         from scripts import agent_loop_claude_turn as claude_turn, agent_loop_codex_turn as codex_turn
@@ -12008,7 +12178,7 @@ def _run_agent_lane(
         import agent_loop_claude_turn as claude_turn  # type: ignore[no-redef]
         import agent_loop_codex_turn as codex_turn  # type: ignore[no-redef]
     model = _resolve_lane_model(agent, role)
-    effort = _resolve_lane_effort(agent, role)
+    effort = _resolve_lane_effort_override(agent, role, effort_override)
     if agent == "claude":
         effort = _validate_effort_for_model(model, effort)
         # ADR 0082: stale CLI (< 2.1.150) rejects `--effort` as unknown option → verdict=error.
@@ -12113,6 +12283,7 @@ def write_agent_turn(
     repo_root: Path = ROOT_DIR,
     prior_artifact: dict | None = None,
     timeout_seconds: int | None = None,
+    effort_override: str | None = None,
 ) -> AgentTurnResult:
     """Run one read-only Claude/Codex review lane; persist artifact + lane heartbeat.
 
@@ -12120,6 +12291,9 @@ def write_agent_turn(
     core (verdict/summary/findings/next_steps); this function authoritatively sets the
     meta fields, runs a fail-closed privacy scrub (ADR 0005), records the Work Unit, and
     drives ``write_session_heartbeat`` so the conservative gate sees the lane verdict.
+
+    ADR 0092 (PR2, AC9): ``effort_override`` threads the opt-in lane-autotune effort into
+    the claude review lane's ``--effort``; ``None`` keeps today's role-table effort.
     """
     safe_session = _validate_session_id(session_id)
     safe_role = _sanitize_inline_text(role)
@@ -12168,6 +12342,7 @@ def write_agent_turn(
         codex_runner=codex_runner,
         prior_artifact=prior_artifact,
         timeout_seconds=timeout_seconds,
+        effort_override=effort_override,
     )
     verdict = str(core.get("verdict") or "needs-attention")
     artifact_path = _agent_turn_artifact_path(
@@ -13951,6 +14126,7 @@ def write_active_codex_runner(
     claude_runner=None,
     runner: str = "codex",
     omc_runner=None,
+    effort_overrides: "dict[tuple[str, str], str] | None" = None,
 ) -> ActiveCodexRunnerResult:
     """Plan or spawn Codex processes for the active loop.
 
@@ -13985,6 +14161,14 @@ def write_active_codex_runner(
     # ADR 0092: resolve once per runner call. When OFF, no per-lane elapsed_s is recorded
     # into the session dicts so the runner state file / report stay byte-identical.
     lane_autotune_on = _lane_autotune_enabled()
+    # ADR 0092 (PR2, AC9/AC10): per-(role, agent) effort overrides from the controller, applied
+    # to this iteration's lanes. Empty/None == no actuation (byte-identical). A helper keeps the
+    # per-call-site lookup terse; off-mode never populates it so off paths stay unchanged.
+    _effort_overrides: dict[tuple[str, str], str] = dict(effort_overrides) if effort_overrides else {}
+
+    def _lane_effort_for(role: str, lane_agent: str) -> str | None:
+        return _effort_overrides.get((role, lane_agent)) if _effort_overrides else None
+
     registry_path = _active_path(registry, repo_root=repo_root)
     assignments_path = _active_path(assignments_dir, repo_root=repo_root)
     runs_path = _active_path(runs_dir, repo_root=repo_root)
@@ -14037,6 +14221,8 @@ def write_active_codex_runner(
             git_runner=git_runner,
             write_agent=write_agent,
             claude_runner=claude_runner,
+            # ADR 0092 (PR2): thread the controller's effort overrides into the patch lane.
+            effort_overrides=_effort_overrides or None,
         )
 
     blockers: list[str] = []
@@ -14081,6 +14267,7 @@ def write_active_codex_runner(
                                 sandbox=sandbox,
                                 last_message_path=last_message_path,
                                 repo_root=repo_root,
+                                effort=_lane_effort_for(role, session_agent),
                             )
                         )
                     )
@@ -14188,6 +14375,9 @@ def write_active_codex_runner(
                             # Claude read lane so a hung review session is bounded by the
                             # wall-clock budget when one is set (0 == unlimited otherwise).
                             timeout_seconds=timeout_seconds,
+                            # ADR 0092 (PR2, AC9): apply the opt-in lane-autotune effort for this
+                            # (role, claude) lane; None == today's role-table effort.
+                            effort_override=_lane_effort_for(role, "claude"),
                         )
                     except Exception as exc:  # fail closed; the loop can route repair/retry.
                         item["status"] = "failed"
@@ -14249,6 +14439,9 @@ def write_active_codex_runner(
                     sandbox=sandbox,
                     last_message_path=last_message_path,
                     repo_root=repo_root,
+                    # ADR 0092 (PR2, AC10): inject the opt-in lane-autotune effort for this
+                    # (role, codex) lane as `-c model_reasoning_effort`; None == byte-identical.
+                    effort=_lane_effort_for(role, session_agent),
                 )
                 stderr_file = None
                 try:
@@ -14532,6 +14725,7 @@ def _write_active_codex_patch(
     write_agent: str = "codex",
     claude_runner=None,
     now: datetime | None = None,
+    effort_overrides: "dict[tuple[str, str], str] | None" = None,
 ) -> ActiveCodexRunnerResult:
     """Patch mode: a single write-lane on the Implementer (write-lease owner).
 
@@ -14584,6 +14778,11 @@ def _write_active_codex_patch(
     else:
         agent = write_agent
     resolved_model = _resolve_lane_model_override(agent, "Implementer", model)
+    # ADR 0092 (PR2, AC9/AC10): the patch lane is always the ("Implementer", agent) lane —
+    # resolve its opt-in effort override once. None == today's role-table effort (byte-identical).
+    patch_effort_override = (
+        effort_overrides.get(("Implementer", agent)) if effort_overrides else None
+    )
 
     # ADR 0086 (Codex finding) fail-closed: the Claude write lane runs with bypass-style
     # permissions and cannot enforce the codex OS sandbox (``DEFAULT_PATCH_SANDBOX``). Under
@@ -14661,6 +14860,7 @@ def _write_active_codex_patch(
                             last_message_path=last_message_path,
                             repo_root=repo_root,
                             cd=str(scratch_path),
+                            effort=patch_effort_override,
                         )
                     )
                 )
@@ -14773,7 +14973,13 @@ def _write_active_codex_patch(
                     )
                     rc: int | None = None
                     if agent == "claude":
-                        effort = _validate_effort_for_model(resolved_model, _resolve_lane_effort("claude", "Implementer"))
+                        # ADR 0092 (PR2, AC9): apply the opt-in lane-autotune effort override
+                        # (None == today's role-table effort), then keep the claude-only
+                        # _validate_effort_for_model guard (xhigh→high for non-Opus models).
+                        effort = _validate_effort_for_model(
+                            resolved_model,
+                            _resolve_lane_effort_override("claude", "Implementer", patch_effort_override),
+                        )
                         if claude_runner is None and not _claude_cli_supports_effort():
                             effort = ""
                         # ADR 0085: 0 (env or --timeout-seconds) now means *unlimited* for
@@ -14828,6 +15034,9 @@ def _write_active_codex_patch(
                             last_message_path=last_message_path,
                             repo_root=repo_root,
                             cd=str(created_path),
+                            # ADR 0092 (PR2, AC10): inject the patch-lane effort override as
+                            # `-c model_reasoning_effort`; None == byte-identical.
+                            effort=patch_effort_override,
                         )
                         factory = popen_factory if popen_factory is not None else subprocess.Popen
                         proc = None
@@ -16214,6 +16423,7 @@ def _active_codex_exec_command(
     last_message_path: Path,
     repo_root: Path,
     cd: str = ".",
+    effort: str | None = None,
 ) -> list[str]:
     command = [
         codex_executable,
@@ -16226,6 +16436,14 @@ def _active_codex_exec_command(
     ]
     if model:
         command.extend(["--model", model])
+    # ADR 0092 (PR2, AC10): opt-in lane-autotune effort override. ``-c model_reasoning_effort``
+    # MUST land in the --model-adjacent flag block, BEFORE the positional ``-`` stdin marker
+    # below — codex argparse breaks if a ``-c`` flag follows the positional ``-`` (a bare
+    # ``["-", "-c", ...]`` ordering is rejected). ``effort is None`` (the default for every
+    # non-autotune call site) appends nothing, so the rendered command stays byte-identical to
+    # today (AC14).
+    if effort:
+        command.extend(["-c", f"model_reasoning_effort={effort}"])
     command.extend([
         "--output-last-message",
         _repo_path(last_message_path, repo_root),
@@ -18276,6 +18494,7 @@ def build_parser() -> argparse.ArgumentParser:
     auto_loop.add_argument("--lane-autotune-fail-window", type=int, default=None, help="fail_rate window W in iterations (default 3).")
     auto_loop.add_argument("--lane-autotune-fail-min-sample", type=int, default=None, help="Minimum observations before a fail_rate signal (default 2).")
     auto_loop.add_argument("--lane-autotune-fail-threshold", type=float, default=None, help="fail_rate threshold for strengthen vs accelerate (default 0.5).")
+    auto_loop.add_argument("--lane-autotune-cooldown", type=int, default=None, help="Iterations a just-actuated lane is held before re-adjustment (ADR 0092 PR2; default 2).")
 
     active_apply = sub.add_parser("active-apply", help="Apply a codex patch artifact to its integration branch after git apply --check (never touches main).")
     active_apply.add_argument("--patch", type=Path, help="Patch artifact JSON; defaults to the Implementer session's patch_artifact.json.")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3845,6 +3845,112 @@ def test_active_codex_runner_lane_autotune_on_dry_run_still_omits_effort_flag(mo
     assert all("-c model_reasoning_effort" not in item["command"] for item in result.sessions)
 
 
+def test_active_codex_runner_applies_effort_override_to_codex_command(tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC10: when the controller supplies an effort override for a (role, codex)
+    lane, the runner injects ``-c model_reasoning_effort`` into THAT lane's rendered command
+    (and only that lane). Dry-run -> no spawn, command-only assertion (3795-series anchor)."""
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    result = agent_loop.write_active_codex_runner(
+        repo_root=repo,
+        effort_overrides={("CI / Regression Auditor", "codex"): "high"},
+    )
+
+    assert result.decision == "planned"
+    target = next(item for item in result.sessions if item["role"] == "CI / Regression Auditor")
+    assert "-c model_reasoning_effort=high" in target["command"]
+    # Only the targeted lane is actuated; every other lane stays byte-identical (no -c).
+    others = [item for item in result.sessions if item["role"] != "CI / Regression Auditor"]
+    assert others  # sanity: there are other lanes
+    assert all("model_reasoning_effort" not in item["command"] for item in others)
+
+
+def test_active_codex_runner_empty_effort_overrides_is_byte_identical(tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC14: an empty/None effort_overrides leaves every rendered command
+    byte-identical (no -c model_reasoning_effort), same as not passing the kwarg at all."""
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    result = agent_loop.write_active_codex_runner(repo_root=repo, effort_overrides=None)
+
+    assert result.decision == "planned"
+    assert all("model_reasoning_effort" not in item["command"] for item in result.sessions)
+
+
+def test_active_codex_runner_applies_effort_override_to_claude_read_lane(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC9: an effort override for a (role, claude) lane threads into the claude
+    review subprocess command as ``--effort <level>``. The CLI-version gate is forced ON so the
+    test does not depend on the local claude version (AC9 skips effort when effort_applied=False)."""
+    monkeypatch.setattr(agent_loop, "_claude_cli_supports_effort", lambda: True)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+
+    def fake_claude(cmd):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {"result": {"verdict": "approved", "summary": "ok", "findings": [], "next_steps": []}}
+            ),
+            stderr="",
+        )
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        read_agent="claude",
+        sessions="reviewer",
+        repo_root=repo,
+        which_func=lambda exe: f"/usr/bin/{exe}",
+        claude_runner=fake_claude,
+        record_gate_heartbeats=True,
+        effort_overrides={("Reviewer", "claude"): "high"},
+    )
+
+    assert result.decision == "completed"
+    assert calls, "claude lane should have been invoked"
+    cmd = calls[0]
+    assert "--effort" in cmd
+    assert cmd[cmd.index("--effort") + 1] == "high"
+
+
+def test_active_codex_runner_claude_lane_skips_effort_when_cli_unsupported(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC9: when the claude CLI cannot consume --effort (< 2.1.150), the override
+    is dropped (effort_applied=False) rather than passed as an unknown flag — the lane still runs."""
+    monkeypatch.setattr(agent_loop, "_claude_cli_supports_effort", lambda: False)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+
+    def fake_claude(cmd):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {"result": {"verdict": "approved", "summary": "ok", "findings": [], "next_steps": []}}
+            ),
+            stderr="",
+        )
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        read_agent="claude",
+        sessions="reviewer",
+        repo_root=repo,
+        which_func=lambda exe: f"/usr/bin/{exe}",
+        claude_runner=fake_claude,
+        record_gate_heartbeats=True,
+        effort_overrides={("Reviewer", "claude"): "high"},
+    )
+
+    assert result.decision == "completed"
+    assert calls, "claude lane should have been invoked"
+    assert "--effort" not in calls[0]
+
+
 def test_active_codex_runner_can_execute_claude_read_lane(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     _write_expanded_active_runner_fixture(repo)
@@ -6948,6 +7054,69 @@ def test_codex_runner_patch_mode_embeds_assignment_in_prompt(tmp_path: Path) -> 
     assert "ASSIGNMENT-MARKER: refactor foo." in prompt
 
 
+def test_codex_runner_patch_mode_applies_effort_override(tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC10: an Implementer/codex effort override injects -c model_reasoning_effort
+    into the spawned codex patch command, before the positional '-' stdin marker."""
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo, claimed_files=["foo.py"])
+    _seed_patch_assignment(repo)
+    spawned: list[list[str]] = []
+
+    def capture_factory(cmd, **kw):  # type: ignore[no-untyped-def]
+        spawned.append(list(cmd))
+        return _FakeCodexProc()
+
+    agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        write_agent="codex",
+        repo_root=repo,
+        popen_factory=capture_factory,
+        which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
+        git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
+        effort_overrides={("Implementer", "codex"): "high"},
+    )
+
+    assert spawned, "codex patch lane should have spawned"
+    cmd = spawned[0]
+    assert "-c" in cmd
+    assert "model_reasoning_effort=high" in cmd
+    assert cmd[-1] == "-"  # positional stdin marker is last
+    assert cmd.index("-c") < len(cmd) - 1  # -c precedes the positional '-'
+
+
+def test_codex_runner_patch_mode_no_override_is_byte_identical(tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC14: without an effort override the spawned codex patch command carries
+    no -c model_reasoning_effort (byte-identical to today)."""
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo, claimed_files=["foo.py"])
+    _seed_patch_assignment(repo)
+    spawned: list[list[str]] = []
+
+    def capture_factory(cmd, **kw):  # type: ignore[no-untyped-def]
+        spawned.append(list(cmd))
+        return _FakeCodexProc()
+
+    agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        write_agent="codex",
+        repo_root=repo,
+        popen_factory=capture_factory,
+        which_func=lambda exe: "/usr/bin/codex",
+        auth_runner=_chatgpt_auth_runner,
+        git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
+    )
+
+    assert spawned, "codex patch lane should have spawned"
+    assert all("model_reasoning_effort" not in tok for tok in spawned[0])
+
+
 # --- Phase 4: claimed_files scope enforcement on the codex patch lane (issue #1612) ---
 
 
@@ -9953,9 +10122,21 @@ def _autotune_cfg(**overrides):  # type: ignore[no-untyped-def]
     return agent_loop.LaneAutotuneConfig(**base)
 
 
+# ADR 0092 PR2: compute_lane_autotune signature is now
+# (prior_lane_stats, cooldown_state, config, *, effort_resolver) ->
+# (effort_overrides, recommendations, new_cooldown_state, events). These sense/detect tests
+# pass a fixed effort_resolver so the assertions stay deterministic (independent of the
+# env-aware default) and unpack the 4-tuple; cooldown/actuation specifics have dedicated tests.
+_FIXED_EFFORT = lambda _agent, _role: "medium"  # noqa: E731 — terse test seam
+
+
 def test_compute_lane_autotune_empty_history_is_noop() -> None:
-    recs, events = agent_loop.compute_lane_autotune([], _autotune_cfg())
+    overrides, recs, cooldown, events = agent_loop.compute_lane_autotune(
+        [], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
+    assert overrides == {}
     assert recs == []
+    assert cooldown == {}
     assert events == []
 
 
@@ -9966,7 +10147,9 @@ def test_compute_lane_autotune_within_agent_median_flags_slow_lane() -> None:
         {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
     ]
-    recs, _events = agent_loop.compute_lane_autotune([batch], _autotune_cfg())
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        [batch], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
     assert [r["role"] for r in recs] == ["C"]
     assert recs[0]["agent"] == "codex"
     assert recs[0]["median_elapsed_s"] == 10.0
@@ -9974,7 +10157,10 @@ def test_compute_lane_autotune_within_agent_median_flags_slow_lane() -> None:
     # Single observation of C -> below min-sample -> no fail signal -> accelerate.
     assert recs[0]["fail_signal"] == "no-signal"
     assert recs[0]["direction"] == "accelerate"
-    assert recs[0]["actuated"] is False
+    # PR2: not in cooldown + on-ladder -> actuates (medium -> low for accelerate).
+    assert recs[0]["actuated"] is True
+    assert recs[0]["effort_from"] == "medium"
+    assert recs[0]["effort_to"] == "low"
 
 
 def test_compute_lane_autotune_groups_per_agent_separately() -> None:
@@ -9987,7 +10173,9 @@ def test_compute_lane_autotune_groups_per_agent_separately() -> None:
         {"role": "Y", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "Z", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
     ]
-    recs, _events = agent_loop.compute_lane_autotune([batch], _autotune_cfg())
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        [batch], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
     flagged = {(r["role"], r["agent"]) for r in recs}
     assert flagged == {("Z", "codex")}  # within-agent only: claude's 500s lanes are not cross-compared
 
@@ -9998,7 +10186,10 @@ def test_compute_lane_autotune_degenerate_single_lane_is_noop() -> None:
         {"role": "A", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
         {"role": "B", "agent": "claude", "elapsed_s": 5.0, "status": "completed"},
     ]
-    recs, events = agent_loop.compute_lane_autotune([batch], _autotune_cfg())
+    overrides, recs, _cd, events = agent_loop.compute_lane_autotune(
+        [batch], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
+    assert overrides == {}
     assert recs == []
     assert all(e["decision"] == "no-op" for e in events)
     assert {e["agent"] for e in events} == {"codex", "claude"}
@@ -10016,12 +10207,17 @@ def test_compute_lane_autotune_fail_rate_window_strengthens_failing_lane() -> No
         {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
     ]
-    recs, _events = agent_loop.compute_lane_autotune([fail_iter, fail_iter, newest], _autotune_cfg())
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
     c = next(r for r in recs if r["role"] == "C")
     assert c["fail_signal"] == "observed"
     assert c["fail_sample"] == 3
     assert c["fail_rate"] == round(2 / 3, 3)
     assert c["direction"] == "strengthen"
+    # PR2: strengthen steps medium -> high.
+    assert c["effort_from"] == "medium"
+    assert c["effort_to"] == "high"
 
 
 def test_compute_lane_autotune_min_sample_gate_yields_no_fail_signal() -> None:
@@ -10031,7 +10227,9 @@ def test_compute_lane_autotune_min_sample_gate_yields_no_fail_signal() -> None:
         {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
     ]
-    recs, _events = agent_loop.compute_lane_autotune([newest], _autotune_cfg())
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        [newest], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
     c = next(r for r in recs if r["role"] == "C")
     assert c["fail_signal"] == "no-signal"
     assert c["fail_sample"] == 1
@@ -10052,7 +10250,9 @@ def test_compute_lane_autotune_window_resets_on_agent_flip() -> None:
             {"role": "T", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
         ],
     ]
-    recs, _events = agent_loop.compute_lane_autotune(history, cfg)
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        history, None, cfg, effort_resolver=_FIXED_EFFORT
+    )
     r = next(x for x in recs if x["role"] == "R")
     assert r["agent"] == "claude"
     assert r["fail_signal"] == "no-signal"  # reset: codex failures excluded
@@ -10068,9 +10268,193 @@ def test_compute_lane_autotune_ignores_lanes_without_elapsed() -> None:
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
         {"role": "D", "agent": "codex", "elapsed_s": None, "status": "timeout"},
     ]
-    recs, _events = agent_loop.compute_lane_autotune([newest], _autotune_cfg())
+    _ov, recs, _cd, _events = agent_loop.compute_lane_autotune(
+        [newest], None, _autotune_cfg(), effort_resolver=_FIXED_EFFORT
+    )
     # median over the 3 timed lanes (10,10,100) = 10; only C exceeds 20. D is never elapsed-flagged.
     assert [r["role"] for r in recs] == ["C"]
+
+
+# ---------------------------------------------------------------------------
+# ADR 0092 PR2 — actuate: effort override resolution, per-agent ladder clamp,
+# 2-signal direction + cooldown, codex/claude command injection, byte-identical-off
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_lane_effort_override_none_is_byte_identical(monkeypatch) -> None:
+    """AC14: None override resolves exactly the role-table effort (byte-identical off path)."""
+    for key in list(os.environ.keys()):
+        if key.startswith("BIDMATE_CLAUDE_LANE_") or key.startswith("BIDMATE_CODEX_LANE_"):
+            monkeypatch.delenv(key, raising=False)
+    # claude Planner baseline xhigh; codex CI Auditor baseline medium.
+    assert agent_loop._resolve_lane_effort_override("claude", "Planner / Issue Triage", None) == "xhigh"
+    assert agent_loop._resolve_lane_effort_override("codex", "CI / Regression Auditor", None) == "medium"
+    assert agent_loop._resolve_lane_effort_override("claude", "Planner / Issue Triage", None) == agent_loop._resolve_lane_effort(
+        "claude", "Planner / Issue Triage"
+    )
+
+
+def test_resolve_lane_effort_override_requested_wins() -> None:
+    """A provided override wins over the role-table baseline (mirrors _resolve_lane_model_override)."""
+    assert agent_loop._resolve_lane_effort_override("codex", "CI / Regression Auditor", "high") == "high"
+    assert agent_loop._resolve_lane_effort_override("claude", "Planner / Issue Triage", "low") == "low"
+
+
+def test_step_lane_effort_per_agent_ladder_and_clamp() -> None:
+    """AC11: claude ladder tops at xhigh (no max), codex tops at high; both clamp at bounds."""
+    # claude ladder: low < medium < high < xhigh
+    assert agent_loop._step_lane_effort("claude", "medium", 1) == "high"
+    assert agent_loop._step_lane_effort("claude", "high", 1) == "xhigh"
+    assert agent_loop._step_lane_effort("claude", "xhigh", 1) == "xhigh"  # clamp at ceiling (no max rung)
+    assert agent_loop._step_lane_effort("claude", "low", -1) == "low"  # clamp at floor
+    assert "max" not in agent_loop._CLAUDE_EFFORT_LADDER
+    # codex ladder: minimal < low < medium < high
+    assert agent_loop._step_lane_effort("codex", "medium", 1) == "high"
+    assert agent_loop._step_lane_effort("codex", "high", 1) == "high"  # clamp at ceiling (no xhigh rung)
+    assert agent_loop._step_lane_effort("codex", "minimal", -1) == "minimal"  # clamp at floor
+    assert agent_loop._step_lane_effort("codex", "low", -1) == "minimal"
+    # off-ladder value -> None (left for the lane to resolve)
+    assert agent_loop._step_lane_effort("codex", "xhigh", -1) is None
+    assert agent_loop._step_lane_effort("claude", "minimal", 1) is None
+
+
+def test_compute_lane_autotune_codex_ceiling_clamp_records_no_override() -> None:
+    """AC11/AC12: a codex strengthen at the ladder ceiling (high) clamps -> no override emitted,
+    but the recommendation is still recorded (with actuated False)."""
+    fail_iter = [
+        {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    newest = [
+        {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    # C fails 3/3 -> strengthen; but baseline already 'high' -> step clamps -> no actuation.
+    high_baseline = lambda _agent, _role: "high"  # noqa: E731
+    overrides, recs, cooldown, _events = agent_loop.compute_lane_autotune(
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=high_baseline
+    )
+    c = next(r for r in recs if r["role"] == "C")
+    assert c["direction"] == "strengthen"
+    assert c["actuated"] is False
+    assert c["effort_to"] is None
+    assert ("C", "codex") not in overrides
+    assert cooldown == {}  # nothing actuated -> nothing to cool down
+
+
+def test_compute_lane_autotune_cooldown_suppresses_then_decrements() -> None:
+    """AC13: a lane already in cooldown is not re-adjusted; its remaining ticks down each call."""
+    batch = [
+        {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+    ]
+    res = lambda _agent, _role: "medium"  # noqa: E731
+    cfg = _autotune_cfg(cooldown=2)
+    # Iter 1: actuate C -> cooldown 2.
+    ov1, recs1, cd1, _e1 = agent_loop.compute_lane_autotune([batch], None, cfg, effort_resolver=res)
+    assert ov1 == {("C", "codex"): "low"}
+    assert cd1 == {"C||codex": 2}
+    assert recs1[0]["actuated"] is True
+    # Iter 2: C in cooldown -> suppressed, no override; cooldown decremented to 1.
+    ov2, recs2, cd2, _e2 = agent_loop.compute_lane_autotune([batch], cd1, cfg, effort_resolver=res)
+    assert ov2 == {}
+    assert cd2 == {"C||codex": 1}
+    assert recs2[0]["actuated"] is False
+    assert recs2[0]["cooldown_remaining"] == 2
+    # Iter 3: still in cooldown (1) -> suppressed; decrement to 0 -> dropped.
+    ov3, _recs3, cd3, _e3 = agent_loop.compute_lane_autotune([batch], cd2, cfg, effort_resolver=res)
+    assert ov3 == {}
+    assert cd3 == {}
+    # Iter 4: cooldown cleared -> re-actuates.
+    ov4, _recs4, cd4, _e4 = agent_loop.compute_lane_autotune([batch], cd3, cfg, effort_resolver=res)
+    assert ov4 == {("C", "codex"): "low"}
+    assert cd4 == {"C||codex": 2}
+
+
+def test_compute_lane_autotune_claude_strengthen_uses_validate_safe_rung() -> None:
+    """AC12: claude flagged lane with high fail_rate strengthens up its ladder (medium -> high)."""
+    fail_iter = [
+        {"role": "RC1", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "RC2", "agent": "claude", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    newest = [
+        {"role": "RC1", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "RC3", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "RC2", "agent": "claude", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    res = lambda _agent, _role: "medium"  # noqa: E731
+    overrides, recs, _cd, _e = agent_loop.compute_lane_autotune(
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=res
+    )
+    rc2 = next(r for r in recs if r["role"] == "RC2")
+    assert rc2["direction"] == "strengthen"
+    assert overrides[("RC2", "claude")] == "high"
+
+
+def test_active_codex_exec_command_injects_effort_before_positional_dash() -> None:
+    """AC10 (code blocker): -c model_reasoning_effort lands in the --model-adjacent block,
+    strictly BEFORE the positional '-' stdin marker (codex argparse breaks otherwise)."""
+    cmd = agent_loop._active_codex_exec_command(
+        codex_executable="codex",
+        model="gpt-5.5",
+        sandbox="read-only",
+        last_message_path=Path("/tmp/lm.md"),
+        repo_root=Path("/tmp"),
+        effort="high",
+    )
+    assert "-c" in cmd
+    assert "model_reasoning_effort=high" in cmd
+    c_idx = cmd.index("-c")
+    val_idx = cmd.index("model_reasoning_effort=high")
+    assert cmd[c_idx + 1] == "model_reasoning_effort=high"  # adjacent key=value
+    # positional stdin marker is the LAST token; -c must precede it.
+    assert cmd[-1] == "-"
+    last_dash_idx = len(cmd) - 1
+    assert c_idx < last_dash_idx and val_idx < last_dash_idx
+    # and it must sit after --model (the adjacent flag block), before --output-last-message.
+    assert cmd.index("--model") < c_idx < cmd.index("--output-last-message")
+
+
+def test_active_codex_exec_command_effort_none_is_byte_identical() -> None:
+    """AC14: effort None (the default for every non-autotune call site) appends nothing."""
+    cmd = agent_loop._active_codex_exec_command(
+        codex_executable="codex",
+        model="gpt-5.5",
+        sandbox="read-only",
+        last_message_path=Path("/tmp/lm.md"),
+        repo_root=Path("/tmp"),
+    )
+    assert "-c" not in cmd
+    assert all("model_reasoning_effort" not in tok for tok in cmd)
+    # exactly today's shape.
+    assert cmd == [
+        "codex", "exec", "--cd", ".", "--sandbox", "read-only", "--json",
+        "--model", "gpt-5.5", "--output-last-message", "lm.md", "-",
+    ]
+
+
+def test_active_claude_patch_command_threads_effort_flag() -> None:
+    """AC9: the claude patch command carries --effort <level> when an effort is supplied."""
+    cmd = agent_loop._active_claude_patch_command(
+        claude_executable="claude",
+        prompt="do the thing",
+        model="claude-opus-4-8",
+        effort="xhigh",
+        cwd=Path("/tmp/scratch"),
+    )
+    assert "--effort" in cmd
+    assert cmd[cmd.index("--effort") + 1] == "xhigh"
+    # empty effort -> no flag (CLI < 2.1.150 strip path / off).
+    cmd_off = agent_loop._active_claude_patch_command(
+        claude_executable="claude",
+        prompt="do the thing",
+        model="claude-opus-4-8",
+        effort="",
+        cwd=Path("/tmp/scratch"),
+    )
+    assert "--effort" not in cmd_off
 
 
 def test_resolve_lane_autotune_config_off_by_default(monkeypatch) -> None:
@@ -10148,15 +10532,22 @@ def test_active_auto_loop_records_lane_recommendations_from_runner_sessions(monk
         "Reviewer",
         "CI / Regression Auditor",
     }
-    # The within-agent slow lane (100s vs median 10s) is recommended (AC4/AC8), recommendation-only.
+    # The within-agent slow lane (100s vs median 10s) is recommended AND actuated (PR2):
+    # CI / Regression Auditor codex baseline effort is medium; single obs -> no fail signal
+    # -> accelerate -> medium steps down to low, and the lane enters cooldown (AC9-AC13).
     state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
     recs = state["lane_autotune_recommendations"]
     assert len(recs) == 1
     assert recs[0]["role"] == "CI / Regression Auditor"
     assert recs[0]["agent"] == "codex"
-    assert recs[0]["actuated"] is False
+    assert recs[0]["actuated"] is True
+    assert recs[0]["effort_from"] == "medium"
+    assert recs[0]["effort_to"] == "low"
+    assert recs[0]["direction"] == "accelerate"
     assert recs[0]["iteration"] == 1
     assert recs[0]["task_id"] == "T-2026-1001"
+    # cooldown_state persisted for the just-actuated lane (default cooldown 2).
+    assert state["lane_autotune_cooldown"] == {"CI / Regression Auditor||codex": 2}
 
 
 def test_active_auto_loop_off_records_no_lane_autotune_keys(monkeypatch, tmp_path: Path) -> None:
@@ -10202,3 +10593,135 @@ def test_active_auto_loop_off_records_no_lane_autotune_keys(monkeypatch, tmp_pat
     assert "lane_stats" not in result.cycles[0]
     state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
     assert "lane_autotune_recommendations" not in state
+    assert "lane_autotune_cooldown" not in state
+
+
+def test_active_auto_loop_applies_effort_override_to_next_runner_call(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC9/AC10: the controller's effort override for a within-agent slow lane is
+    threaded into the runner call (here the first/only iteration's runner receives no override
+    because there is no PRIOR observation yet; the override is computed AFTER the runner and
+    flows to the next iteration — which we assert via the persisted cooldown + recommendation)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Autotune actuate task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    captured_overrides: list[object] = []
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        captured_overrides.append(kwargs.get("effort_overrides"))
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        sessions = (
+            {"role": "Implementer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "Reviewer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "CI / Regression Auditor", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+        )
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", sessions, (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        auto_max_iterations_cap=1,
+        execute_runner=True,
+        execute_ship=False,
+        auto_repair=False,
+        lane_autotune_config=agent_loop.LaneAutotuneConfig(),
+        repo_root=repo,
+    )
+
+    assert result.completed_task_ids == ("T-2026-1001",)
+    # First runner call: no prior observations -> no override yet (None passed through).
+    assert captured_overrides[0] is None
+    # The controller actuated the slow CI / Regression Auditor codex lane (medium -> low) and
+    # persisted the override into the cycle audit + the cooldown into the state file.
+    cycle = result.cycles[0]
+    assert cycle["lane_autotune"]["effort_overrides"] == {"CI / Regression Auditor||codex": "low"}
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["lane_autotune_cooldown"] == {"CI / Regression Auditor||codex": 2}
+
+
+def test_active_auto_loop_resumes_cooldown_from_prior_run_and_decrements(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0092 PR2 AC13 cross-run: a lane left in cooldown by a prior run is read back from
+    auto_loop_state.json, suppressed this run (no effort override threaded to the runner), and
+    its cooldown is decremented + re-persisted."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1002", title="Autotune cooldown resume task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    active_dir.mkdir(parents=True, exist_ok=True)
+    # Pre-seed a prior run's state: the slow lane was actuated last run and is mid-cooldown,
+    # AND a prior cycle's lane_stats so the controller has a history window to flag it again.
+    (active_dir / "auto_loop_state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "cycles": [
+                    {
+                        "lane_stats": [
+                            {"role": "Implementer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+                            {"role": "Reviewer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+                            {"role": "CI / Regression Auditor", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+                        ]
+                    }
+                ],
+                "lane_autotune_cooldown": {"CI / Regression Auditor||codex": 2},
+                "lane_autotune_recommendations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured_overrides: list[object] = []
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        captured_overrides.append(kwargs.get("effort_overrides"))
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        sessions = (
+            {"role": "Implementer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "Reviewer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "CI / Regression Auditor", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+        )
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", sessions, (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        auto_max_iterations_cap=1,
+        execute_runner=True,
+        execute_ship=False,
+        auto_repair=False,
+        lane_autotune_config=agent_loop.LaneAutotuneConfig(),
+        repo_root=repo,
+    )
+
+    assert result.completed_task_ids == ("T-2026-1002",)
+    # The lane is in cooldown from the prior run -> NOT re-actuated this run.
+    cycle = result.cycles[0]
+    assert cycle["lane_autotune"]["effort_overrides"] == {}
+    rec = next(r for r in cycle["lane_autotune"]["recommendations"] if r["role"] == "CI / Regression Auditor")
+    assert rec["actuated"] is False
+    assert rec["cooldown_remaining"] == 2
+    # Cooldown decremented from 2 -> 1 and re-persisted for the next run.
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["lane_autotune_cooldown"] == {"CI / Regression Auditor||codex": 1}


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

lane autotune **actuate (PR2)** — PR1([#1717](https://github.com/hskim-solv/BidMate-DocAgent/pull/1717), merged)의 sense+detect 권고를 실제 effort 조정으로 연결한다. controller가 `effort_overrides`를 내고 loop→runner→lane adapter로 thread해 다음 iteration에 주입: claude `--effort`, codex `-c model_reasoning_effort`(positional `-` 이전 삽입). per-agent ladder clamp + 2-신호(fail→강화 / success→가속) + cooldown N. 기본 OFF byte-identical.

설계: consensus plan(Architect+Critic 2R) PR2 + opus code-review SHIP-READY. codex `-c` 효력 런타임 검증(strict-config rc=0 + "reasoning effort" 배너).

Closes #1718

## 2. 영향 파일

- `scripts/agent_loop.py` (+291/−54, **non-load-bearing** ADR 0087(d)) — `_resolve_lane_effort_override`(`_resolve_lane_model_override` 대칭) + per-agent ladder/`_step_lane_effort` clamp + `compute_lane_autotune` 4-tuple 확장(cooldown_state→effort_overrides) + claude/codex/patch actuate threading + cooldown 영속
- `Makefile` (+12) — `ACTIVE_LANE_AUTOTUNE_COOLDOWN`
- `docs/adr/0092-lane-adaptive-autotune.md` (**load-bearing**) — PR2 landed + verifies-key
- `tests/test_agent_loop.py` (+545)

## 3. 리스크

가장 가능성 높은 깨짐: autotune OFF 시 effort 해석 경로가 미세 변화(PR2는 기존 함수 수정 — 54 deletion, PR1과 달리 순수 additive 아님). 배제 — `_resolve_lane_effort_override(agent,role,None)`이 `_resolve_lane_effort(agent,role)`와 **16 조합 동일** 반환, codex `effort=None`→기존 명령 리터럴 동일, 모든 신규 분기 gate 뒤. patch-lane은 별도 top-level 함수(`_write_active_codex_patch`)라 effort param 명시 thread(ruff F821이 NameError 사전 차단).

## 4. 테스트

- **byte-identical-off(AC14)**: 3795-계열 리터럴 명령 == 기존 + `-c model_reasoning_effort` 부재 (claude/codex/patch 3 lane).
- **codex actuate(AC10)**: `-c` positional `-` **이전** 삽입(`--model < -c < --output-last-message` 인덱스 단언) + 런타임 효력(strict-config rc=0 + "reasoning effort: high/low/minimal" 배너).
- **claude actuate(AC9)**: `--effort` 주입 + `effort_applied=False`(stale CLI) skip.
- **ladder clamp(AC11)** 경계(claude xhigh / codex high 상한, off-ladder→None) · **2-신호(AC12)** 방향 · **cooldown(AC13)** suppress+decrement+cross-run 복원.
- PR1 controller 테스트 4-tuple 시그니처 업데이트. `tests/test_agent_loop.py` 328 · `bash scripts/test.sh` **3273 pass** · ruff clean.

## 5. Eval 영향

All `·` (no eval delta). RAG 런타임 무접촉 — `agent_loop.py`+`Makefile` non-load-bearing(ADR 0087(d)). `docs/adr/` 문서만. autotune opt-in, 기본 OFF byte-identical.

## 6. 하위 호환

깨짐 없음. 신규 노브 opt-in(기본 off). `compute_lane_autotune` 시그니처는 내부 계약(공개 아님) — PR1 호출처/테스트 일괄 업데이트. 답변 계약(ADR 0003)/CLI flag 무관.

## 7. 범위 외

- codex `xhigh` rung — follow-up [#1723](https://github.com/hskim-solv/BidMate-DocAgent/issues/1723) (codex가 xhigh 수용하나 PR2는 high 상한).
- model-swap actuate · multi-worker diff · cross-agent 정규화 비교 — ADR 0092 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
