### PR TITLE
feat(agent-loop): extend codex effort ladder to xhigh (PR3, ADR 0092 follow-up)

### DIFF
--- a/docs/adr/0092-lane-adaptive-autotune.md
+++ b/docs/adr/0092-lane-adaptive-autotune.md
@@ -89,8 +89,10 @@ codex 명령(`-c model_reasoning_effort` 미주입)과 `auto_loop_state.json` �
   `compute_lane_autotune(prior_lane_stats, cooldown_state, config) ->
   (effort_overrides, recommendations, new_cooldown_state, events)`로 확장됨. codex effort 가드는
   controller ladder-clamp 단독(`_validate_effort_for_model`은 claude lane 전용 — 오인용 금지).
-- **codex `xhigh` rung.** controller 사다리는 `high` 상한; `~/.codex/config.toml`이 `xhigh`를
-  쓰더라도 PR2 사다리는 `high`까지만 → 필요 시 후속 검토.
+- **codex `xhigh` rung (PR3 — landed, #1723).** `_CODEX_EFFORT_LADDER`를 `high` → `xhigh`
+  상한으로 확장. `codex exec --strict-config -c model_reasoning_effort=xhigh` rc=0 (유효 값
+  확정) + `~/.codex/config.toml`이 xhigh 사용 → autotune이 codex 병목을 진짜 ceiling까지
+  강화 가능. (claude는 ADR 0082상 xhigh가 이미 상한.)
 - **model-swap actuation.** blast radius·비용 가드 필요 → deferred.
 - **cross-agent 정규화 비교.** claude 오버헤드 보정 후 교차 비교 → 별도 측정 작업.
 - **claude `max` rung.** 코드 profile 상한이 `xhigh`라 `max`는 제외(코드 부재); 필요 시 smoke

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -447,12 +447,15 @@ def _validate_effort_for_model(model: str, effort: str) -> str:
 # ADR 0092 (PR2): per-agent effort ladder for autotune actuation. Ordered low→high.
 # claude tops out at ``xhigh`` (the code profile ceiling; ``max`` is absent from
 # _CLAUDE_ROLE_PROFILE so it is intentionally excluded — a ``max`` rung is a smoke-gated
-# follow-up). codex tops out at ``high`` (``~/.codex/config.toml`` may use ``xhigh``, but
-# the controller ladder caps at ``high``; an ``xhigh`` rung is a follow-up). These ladders
+# follow-up). codex tops out at ``xhigh`` too (#1723; per-rung provenance below). These ladders
 # are the SINGLE clamp guard for codex effort — _validate_effort_for_model is claude-only
 # (it would no-op on codex effort, so calling it there would be misuse, AC11).
 _CLAUDE_EFFORT_LADDER: tuple[str, ...] = ("low", "medium", "high", "xhigh")
-_CODEX_EFFORT_LADDER: tuple[str, ...] = ("minimal", "low", "medium", "high")
+# codex accepts xhigh via `-c model_reasoning_effort=xhigh` (codex-cli 0.135.0, verified
+# `codex exec --strict-config -c model_reasoning_effort=xhigh` rc=0; ~/.codex/config.toml
+# uses xhigh) — so the codex ladder tops at xhigh too, letting autotune strengthen a codex
+# bottleneck to its true ceiling instead of stopping at high (ADR 0092 follow-up, #1723).
+_CODEX_EFFORT_LADDER: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 
 def _lane_effort_ladder(agent: str) -> tuple[str, ...]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -10301,26 +10301,28 @@ def test_resolve_lane_effort_override_requested_wins() -> None:
 
 
 def test_step_lane_effort_per_agent_ladder_and_clamp() -> None:
-    """AC11: claude ladder tops at xhigh (no max), codex tops at high; both clamp at bounds."""
+    """AC11: claude ladder tops at xhigh (no max), codex tops at xhigh too (#1723); both clamp at bounds."""
     # claude ladder: low < medium < high < xhigh
     assert agent_loop._step_lane_effort("claude", "medium", 1) == "high"
     assert agent_loop._step_lane_effort("claude", "high", 1) == "xhigh"
     assert agent_loop._step_lane_effort("claude", "xhigh", 1) == "xhigh"  # clamp at ceiling (no max rung)
     assert agent_loop._step_lane_effort("claude", "low", -1) == "low"  # clamp at floor
     assert "max" not in agent_loop._CLAUDE_EFFORT_LADDER
-    # codex ladder: minimal < low < medium < high
+    # codex ladder: minimal < low < medium < high < xhigh (#1723)
     assert agent_loop._step_lane_effort("codex", "medium", 1) == "high"
-    assert agent_loop._step_lane_effort("codex", "high", 1) == "high"  # clamp at ceiling (no xhigh rung)
+    assert agent_loop._step_lane_effort("codex", "high", 1) == "xhigh"  # codex now reaches xhigh ceiling
+    assert agent_loop._step_lane_effort("codex", "xhigh", 1) == "xhigh"  # clamp at ceiling
+    assert agent_loop._step_lane_effort("codex", "xhigh", -1) == "high"  # xhigh now on the codex ladder
     assert agent_loop._step_lane_effort("codex", "minimal", -1) == "minimal"  # clamp at floor
     assert agent_loop._step_lane_effort("codex", "low", -1) == "minimal"
     # off-ladder value -> None (left for the lane to resolve)
-    assert agent_loop._step_lane_effort("codex", "xhigh", -1) is None
+    assert agent_loop._step_lane_effort("codex", "max", -1) is None
     assert agent_loop._step_lane_effort("claude", "minimal", 1) is None
 
 
 def test_compute_lane_autotune_codex_ceiling_clamp_records_no_override() -> None:
-    """AC11/AC12: a codex strengthen at the ladder ceiling (high) clamps -> no override emitted,
-    but the recommendation is still recorded (with actuated False)."""
+    """AC11/AC12: a codex strengthen at the ladder ceiling (xhigh, #1723) clamps -> no override
+    emitted, but the recommendation is still recorded (with actuated False)."""
     fail_iter = [
         {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
@@ -10330,10 +10332,10 @@ def test_compute_lane_autotune_codex_ceiling_clamp_records_no_override() -> None
         {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
         {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
     ]
-    # C fails 3/3 -> strengthen; but baseline already 'high' -> step clamps -> no actuation.
-    high_baseline = lambda _agent, _role: "high"  # noqa: E731
+    # C fails 3/3 -> strengthen; but baseline already 'xhigh' (codex ceiling) -> step clamps -> no actuation.
+    xhigh_baseline = lambda _agent, _role: "xhigh"  # noqa: E731
     overrides, recs, cooldown, _events = agent_loop.compute_lane_autotune(
-        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=high_baseline
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=xhigh_baseline
     )
     c = next(r for r in recs if r["role"] == "C")
     assert c["direction"] == "strengthen"
@@ -10341,6 +10343,28 @@ def test_compute_lane_autotune_codex_ceiling_clamp_records_no_override() -> None
     assert c["effort_to"] is None
     assert ("C", "codex") not in overrides
     assert cooldown == {}  # nothing actuated -> nothing to cool down
+
+
+def test_compute_lane_autotune_codex_strengthens_high_to_xhigh() -> None:
+    """#1723: a failing codex lane at 'high' now strengthens to 'xhigh' (previously clamped at high)."""
+    fail_iter = [
+        {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    newest = [
+        {"role": "A", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "B", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "codex", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    high_baseline = lambda _agent, _role: "high"  # noqa: E731
+    overrides, recs, _cooldown, _events = agent_loop.compute_lane_autotune(
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=high_baseline
+    )
+    c = next(r for r in recs if r["role"] == "C")
+    assert c["direction"] == "strengthen"
+    assert c["actuated"] is True
+    assert c["effort_to"] == "xhigh"
+    assert overrides[("C", "codex")] == "xhigh"
 
 
 def test_compute_lane_autotune_cooldown_suppresses_then_decrements() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

lane autotune의 codex effort 사다리 `_CODEX_EFFORT_LADDER`를 `high` → `xhigh` 상한으로 확장한다. codex는 `-c model_reasoning_effort=xhigh`를 수용하므로(`codex exec --strict-config -c model_reasoning_effort=xhigh` rc=0; `~/.codex/config.toml`이 xhigh 사용), autotune이 codex 병목 lane을 `high` 너머 진짜 ceiling(`xhigh`)까지 강화할 수 있다. PR2([#1724](https://github.com/hskim-solv/BidMate-DocAgent/pull/1724))는 high에서 막혔다.

Closes #1723

## 2. 영향 파일

- `scripts/agent_loop.py` (**non-load-bearing** ADR 0087(d)) — `_CODEX_EFFORT_LADDER` += `xhigh` + 설명 주석(rc=0 provenance) + stale 주석 정정
- `tests/test_agent_loop.py` — `test_step_lane_effort_per_agent_ladder_and_clamp` 갱신 + ceiling clamp baseline `high`→`xhigh` + 신규 `test_compute_lane_autotune_codex_strengthens_high_to_xhigh`
- `docs/adr/0092-lane-adaptive-autotune.md` (**load-bearing**) — follow-up 노트 landed 표기

## 3. 리스크

가장 가능성 높은 깨짐: codex ceiling=`high` 가정한 다른 코드/테스트. 배제 — `_CODEX_EFFORT_LADDER`는 `_step_lane_effort`(autotune actuate 경로)에서만 소비(reviewer가 grep으로 다른 소비처 0 확인). `ACTIVE_LANE_AUTOTUNE` OFF 시 도달 불가 → byte-identical. claude 사다리 무변경.

## 4. 테스트

- **ladder clamp**: codex `high`+1→`xhigh`, `xhigh`+1→`xhigh`(clamp at new ceiling), `xhigh`-1→`high`, off-ladder `max`→None.
- **ceiling clamp**: baseline `high`→`xhigh` 갱신(새 ceiling에서 강화 step→clamp→no override).
- **신규**: 실패 codex lane이 `high`→`xhigh` 강화(override `xhigh`, actuated True) — 이전엔 high 클램프.
- `tests/test_agent_loop.py` **329 pass** · ruff clean · code-review SHIP-READY.

## 5. Eval 영향

All `·` (no eval delta). RAG 런타임 무접촉 — `agent_loop.py` non-load-bearing(ADR 0087(d)). `docs/adr/` 문서만. autotune opt-in, OFF byte-identical.

## 6. 하위 호환

깨짐 없음. autotune 노브 동작 확장(codex 상한 high→xhigh), OFF 무변경. 답변 계약(ADR 0003)/CLI 무관.

## 7. 범위 외

- model-swap actuate · multi-worker diff · cross-agent 정규화 비교 — ADR 0092 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
