### PR TITLE
feat(agent-loop): extend claude effort ladder to max (PR B, ADR 0092 follow-up)

### DIFF
--- a/docs/adr/0092-lane-adaptive-autotune.md
+++ b/docs/adr/0092-lane-adaptive-autotune.md
@@ -92,11 +92,13 @@ codex 명령(`-c model_reasoning_effort` 미주입)과 `auto_loop_state.json` �
 - **codex `xhigh` rung (PR3 — landed, #1723).** `_CODEX_EFFORT_LADDER`를 `high` → `xhigh`
   상한으로 확장. `codex exec --strict-config -c model_reasoning_effort=xhigh` rc=0 (유효 값
   확정) + `~/.codex/config.toml`이 xhigh 사용 → autotune이 codex 병목을 진짜 ceiling까지
-  강화 가능. (claude는 ADR 0082상 xhigh가 이미 상한.)
+  강화 가능. (claude는 PR3 당시 xhigh 상한 — 이후 #1730에서 max로 확장, 아래 항목.)
 - **model-swap actuation.** blast radius·비용 가드 필요 → deferred.
 - **cross-agent 정규화 비교.** claude 오버헤드 보정 후 교차 비교 → 별도 측정 작업.
-- **claude `max` rung.** 코드 profile 상한이 `xhigh`라 `max`는 제외(코드 부재); 필요 시 smoke
-  (`claude --effort max`) 후 추가.
+- **claude `max` rung (PR B — landed, #1730).** `_CLAUDE_EFFORT_LADDER`를 `xhigh` → `max`
+  상한으로 확장. CLI 수용 확정(`claude -p --effort bogus` → enum 에러가 `max`를 유효값 목록에
+  열거, rc=0 통과). `_validate_effort_for_model` 확장: 비-Opus-4.7/4.8 모델에서 `max`도 `high`로
+  보수 강등(xhigh와 동일 per-model gate, #1730 conservative guard).
 
 ## Verification
 

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -412,7 +412,7 @@ prior lane 데이터만 입력으로 받아 결정을 반환한다.
 
 **effort 사다리**
 
-- claude: `low` → `medium` → `high` → `xhigh`
+- claude: `low` → `medium` → `high` → `xhigh` → `max`
 - codex: `minimal` → `low` → `medium` → `high` → `xhigh`
 
 양 끝에서 clamp — 이미 최대/최소 rung 이면 권고는 기록하되 actuation 하지 않는다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -438,19 +438,24 @@ def _resolve_lane_model_override(agent: str, role: str, requested_model: str | N
 
 
 def _validate_effort_for_model(model: str, effort: str) -> str:
-    """ADR 0082: `xhigh` is Opus-4-7+ only. Other models 400 on xhigh → coerce to `high`."""
-    if effort == "xhigh" and not re.match(r"^claude-opus-4-(?:7|8)(?:\b|[-_])", model):
+    """ADR 0082: `xhigh`/`max` are Opus-4-7+ only. Other models 400 on xhigh/max → coerce to `high`.
+
+    `max` acceptance verified: `claude -p --effort bogus` emits enum error listing max as valid
+    (rc=0 for valid values, error for bogus — confirms CLI accepts max). Per-model availability
+    follows same-or-narrower gate as xhigh → same Opus-4-7+ guard applied conservatively (#1730).
+    """
+    if effort in ("xhigh", "max") and not re.match(r"^claude-opus-4-(?:7|8)(?:\b|[-_])", model):
         return "high"
     return effort
 
 
 # ADR 0092 (PR2): per-agent effort ladder for autotune actuation. Ordered low→high.
-# claude tops out at ``xhigh`` (the code profile ceiling; ``max`` is absent from
-# _CLAUDE_ROLE_PROFILE so it is intentionally excluded — a ``max`` rung is a smoke-gated
-# follow-up). codex tops out at ``xhigh`` too (#1723; per-rung provenance below). These ladders
-# are the SINGLE clamp guard for codex effort — _validate_effort_for_model is claude-only
-# (it would no-op on codex effort, so calling it there would be misuse, AC11).
-_CLAUDE_EFFORT_LADDER: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+# claude tops out at ``max`` (PR B, #1730; verified `claude -p --effort bogus` → enum error
+# lists max as valid, rc=0 for accepted values). codex tops out at ``xhigh`` too (#1723;
+# per-rung provenance below). These ladders are the SINGLE clamp guard for codex effort —
+# _validate_effort_for_model is claude-only (it would no-op on codex effort, so calling it
+# there would be misuse, AC11).
+_CLAUDE_EFFORT_LADDER: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 # codex accepts xhigh via `-c model_reasoning_effort=xhigh` (codex-cli 0.135.0, verified
 # `codex exec --strict-config -c model_reasoning_effort=xhigh` rc=0; ~/.codex/config.toml
 # uses xhigh) — so the codex ladder tops at xhigh too, letting autotune strengthen a codex

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5942,16 +5942,21 @@ def test_claude_lane_adapter_omits_schema_when_unreadable(tmp_path: Path) -> Non
 
 
 def test_claude_lane_adapter_xhigh_only_on_opus_47_plus() -> None:
-    """ADR 0082: `xhigh` is Opus-4-7+ only — _validate_effort_for_model coerces other models."""
+    """ADR 0082 + #1730: `xhigh`/`max` are Opus-4-7+ only — _validate_effort_for_model coerces other models."""
     from scripts.agent_loop import _validate_effort_for_model
 
+    # xhigh: Opus-4.7/4.8 pass, others coerce to high (existing behaviour — regression guard).
     assert _validate_effort_for_model("claude-opus-4-7", "xhigh") == "xhigh"
     assert _validate_effort_for_model("claude-opus-4-8", "xhigh") == "xhigh"
     assert _validate_effort_for_model("claude-sonnet-4-6", "xhigh") == "high"
     assert _validate_effort_for_model("claude-opus-4-6", "xhigh") == "high"
+    # max: same Opus-4.7+ gate (#1730 conservative guard).
+    assert _validate_effort_for_model("claude-opus-4-7", "max") == "max"
+    assert _validate_effort_for_model("claude-opus-4-8", "max") == "max"
+    assert _validate_effort_for_model("claude-sonnet-4-6", "max") == "high"
+    assert _validate_effort_for_model("claude-opus-4-6", "max") == "high"
     # Other valid efforts unchanged.
     assert _validate_effort_for_model("claude-sonnet-4-6", "medium") == "medium"
-    assert _validate_effort_for_model("claude-opus-4-8", "max") == "max"
 
 
 def test_claude_turn_read_lane_is_read_only() -> None:
@@ -10301,13 +10306,15 @@ def test_resolve_lane_effort_override_requested_wins() -> None:
 
 
 def test_step_lane_effort_per_agent_ladder_and_clamp() -> None:
-    """AC11: claude ladder tops at xhigh (no max), codex tops at xhigh too (#1723); both clamp at bounds."""
-    # claude ladder: low < medium < high < xhigh
+    """AC11: claude ladder tops at max (#1730), codex tops at xhigh (#1723); both clamp at bounds."""
+    # claude ladder: low < medium < high < xhigh < max (#1730)
     assert agent_loop._step_lane_effort("claude", "medium", 1) == "high"
     assert agent_loop._step_lane_effort("claude", "high", 1) == "xhigh"
-    assert agent_loop._step_lane_effort("claude", "xhigh", 1) == "xhigh"  # clamp at ceiling (no max rung)
-    assert agent_loop._step_lane_effort("claude", "low", -1) == "low"  # clamp at floor
-    assert "max" not in agent_loop._CLAUDE_EFFORT_LADDER
+    assert agent_loop._step_lane_effort("claude", "xhigh", 1) == "max"   # xhigh+1 -> max
+    assert agent_loop._step_lane_effort("claude", "max", 1) == "max"     # clamp at ceiling
+    assert agent_loop._step_lane_effort("claude", "max", -1) == "xhigh"  # max-1 -> xhigh
+    assert agent_loop._step_lane_effort("claude", "low", -1) == "low"    # clamp at floor
+    assert "max" in agent_loop._CLAUDE_EFFORT_LADDER
     # codex ladder: minimal < low < medium < high < xhigh (#1723)
     assert agent_loop._step_lane_effort("codex", "medium", 1) == "high"
     assert agent_loop._step_lane_effort("codex", "high", 1) == "xhigh"  # codex now reaches xhigh ceiling
@@ -10365,6 +10372,28 @@ def test_compute_lane_autotune_codex_strengthens_high_to_xhigh() -> None:
     assert c["actuated"] is True
     assert c["effort_to"] == "xhigh"
     assert overrides[("C", "codex")] == "xhigh"
+
+
+def test_compute_lane_autotune_claude_strengthens_xhigh_to_max() -> None:
+    """#1730: a failing claude lane at 'xhigh' now strengthens to 'max' (new top rung, PR B)."""
+    fail_iter = [
+        {"role": "A", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "claude", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    newest = [
+        {"role": "A", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "B", "agent": "claude", "elapsed_s": 10.0, "status": "completed"},
+        {"role": "C", "agent": "claude", "elapsed_s": 100.0, "status": "failed"},
+    ]
+    xhigh_baseline = lambda _agent, _role: "xhigh"  # noqa: E731
+    overrides, recs, _cooldown, _events = agent_loop.compute_lane_autotune(
+        [fail_iter, fail_iter, newest], None, _autotune_cfg(), effort_resolver=xhigh_baseline
+    )
+    c = next(r for r in recs if r["role"] == "C")
+    assert c["direction"] == "strengthen"
+    assert c["actuated"] is True
+    assert c["effort_to"] == "max"
+    assert overrides[("C", "claude")] == "max"
 
 
 def test_compute_lane_autotune_cooldown_suppresses_then_decrements() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR3([#1726](https://github.com/hskim-solv/BidMate-DocAgent/pull/1726))의 codex `high`→`xhigh` 대칭 — lane autotune의 claude effort 사다리를 `xhigh`→`max` 상한으로 확장. claude CLI(2.1.159)가 `--effort max`를 수용(`claude -p --effort bogus` → enum 에러가 `max`를 유효값으로 나열). autotune이 claude 병목 lane을 `xhigh` 너머 `max`까지 강화 가능.

Closes #1730

## 2. 영향 파일

- `scripts/agent_loop.py` (**non-load-bearing** ADR 0087(d)) — `_CLAUDE_EFFORT_LADDER` += `max`; `_validate_effort_for_model`을 `xhigh` → `(xhigh, max)`로 확장(비-Opus-4.7/4.8에서 max도 high 보수 강등, ADR 0082)
- `tests/test_agent_loop.py` — ladder clamp + `_validate_effort_for_model` max(Opus/비-Opus) + 신규 claude xhigh→max strengthen
- `docs/operations/active-agent-loop.md` + `docs/adr/0092-lane-adaptive-autotune.md` — 갱신

## 3. 리스크

가장 가능성 높은 깨짐: `_validate_effort_for_model` 회귀(기존 xhigh 동작) 또는 비-Opus에 max 통과(API 400→lane error). 배제 — code-review가 **23개 케이스(adversarial regex 포함) 실측**: 비-Opus xhigh/max→high, Opus-4.7/4.8 passthrough, low/medium/high 무영향. `max`는 opus-4-8 lane(xhigh baseline)에서만 도달하므로 검증을 통과(self-consistent). byte-identical-off — 사다리/검증은 autotune actuate 경로 전용, claude max baseline 없음(최고 role=xhigh)이라 OFF-path 무영향.

## 4. 테스트

- **ladder clamp**: claude `high`→`xhigh`→`max`, `max`+1 clamp, `max`-1→`xhigh`. codex 무영향(PR3 xhigh 상한 유지).
- **`_validate_effort_for_model`**: 비-Opus `max`→`high` 강등, Opus-4.7/4.8 `max` passthrough, 기존 `xhigh` 회귀.
- **신규**: claude lane xhigh→max 강화(override `max`, actuated True).
- `tests/test_agent_loop.py` **330 pass** · `bash scripts/test.sh` · ruff clean · pyright 0 error.

## 5. Eval 영향

All `·` (no eval delta). RAG 런타임 무접촉 — non-load-bearing(ADR 0087(d)). autotune opt-in, OFF byte-identical.

## 6. 하위 호환

깨짐 없음. autotune claude 상한 확장(opt-in), OFF 무변경. `_validate_effort_for_model` 기존 `xhigh` 동작 보존(회귀 테스트).

## 7. 범위 외

- `max`의 per-model 가용성 정밀 검증(비-Opus 완화 가능성) — 필요 시 후속.
- model-swap actuate · cross-agent 정규화 비교 — ADR 0092 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
