### PR TITLE
feat(agent-loop): worktree confinement guards + exit hygiene for parallel write lanes (#1719)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -14895,9 +14895,25 @@ def _write_active_codex_patch(
                     resolved_task, agent, base=base, repo_root=repo_root, runner=git_runner
                 )
                 blockers.extend(wt_blockers)
+                lease_items = _load_active_leases(_active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root))
+                if not wt_blockers:
+                    # Guards 1+2 (issue #1719): before any edit, prove the write lane is
+                    # confined to its assigned scratch worktree and is not the parent repo.
+                    # Only meaningful against a real git topology, so run it on the production
+                    # path (no injected runner); tests cover the helper directly.
+                    if git_runner is None:
+                        confinement_blockers = assert_worktree_confinement(
+                            created_path, repo_root=repo_root
+                        )
+                        blockers.extend(confinement_blockers)
+                        wt_blockers = list(wt_blockers) + confinement_blockers
+                    # Guard 3 (issue #1719): concurrent write leases must claim disjoint files.
+                    disjoint_blockers = assert_claimed_files_disjoint(lease_items)
+                    if disjoint_blockers:
+                        blockers.extend(disjoint_blockers)
+                        wt_blockers = list(wt_blockers) + disjoint_blockers
                 if not wt_blockers:
                     seed_include_paths: Sequence[str] | None = None
