### PR TITLE
docs(operations): lane autotune operator guide + reproducible demo (ADR 0092)

### DIFF
--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -358,6 +358,165 @@ blocker 가 아니다. 직접 CLI 로는 `--max-iterations 0`(또는 `infinite`/
 `make 시작` 기본 `ACTIVE_AUTO_LOOP_EXECUTE_SHIP=0` 은 무한 모드에서도 유지된다 —
 실제 ship 은 여전히 기존 human-gated 경로가 담당한다.
 
+## Lane Autotune (opt-in)
+
+> ADR 0092 ([`docs/adr/0092-lane-adaptive-autotune.md`](../adr/0092-lane-adaptive-autotune.md))
+
+`make 시작` 루프는 `(role, agent)` 단위의 **lane 별 실행시간·실패율**을 감지해,
+다음 iteration 의 effort 노브를 자동으로 한 칸 조정할 수 있다. 기본값은 **OFF**
+— 환경변수를 명시해야만 활성화된다. OFF 상태에서 runner 산출물은 byte-identical
+로 유지된다 (ADR 0087 (d)).
+
+### 켜기
+
+```bash
+ACTIVE_LANE_AUTOTUNE=1 make 시작
+```
+
+### 노브 (env / Makefile 변수)
+
+| 변수 | 기본값 | 의미 |
+|---|---|---|
+| `ACTIVE_LANE_AUTOTUNE` | `` (빈값 = OFF) | `1` / `true` / `yes` / `on` 으로 활성화 |
+| `ACTIVE_LANE_AUTOTUNE_K` | `2.0` | within-agent median 배수 — 이 배수 초과 lane 을 병목으로 표시 |
+| `ACTIVE_LANE_AUTOTUNE_FAIL_WINDOW` | `3` | fail_rate 계산에 사용하는 최근 iteration 수 |
+| `ACTIVE_LANE_AUTOTUNE_FAIL_MIN_SAMPLE` | `2` | fail_rate 판정에 필요한 최소 관측 횟수 |
+| `ACTIVE_LANE_AUTOTUNE_FAIL_THRESHOLD` | `0.5` | 이 비율 초과 시 "느리고 실패" → effort 강화 |
+| `ACTIVE_LANE_AUTOTUNE_COOLDOWN` | `2` | 조정 직후 동결 iteration 수 (진동 방지) |
+
+### 동작
+
+컨트롤러 (`compute_lane_autotune`) 는 순수 함수 — I/O·env 읽기 없이
+prior lane 데이터만 입력으로 받아 결정을 반환한다.
+
+**감지 (sense + detect)**
+
+- **elapsed 신호**: 최신 batch 에서 같은 agent 의 lane 들을 묶어 `elapsed_s`
+  의 중앙값(median)을 구한다. `elapsed_s > k × median` 인 lane 을 병목으로
+  표시한다. 같은 agent 의 timed lane 이 2개 미만이면 median 이 무의미하므로
+  no-op (단일 lane 비교 안 함).
+- **fail_rate 신호**: 최근 `fail_window` iteration 의 `(role, agent)` 별
+  실패율(`status in {"failed", "error", …}`). `fail_min_sample` 미만이면
+  신호 없음(`no-signal`).
+- **agent 분리**: claude 와 codex 는 처리 시간 단위가 달라 **교차 비교하지
+  않는다** (codex 내부끼리, claude 내부끼리만 비교).
+- **window reset**: role 의 agent 가 바뀌면(`read_agent=auto`) 새 키로 시작
+  — 이전 agent 의 관측이 새 lane 에 누출되지 않는다.
+
+**방향 결정**
+
+| 조건 | 방향 | effort 변화 |
+|---|---|---|
+| 병목 + fail_rate > threshold | `strengthen` | +1 단계 (더 많이 생각) |
+| 병목 + fail_rate ≤ threshold (또는 no-signal) | `accelerate` | −1 단계 (더 빠르게) |
+
+**effort 사다리**
+
+- claude: `low` → `medium` → `high` → `xhigh`
+- codex: `minimal` → `low` → `medium` → `high` → `xhigh`
+
+양 끝에서 clamp — 이미 최대/최소 rung 이면 권고는 기록하되 actuation 하지 않는다.
+
+**주입**
+
+- claude lane: `--effort <level>`
+- codex lane: `-c model_reasoning_effort=<level>`
+
+**cooldown**
+
+방금 조정된 lane 은 `cooldown` iteration 동안 재조정이 억제된다. cooldown
+기간 중에도 권고 행은 기록되지만 `actuated=False` 로 표시된다.
+
+### 산출물 읽는 법
+
+`reports/agent_loop/active/auto_loop_state.json` → `cycles[-1]`:
+
+```
+cycles[-1].lane_stats                    — role / agent / elapsed_s / status
+cycles[-1].lane_autotune_recommendations — 감지된 lane 별 권고 행
+  .role / .agent          — 감지된 lane
+  .direction              — "strengthen" | "accelerate"
+  .effort_from / .effort_to  — 조정 전후 effort 단계
+  .actuated               — true 면 다음 iteration 실제 주입됨
+  .cooldown_remaining     — 재조정 억제 남은 횟수
+```
+
+### Worked Example
+
+아래는 `python3 scripts/demo_lane_autotune.py` 의 실제 출력이다.
+Implementer / Reviewer (codex, ~10 s 정상) + Auditor (codex, ~100 s + failed 반복)
+3 iteration → Auditor 를 병목으로 감지, fail_rate=1.0 → strengthen → `high→xhigh`,
+cooldown 2 iteration 설정.
+
+```
+============================================================
+  AUTOTUNE OFF  (ACTIVE_LANE_AUTOTUNE 미설정)
+============================================================
+ACTIVE_LANE_AUTOTUNE 환경변수가 빈값이면 _resolve_lane_autotune_config()
+가 None 을 반환한다. 루프는 config=None 인 경우 compute_lane_autotune 을
+호출하지 않으며, effort 오버라이드·권고·cooldown 를 생성하지 않는다.
+runner 산출물은 byte-identical 로 유지된다 (ADR 0087 (d)).
+
+  effort_overrides : {}
+  recommendations  : []
+  cooldown_state   : {}
+  (컨트롤러 미호출 — lane 데이터 감지 없음)
+
+============================================================
+  AUTOTUNE ON  (ACTIVE_LANE_AUTOTUNE=1)
+============================================================
+
+--- 입력 lane 데이터 (3 iteration, 최신이 마지막) ---
+  Iteration 1:
+    Implementer     agent=codex  elapsed=10.2s  status=completed
+    Reviewer        agent=codex  elapsed=9.8s  status=completed
+    Auditor         agent=codex  elapsed=97.3s  status=failed
+  Iteration 2:
+    Implementer     agent=codex  elapsed=10.5s  status=completed
+    Reviewer        agent=codex  elapsed=10.1s  status=completed
+    Auditor         agent=codex  elapsed=102.7s  status=failed
+  Iteration 3:
+    Implementer     agent=codex  elapsed=10.3s  status=completed
+    Reviewer        agent=codex  elapsed=9.9s  status=completed
+    Auditor         agent=codex  elapsed=98.6s  status=failed
+
+--- Config (env 기본값) ---
+  k                  = 2.0   (within-agent median 배수)
+  fail_window        = 3   (fail_rate 계산 window)
+  fail_min_sample    = 2   (최소 관측 횟수)
+  fail_threshold     = 0.5  (fail_rate 임계값)
+  cooldown           = 2   (조정 후 동결 iteration 수)
+
+--- elapsed 감지 이벤트 (newest batch, codex 그룹) ---
+  agent=codex  median=10.3s  k=2.0  flag_threshold=20.6s  timed_lanes=3
+
+--- 권고 (flagged lane) ---
+  lane      : role=Auditor  agent=codex
+  elapsed   : 98.6s  (median 10.3s,  threshold 20.6s)
+  fail_rate : 1.0 over 3 obs  (min_sample=2  threshold=0.5)
+  signal    : observed
+  direction : strengthen  (fail_rate > threshold → strengthen)
+  effort    : high → xhigh  (actuated=True)
+  note      : effort high -> xhigh
+
+--- 결과 요약 ---
+  effort_overrides[('Auditor', 'codex')] = 'xhigh'
+
+  다음 iteration: Auditor codex lane 에 '-c model_reasoning_effort=xhigh' 주입
+
+  cooldown_state['Auditor||codex'] = 2  → 2 iteration 동안 Auditor/codex 재조정 억제
+
+--- auto_loop_state.json 읽는 법 ---
+reports/agent_loop/active/auto_loop_state.json
+  cycles[-1].lane_stats          — 각 lane 의 role/agent/elapsed_s/status
+  cycles[-1].lane_autotune_recommendations
+    .role / .agent              — 감지된 lane
+    .direction                  — "strengthen" | "accelerate"
+    .effort_from / .effort_to   — 조정 전후 effort 단계
+    .actuated                   — True 면 다음 iteration 에 실제 주입
+    .cooldown_remaining         — 조정 억제 남은 횟수
+```
+
 ## Patch Write-Lane (codex, mutating)
 
 read-only runner와 별개로, `active-codex-runner`는 opt-in `--mode patch`로 **codex

--- a/scripts/demo_lane_autotune.py
+++ b/scripts/demo_lane_autotune.py
@@ -1,0 +1,187 @@
+"""Demo: compute_lane_autotune — 합성 데이터로 opt-in lane autotune 재현.
+
+Lane A/B는 정상(~10 s), Lane C는 느리고(~100 s) 반복 실패한다.
+OFF 경로(autotune 미적용)와 ON 경로(compute_lane_autotune 호출)를 비교해
+컨트롤러가 C 를 감지해 effort 를 high → xhigh 로 높이는 과정을 보여준다.
+
+실행:
+    python3 scripts/demo_lane_autotune.py
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+# scripts/ 디렉터리를 경로에 추가 (직접 실행 지원).
+sys.path.insert(0, str(Path(__file__).parent))
+import agent_loop  # noqa: E402 (side-effect-free import)
+
+
+# ---------------------------------------------------------------------------
+# 합성 lane 데이터 구성
+# ---------------------------------------------------------------------------
+
+# 시나리오:
+#   - Lane A (codex, Implementer) : 정상  ~10 s, completed
+#   - Lane B (codex, Reviewer)    : 정상  ~10 s, completed
+#   - Lane C (codex, Auditor)     : 느림 ~100 s, 반복 failed
+
+FAIL_ITER_1 = [
+    {"role": "Implementer", "agent": "codex", "elapsed_s": 10.2, "status": "completed"},
+    {"role": "Reviewer",    "agent": "codex", "elapsed_s":  9.8, "status": "completed"},
+    {"role": "Auditor",     "agent": "codex", "elapsed_s": 97.3, "status": "failed"},
+]
+FAIL_ITER_2 = [
+    {"role": "Implementer", "agent": "codex", "elapsed_s": 10.5, "status": "completed"},
+    {"role": "Reviewer",    "agent": "codex", "elapsed_s": 10.1, "status": "completed"},
+    {"role": "Auditor",     "agent": "codex", "elapsed_s": 102.7, "status": "failed"},
+]
+NEWEST = [
+    {"role": "Implementer", "agent": "codex", "elapsed_s": 10.3, "status": "completed"},
+    {"role": "Reviewer",    "agent": "codex", "elapsed_s":  9.9, "status": "completed"},
+    {"role": "Auditor",     "agent": "codex", "elapsed_s": 98.6, "status": "failed"},
+]
+
+PRIOR_LANE_STATS = [FAIL_ITER_1, FAIL_ITER_2, NEWEST]
+
+# baseline effort 리졸버: 운영자가 Auditor lane 에 high 를 설정했다고 가정.
+def _high_baseline(agent: str, role: str) -> str:  # noqa: ARG001
+    return "high"
+
+
+# LaneAutotuneConfig: 기본값(k=2.0, fail_window=3, fail_min_sample=2,
+# fail_threshold=0.5, cooldown=2) 사용.
+CFG = agent_loop.LaneAutotuneConfig()
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _banner(title: str) -> None:
+    line = "=" * 60
+    print(f"\n{line}")
+    print(f"  {title}")
+    print(line)
+
+
+def _section(title: str) -> None:
+    print(f"\n--- {title} ---")
+
+
+# ---------------------------------------------------------------------------
+# OFF 경로: autotune 미적용
+# ---------------------------------------------------------------------------
+
+def demo_off() -> None:
+    _banner("AUTOTUNE OFF  (ACTIVE_LANE_AUTOTUNE 미설정)")
+    print(textwrap.dedent("""\
+        ACTIVE_LANE_AUTOTUNE 환경변수가 빈값이면 _resolve_lane_autotune_config()
+        가 None 을 반환한다. 루프는 config=None 인 경우 compute_lane_autotune 을
+        호출하지 않으며, effort 오버라이드·권고·cooldown 를 생성하지 않는다.
+        runner 산출물은 byte-identical 로 유지된다 (ADR 0087 (d)).
+    """))
+    print("  effort_overrides : {}")
+    print("  recommendations  : []")
+    print("  cooldown_state   : {}")
+    print("  (컨트롤러 미호출 — lane 데이터 감지 없음)")
+
+
+# ---------------------------------------------------------------------------
+# ON 경로: compute_lane_autotune 호출
+# ---------------------------------------------------------------------------
+
+def demo_on() -> None:
+    _banner("AUTOTUNE ON  (ACTIVE_LANE_AUTOTUNE=1)")
+
+    _section("입력 lane 데이터 (3 iteration, 최신이 마지막)")
+    for i, batch in enumerate(PRIOR_LANE_STATS, 1):
+        print(f"  Iteration {i}:")
+        for obs in batch:
+            print(f"    {obs['role']:14s}  agent={obs['agent']}  "
+                  f"elapsed={obs['elapsed_s']:.1f}s  status={obs['status']}")
+
+    _section("Config (env 기본값)")
+    print(f"  k                  = {CFG.k}   (within-agent median 배수)")
+    print(f"  fail_window        = {CFG.fail_window}   (fail_rate 계산 window)")
+    print(f"  fail_min_sample    = {CFG.fail_min_sample}   (최소 관측 횟수)")
+    print(f"  fail_threshold     = {CFG.fail_threshold}  (fail_rate 임계값)")
+    print(f"  cooldown           = {CFG.cooldown}   (조정 후 동결 iteration 수)")
+
+    # 실제 함수 호출 (effort_resolver=_high_baseline: Auditor 기준 effort = high)
+    effort_overrides, recommendations, new_cooldown_state, events = agent_loop.compute_lane_autotune(
+        PRIOR_LANE_STATS,
+        None,          # 이전 cooldown 없음 (첫 번째 actuation)
+        CFG,
+        effort_resolver=_high_baseline,
+    )
+
+    _section("elapsed 감지 이벤트 (newest batch, codex 그룹)")
+    for ev in events:
+        if ev.get("decision") == "evaluated":
+            print(f"  agent={ev['agent']}  median={ev['median_elapsed_s']:.1f}s  "
+                  f"k={ev['k']}  flag_threshold={ev['flag_threshold_s']:.1f}s  "
+                  f"timed_lanes={ev['timed_lane_count']}")
+        elif ev.get("decision") == "no-op":
+            print(f"  agent={ev['agent']}  no-op: {ev['reason']}")
+
+    _section("권고 (flagged lane)")
+    for rec in recommendations:
+        print(
+            f"  lane      : role={rec['role']}  agent={rec['agent']}\n"
+            f"  elapsed   : {rec['elapsed_s']:.1f}s  (median {rec['median_elapsed_s']:.1f}s,  "
+            f"threshold {rec['flag_threshold_s']:.1f}s)\n"
+            f"  fail_rate : {rec['fail_rate']} over {rec['fail_sample']} obs  "
+            f"(min_sample={rec['fail_min_sample']}  threshold={rec['fail_threshold']})\n"
+            f"  signal    : {rec['fail_signal']}\n"
+            f"  direction : {rec['direction']}  (fail_rate > threshold → strengthen)\n"
+            f"  effort    : {rec['effort_from']} → {rec['effort_to']}  "
+            f"(actuated={rec['actuated']})\n"
+            f"  note      : {rec['note']}"
+        )
+
+    _section("결과 요약")
+    if effort_overrides:
+        for (role, agent), effort in effort_overrides.items():
+            print(f"  effort_overrides[({role!r}, {agent!r})] = {effort!r}")
+        print()
+        print("  다음 iteration: Auditor codex lane 에 '-c model_reasoning_effort=xhigh' 주입")
+    else:
+        print("  effort_overrides = {}  (오버라이드 없음)")
+
+    print()
+    if new_cooldown_state:
+        for key, remaining in new_cooldown_state.items():
+            role, _, agent = key.partition("||")
+            print(f"  cooldown_state[{key!r}] = {remaining}  "
+                  f"→ {remaining} iteration 동안 {role}/{agent} 재조정 억제")
+    else:
+        print("  cooldown_state = {}")
+
+    _section("auto_loop_state.json 읽는 법")
+    print(textwrap.dedent("""\
+        reports/agent_loop/active/auto_loop_state.json
+          cycles[-1].lane_stats          — 각 lane 의 role/agent/elapsed_s/status
+          cycles[-1].lane_autotune_recommendations
+            .role / .agent              — 감지된 lane
+            .direction                  — "strengthen" | "accelerate"
+            .effort_from / .effort_to   — 조정 전후 effort 단계
+            .actuated                   — True 면 다음 iteration 에 실제 주입
+            .cooldown_remaining         — 조정 억제 남은 횟수
+    """))
+
+
+# ---------------------------------------------------------------------------
+# 진입점
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    demo_off()
+    demo_on()
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

lane autotune 기능(ADR 0092 — PR1 [#1717](https://github.com/hskim-solv/BidMate-DocAgent/pull/1717) + PR2 [#1724](https://github.com/hskim-solv/BidMate-DocAgent/pull/1724) + PR3 [#1726](https://github.com/hskim-solv/BidMate-DocAgent/pull/1726) 머지)의 **operator 가이드 + 재현 데모**를 추가한다. ADR은 *결정*을 기록하지만 운영자가 **어떻게 켜고 읽는지** 가이드가 없었고, 기능이 실제 동작하는 재현 데모가 없었다.

Closes #1729

## 2. 영향 파일

- `docs/operations/active-agent-loop.md` (+159) — `## Lane Autotune (opt-in)` 섹션
- `scripts/demo_lane_autotune.py` (신규) — 실제 `compute_lane_autotune` 호출 재현 데모

## 3. 리스크

가장 가능성 높은 깨짐: 문서 부정확(노브명/스키마 필드 불일치로 운영자 오인). 배제 — 노브명은 Makefile(`ACTIVE_LANE_AUTOTUNE` + `_K`/`_FAIL_WINDOW`/`_FAIL_MIN_SAMPLE`/`_FAIL_THRESHOLD`/`_COOLDOWN`)과, rec 필드(`direction`/`effort_from`/`effort_to`/`actuated`/`cooldown_remaining`)는 `compute_lane_autotune` dict와 1:1 대조 확인. 사다리 PR3 반영(codex `minimal..xhigh`). 데모는 실제 함수 호출이라 self-validating.

## 4. 테스트

N/A — 문서 + non-production 데모만, 기존 동작·테스트 무변경. 데모는 `python3 scripts/demo_lane_autotune.py` 실행 시 실제 `compute_lane_autotune` 출력으로 self-validating(Auditor codex 병목 감지 → strengthen → `high→xhigh` → cooldown 2 확인). ruff clean.

## 5. Eval 영향

All `·` (no eval delta). RAG 런타임 무접촉. 문서 + non-production 데모 스크립트(eval/retrieval/answer 무관).

## 6. 하위 호환

깨짐 없음. 신규 문서/스크립트만. 기존 계약·CLI·스키마 무변경.

## 7. 범위 외

- 실제 `make 시작` **라이브 루프** 실행 데모(agent spawn/quota로 무거움) — 필요 시 후속.
- claude `max` rung([#1730](https://github.com/hskim-solv/BidMate-DocAgent/issues/1730)) · model-swap · cross-agent 정규화 비교 — ADR 0092 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