-                    lease_items = _load_active_leases(_active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root))
                     write_lease = _find_active_write_lease(
                         lease_items,
                         lease_id=None,
@@ -15770,6 +15786,45 @@ def _find_active_write_lease(
     return None
 
 
+def assert_claimed_files_disjoint(
+    leases: Sequence[dict[str, object]],
+) -> list[str]:
+    """Verify concurrently-active write leases claim disjoint file sets (issue #1719).
+
+    When several worktree agents run at once, two lanes claiming the same file means their
+    edits race onto the same path — exactly the kind of overlap that lets one lane's work
+    clobber another's. This enforces a pairwise empty intersection across every active write
+    lease's ``claimed_files``. Context-only claims (queue / plans / agent_loop reports) are
+    excluded because those coordination files are intentionally shared across lanes (same rule
+    as ``_context_only_claimed_files``).
+
+    Returns a list of blocker strings (empty == disjoint). A single active write lease is
+    trivially disjoint. Never raises.
+    """
+    scoped: list[tuple[str, set[str]]] = []
+    for lease in leases:
+        if not isinstance(lease, dict):
+            continue
+        if lease.get("lease_type") != "write" or lease.get("status") not in {"active", "recovery-needed"}:
+            continue
+        claimed_raw = lease.get("claimed_files")
+        claimed = {str(f) for f in claimed_raw} if isinstance(claimed_raw, list) else set()
+        # Context-only coordination files are shared by design — never an overlap conflict.
+        files = {f for f in claimed if f} if not _context_only_claimed_files(claimed) else set()
+        if files:
+            scoped.append((str(lease.get("lease_id") or "<unknown>"), files))
+    blockers: list[str] = []
+    for left in range(len(scoped)):
+        for right in range(left + 1, len(scoped)):
+            overlap = sorted(scoped[left][1] & scoped[right][1])
+            if overlap:
+                blockers.append(
+                    "claimed-files overlap between concurrent write leases "
+                    f"{scoped[left][0]!r} and {scoped[right][0]!r}: " + ", ".join(overlap[:5])
+                )
+    return blockers
+
+
 def acquire_active_agent(
     *,
     agent: str,
@@ -15879,6 +15934,65 @@ def _scratch_worktree_paths(task_id: str, agent: str, *, repo_root: Path) -> tup
 
 def _git_worktree_runner(cmd: list[str]) -> "subprocess.CompletedProcess[str]":
     return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def assert_worktree_confinement(
+    scratch_path: Path,
+    *,
+    repo_root: Path = ROOT_DIR,
+    runner=None,
+) -> list[str]:
+    """Verify a write lane is confined to its assigned scratch worktree (issue #1719).
+
+    Two failures sank the P2.2 parallel run: an agent edited the **parent repo** instead of
+    its isolated worktree (staged changes leaked onto main). This re-checks two invariants
+    before any agent edits:
+
+    1. ``git -C <scratch> rev-parse --show-toplevel`` must resolve to ``scratch_path`` — i.e.
+       the path the lane was assigned really is a git worktree top-level, not a subdir of the
+       parent checkout that ``rev-parse`` would resolve back to ``repo_root``.
+    2. that top-level must NOT equal the parent ``repo_root`` (parent-repo write ban) — a lane
+       that resolves to the parent checkout would write straight to main.
+
+    Returns a list of blocker strings (empty == confined). Never raises; a git failure is
+    itself a fail-closed blocker so the caller refuses to spawn the write agent. The git
+    subprocess is injectable so tests never touch a real worktree.
+    """
+    run = runner or _git_worktree_runner
+    blockers: list[str] = []
+    proc = run(["git", "-C", str(scratch_path), "rev-parse", "--show-toplevel"])
+    if getattr(proc, "returncode", 1) != 0:
+        tail = next((line for line in reversed((getattr(proc, "stderr", "") or "").splitlines()) if line.strip()), "")
+        blockers.append(
+            "worktree confinement check failed: could not resolve scratch worktree top-level"
+            + (f": {tail}" if tail else "")
+        )
+        return blockers
+    toplevel_raw = (getattr(proc, "stdout", "") or "").strip()
+    try:
+        toplevel = Path(toplevel_raw).resolve()
+    except (OSError, ValueError):
+        toplevel = Path(toplevel_raw)
+    try:
+        scratch_resolved = scratch_path.resolve()
+    except (OSError, ValueError):
+        scratch_resolved = scratch_path
+    try:
+        repo_resolved = repo_root.resolve()
+    except (OSError, ValueError):
+        repo_resolved = repo_root
+    if toplevel != scratch_resolved:
+        blockers.append(
+            "worktree confinement violated: write lane is not inside its assigned scratch worktree "
+            f"(top-level {_display_path(str(toplevel), repo_root=repo_root)} != "
+            f"assigned {_display_path(str(scratch_resolved), repo_root=repo_root)})"
+        )
+    if toplevel == repo_resolved:
+        blockers.append(
+            "parent-repo write ban: write lane resolved to the parent repository checkout; "
+            "it must run inside an isolated scratch worktree, never the parent repo"
+        )
+    return blockers
 
 
 def create_scratch_worktree(
@@ -16041,6 +16155,58 @@ def redact_scratch_context_files(
     return changed, warnings
 
 
+def commit_scratch_worktree_before_exit(
+    scratch_path: Path,
+    *,
+    runner=None,
+) -> tuple[bool, list[str]]:
+    """Exit hygiene: commit any uncommitted scratch state before teardown (issue #1719).
+
+    ``teardown_scratch_worktree`` removes the worktree with ``--force``, which silently
+    discards uncommitted working-tree changes. On the happy path the lane has already
+    captured the diff (``add -A`` + ``diff --cached``); but an aborted / errored / interrupted
+    write lane can leave edits uncaptured, and ``--force`` would then destroy them with no
+    trace. This pins those changes to a local commit on the scratch branch first so the work
+    survives and is recoverable, mirroring the seed/redact commit contract (no-verify, fixed
+    agent identity). Returns ``(committed, warnings)``; ``committed`` is False when the tree
+    was already clean (nothing to preserve) or the commit could not be made. Never raises.
+    """
+    warnings: list[str] = []
+    if not scratch_path.exists():
+        return False, warnings
+    run = runner or _git_worktree_runner
+    status = run(["git", "-C", str(scratch_path), "status", "--porcelain=v1"])
+    if getattr(status, "returncode", 1) != 0:
+        warnings.append("exit hygiene: could not read scratch worktree status before teardown")
+        return False, warnings
+    if not (getattr(status, "stdout", "") or "").strip():
+        return False, warnings
+    add = run(["git", "-C", str(scratch_path), "add", "-A"])
+    if getattr(add, "returncode", 1) != 0:
+        warnings.append("exit hygiene: git add failed; uncommitted scratch changes may be lost on teardown")
+        return False, warnings
+    commit = run(
+        [
+            "git",
+            "-C",
+            str(scratch_path),
+            "-c",
+            "user.name=BidMate Agent Loop",
+            "-c",
+            "user.email=agent-loop@example.invalid",
+            "commit",
+            "--no-verify",
+            "-m",
+            "Exit hygiene: preserve uncommitted scratch worktree changes",
+        ]
+    )
+    if getattr(commit, "returncode", 1) != 0:
+        output = (getattr(commit, "stderr", "") or getattr(commit, "stdout", "") or "").strip()
+        warnings.append(f"exit hygiene: commit failed before teardown: {output or 'unknown git error'}")
+        return False, warnings
+    return True, warnings
+
+
 def teardown_scratch_worktree(
     task_id: str,
     agent: str,
@@ -16048,10 +16214,18 @@ def teardown_scratch_worktree(
     repo_root: Path = ROOT_DIR,
     runner=None,
 ) -> list[str]:
-    """Best-effort removal of a scratch worktree + its branch. Returns warnings (never raises)."""
+    """Best-effort removal of a scratch worktree + its branch. Returns warnings (never raises).
+
+    Exit hygiene (issue #1719): before the destructive ``--force`` removal, commit any
+    uncommitted scratch state so an aborted/errored write lane cannot silently lose work.
+    """
     run = runner or _git_worktree_runner
     path, branch = _scratch_worktree_paths(task_id, agent, repo_root=repo_root)
     warnings: list[str] = []
+    committed, hygiene_warnings = commit_scratch_worktree_before_exit(path, runner=run)
+    warnings.extend(hygiene_warnings)
+    if committed:
+        warnings.append(f"exit hygiene: committed uncommitted scratch changes on {branch} before teardown")
     rm = run(["git", "-C", str(repo_root), "worktree", "remove", "--force", str(path)])
     if rm.returncode != 0:
         warnings.append(f"scratch worktree remove warning for {branch}")

--- a/tests/test_agent_loop_worktree_confinement.py
+++ b/tests/test_agent_loop_worktree_confinement.py
@@ -1,0 +1,215 @@
+"""Guards for parallel agent worktree isolation + exit hygiene (issue #1719).
+
+P2.2's parallel run failed two ways: a write lane edited the *parent repo* instead
+of its isolated scratch worktree (changes leaked onto main), and an aborted lane's
+uncommitted scratch work was destroyed by the ``--force`` teardown. These tests pin
+the four guards that close those holes:
+
+- ``assert_worktree_confinement`` — the lane's git top-level is its assigned scratch
+  worktree and is not the parent repo (guards 1+2).
+- ``assert_claimed_files_disjoint`` — concurrent write leases claim disjoint files (guard 3).
+- ``commit_scratch_worktree_before_exit`` + ``teardown_scratch_worktree`` wiring —
+  uncommitted scratch state is pinned to a commit before destructive removal (guard 4).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from scripts import agent_loop
+
+
+def _proc(stdout: str = "", *, returncode: int = 0, stderr: str = "") -> "subprocess.CompletedProcess[str]":
+    return subprocess.CompletedProcess(["git"], returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# Guards 1+2: assert_worktree_confinement
+# ---------------------------------------------------------------------------
+
+
+def test_confinement_passes_when_toplevel_matches_assigned_scratch(tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch-wt"
+    repo = tmp_path / "parent-repo"
+
+    def runner(cmd):
+        return _proc(str(scratch) + "\n")
+
+    assert agent_loop.assert_worktree_confinement(scratch, repo_root=repo, runner=runner) == []
+
+
+def test_confinement_blocks_when_lane_resolves_to_parent_repo(tmp_path: Path) -> None:
+    # The exact #1719 failure: a lane assigned a scratch path actually runs in the
+    # parent checkout, so rev-parse resolves the top-level to the parent repo root.
+    scratch = tmp_path / "scratch-wt"
+    repo = tmp_path / "parent-repo"
+
+    def runner(cmd):
+        return _proc(str(repo) + "\n")
+
+    blockers = agent_loop.assert_worktree_confinement(scratch, repo_root=repo, runner=runner)
+    assert any("not inside its assigned scratch worktree" in b for b in blockers)
+    assert any("parent-repo write ban" in b for b in blockers)
+
+
+def test_confinement_blocks_unrelated_toplevel_without_parent_ban(tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch-wt"
+    repo = tmp_path / "parent-repo"
+    other = tmp_path / "somewhere-else"
+
+    def runner(cmd):
+        return _proc(str(other) + "\n")
+
+    blockers = agent_loop.assert_worktree_confinement(scratch, repo_root=repo, runner=runner)
+    assert any("not inside its assigned scratch worktree" in b for b in blockers)
+    # top-level is not the parent repo, so the parent-repo ban must NOT fire.
+    assert not any("parent-repo write ban" in b for b in blockers)
+
+
+def test_confinement_fail_closed_when_git_errors(tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch-wt"
+    repo = tmp_path / "parent-repo"
+
+    def runner(cmd):
+        return _proc("", returncode=128, stderr="fatal: not a git repository\n")
+
+    blockers = agent_loop.assert_worktree_confinement(scratch, repo_root=repo, runner=runner)
+    assert len(blockers) == 1
+    assert "could not resolve scratch worktree top-level" in blockers[0]
+
+
+# ---------------------------------------------------------------------------
+# Guard 3: assert_claimed_files_disjoint
+# ---------------------------------------------------------------------------
+
+
+def _write_lease(
+    lease_id: str,
+    claimed: list[str],
+    *,
+    status: str = "active",
+    lease_type: str = "write",
+) -> dict[str, object]:
+    return {
+        "lease_id": lease_id,
+        "lease_type": lease_type,
+        "status": status,
+        "claimed_files": claimed,
+    }
+
+
+def test_disjoint_passes_for_non_overlapping_write_leases() -> None:
+    leases = [_write_lease("L1", ["rag_core.py"]), _write_lease("L2", ["rag_answer.py"])]
+    assert agent_loop.assert_claimed_files_disjoint(leases) == []
+
+
+def test_disjoint_blocks_overlapping_write_leases() -> None:
+    leases = [
+        _write_lease("L1", ["rag_core.py", "shared.py"]),
+        _write_lease("L2", ["shared.py"]),
+    ]
+    blockers = agent_loop.assert_claimed_files_disjoint(leases)
+    assert len(blockers) == 1
+    assert "L1" in blockers[0] and "L2" in blockers[0]
+    assert "shared.py" in blockers[0]
+
+
+def test_disjoint_single_write_lease_is_trivially_ok() -> None:
+    assert agent_loop.assert_claimed_files_disjoint([_write_lease("L1", ["rag_core.py"])]) == []
+
+
+def test_disjoint_ignores_non_write_and_inactive_leases() -> None:
+    leases = [
+        _write_lease("R1", ["shared.py"], lease_type="read"),
+        _write_lease("W-done", ["shared.py"], status="released"),
+        _write_lease("W1", ["shared.py"]),
+    ]
+    # Only one *active write* lease claims shared.py -> no overlap.
+    assert agent_loop.assert_claimed_files_disjoint(leases) == []
+
+
+def test_disjoint_excludes_shared_context_only_files() -> None:
+    queue = agent_loop.QUEUE_PATH.as_posix()
+    leases = [
+        _write_lease("L1", [queue, "docs/plans/p.md"]),
+        _write_lease("L2", [queue, "reports/agent_loop/x.md"]),
+    ]
+    # Coordination files are shared across lanes by design -> never an overlap conflict.
+    assert agent_loop.assert_claimed_files_disjoint(leases) == []
+
+
+# ---------------------------------------------------------------------------
+# Guard 4 (exit hygiene): commit_scratch_worktree_before_exit + teardown wiring
+# ---------------------------------------------------------------------------
+
+
+def test_exit_hygiene_noop_when_scratch_missing(tmp_path: Path) -> None:
+    committed, warnings = agent_loop.commit_scratch_worktree_before_exit(tmp_path / "gone")
+    assert committed is False
+    assert warnings == []
+
+
+def test_exit_hygiene_noop_when_tree_clean(tmp_path: Path) -> None:
+    def runner(cmd):
+        return _proc("")  # `status --porcelain` empty == clean
+
+    committed, warnings = agent_loop.commit_scratch_worktree_before_exit(tmp_path, runner=runner)
+    assert committed is False
+    assert warnings == []
+
+
+def test_exit_hygiene_commits_dirty_tree(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(cmd):
+        calls.append(cmd)
+        if "status" in cmd:
+            return _proc(" M scripts/agent_loop.py\n")
+        return _proc("")  # add + commit succeed
+
+    committed, warnings = agent_loop.commit_scratch_worktree_before_exit(tmp_path, runner=runner)
+    assert committed is True
+    assert warnings == []
+    assert any("add" in c for c in calls)
+    assert any("commit" in c and "--no-verify" in c for c in calls)
+
+
+def test_exit_hygiene_warns_when_commit_fails(tmp_path: Path) -> None:
+    def runner(cmd):
+        if "status" in cmd:
+            return _proc(" M scripts/agent_loop.py\n")
+        if "commit" in cmd:
+            return _proc("", returncode=1, stderr="nothing to commit\n")
+        return _proc("")  # add ok
+
+    committed, warnings = agent_loop.commit_scratch_worktree_before_exit(tmp_path, runner=runner)
+    assert committed is False
+    assert any("commit failed" in w for w in warnings)
+
+
+def test_exit_hygiene_warns_when_status_unreadable(tmp_path: Path) -> None:
+    def runner(cmd):
+        return _proc("", returncode=128, stderr="fatal\n")
+
+    committed, warnings = agent_loop.commit_scratch_worktree_before_exit(tmp_path, runner=runner)
+    assert committed is False
+    assert any("could not read scratch worktree status" in w for w in warnings)
+
+
+def test_teardown_commits_dirty_scratch_before_removal(tmp_path: Path) -> None:
+    # Wiring: teardown must pin uncommitted scratch state to a commit before the
+    # destructive `worktree remove --force` (issue #1719). Make the computed scratch
+    # path exist + report dirty, and assert the hygiene-commit warning surfaces.
+    path, branch = agent_loop._scratch_worktree_paths("T-2026-1719", "codex", repo_root=tmp_path)
+    path.mkdir(parents=True, exist_ok=True)
+
+    def runner(cmd):
+        if "status" in cmd:
+            return _proc(" M scripts/agent_loop.py\n")
+        return _proc("")  # add / commit / worktree remove / branch delete all succeed
+
+    warnings = agent_loop.teardown_scratch_worktree(
+        "T-2026-1719", "codex", repo_root=tmp_path, runner=runner
+    )
+    assert any("committed uncommitted scratch changes" in w and branch in w for w in warnings)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0071 P2.2 병렬 worktree agent 실행 중 두 가지 격리 실패가 발생했다: (1) write lane 이 격리 scratch worktree 가 아닌 **부모 repo** 에서 작업 → staged 변경이 main 으로 누출; (2) 중단된 lane 의 uncommitted scratch 작업이 `--force` teardown 으로 소실. codex 진단상 root cause 는 worktree-confinement 실패 + exit hygiene 부재(동시성은 증폭 조건). write-patch lane 에 외과적(surgical) 가드 4종을 추가한다 (`agent_loop.py` 대규모 재작성 없음).

Closes #1719

## 2. 영향 파일

- `scripts/agent_loop.py` — `assert_worktree_confinement` / `assert_claimed_files_disjoint` / `commit_scratch_worktree_before_exit` 신규 + `_write_active_codex_patch`(가드 1+2+3 호출) · `teardown_scratch_worktree`(exit hygiene) 배선. **NOT load-bearing** (ADR 0080/0085 — `LOAD_BEARING_PATHS` 비승격 유지)
- `tests/test_agent_loop_worktree_confinement.py` — 신규, 가드 4종 15 케이스

## 3. 리스크

- **confinement 가드의 production-only 실행**: `assert_worktree_confinement` 은 `git_runner is None`(production) 일 때만 real git(`rev-parse --show-toplevel`)으로 검증 — write spawn 당 git subprocess 1회 추가(저렴). injected-runner 테스트 경로는 건너뜀(헬퍼는 직접 테스트로 커버).
- **disjoint 가드가 정당한 overlap 도 block**: 동시 active write lease 가 같은 파일을 claim 하면 abort — 이게 의도(race 차단). 조율 파일(queue/docs/plans/reports/agent_loop)은 기존 `_context_only_claimed_files` 규칙으로 제외.
- **fail-closed**: git 오류 시 가드는 blocker 를 내 write agent 를 미spawn(은폐 없이 차단). 배제 확인: 전체 agent_loop 스위트 420 green + 신규 15.

## 4. 테스트

`tests/test_agent_loop_worktree_confinement.py` 15 케이스 — confinement(정상/부모repo누출=#1719 실패 재현/무관경로/git실패 fail-closed), disjoint(비overlap/overlap/단일/non-write·inactive 무시/context-only 제외), exit hygiene(미존재 no-op/clean no-op/dirty commit/commit실패 warn/status불가 warn/teardown commit-before-removal 배선). 전체 `tests/test_agent_loop*.py` **420 passed**.

## 5. Eval 영향

All `·` (델타 없음). `scripts/agent_loop.py` 는 `LOAD_BEARING_PATHS` 미포함(ADR 0080/0085) — RAG 파이프라인(retrieval/answer/verifier/eval) 코드 경로 아님. real-data 동작 무변경, real-eval 불요.

## 6. 하위 호환

- 신규 함수 3개 + 기존 함수 2곳 배선 — 전부 additive. `teardown_scratch_worktree` 는 destructive `--force` 제거 **전에** commit-or-preserve 단계를 추가(작업 보존 강화, 기존 동작 무손실).
- 계약/스키마/CLI flag 변경 없음. answer-contract(ADR 0003) 무관 → `schema_version` bump 불요.

## 7. 범위 외

- **guard 4 의 "TaskStop pid 종료 보장" 부분**: 이슈의 exit-hygiene 는 commit-or-stash(구현) + TaskStop 실제 pid 종료(미구현) 두 갈래였다. 후자는 orchestrator/harness 가 agent 프로세스를 어떻게 종료하느냐의 문제로 `agent_loop.py` 통제 밖 → 별도 follow-up. 본 PR 은 `agent_loop.py` 가 통제 가능한 commit-before-teardown 을 구현.
- **pre-existing pyright 진단**: `agent_loop.py` 라인 1278~4564 의 타입 이슈는 본 변경(라인 14895+/15786+/15936+/16155+) **이전부터 존재** — 별도 cleanup.
- P2.2 cap store / manifest seam (Non-Goal, 별도 task).
