### PR TITLE
feat(agent-loop): ralplan plan-gate advisory for ambiguous tasks at preflight (T-X3)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -2680,6 +2680,46 @@ def render_status(
     return "\n".join(lines) + "\n"
 
 
+def _task_is_ambiguous(task_id: str, *, repo_root: Path = ROOT_DIR) -> bool:
+    """Whether the queued task lacks BOTH an Acceptance Criteria section and any
+    Validation Commands.
+
+    These are the two crystallization signals ``select_next_task`` already sorts
+    on (see its sort key). A task missing both has no verifiable acceptance
+    contract yet and benefits from a ``/ralplan`` consensus plan gate before it
+    enters the implementation lane. A missing/unreadable queue or an unknown task
+    id returns ``False`` — the advisory is opt-in and must never block.
+    """
+    try:
+        entries = parse_task_entries(_read_text(repo_root / QUEUE_PATH))
+    except (OSError, ValueError):
+        return False
+    task = next((entry for entry in entries if entry.task_id == task_id), None)
+    if task is None:
+        return False
+    has_validation = bool(_extract_validation_commands(task))
+    has_acceptance = "Acceptance Criteria" in task.body
+    return not (has_validation or has_acceptance)
+
+
+def _render_ralplan_advisory(task_id: str) -> list[str]:
+    """Advisory-only plan-gate recommendation lines for an ambiguous task.
+
+    Surfaced in the preflight body between queue selection and the implementation
+    lane (agent-loop integration plan T-X3). It NEVER changes preflight's exit
+    code or blocks the loop — call-only ("호출만"): it points the operator/agent
+    at the ``/ralplan`` consensus plan gate, it does not invoke it.
+    """
+    return [
+        "",
+        "Plan gate (ralplan):",
+        f"- `{task_id}` has neither an Acceptance Criteria section nor Validation Commands;",
+        "  it is ambiguous and has no verifiable acceptance contract yet.",
+        "- Crystallize it with the `/ralplan` consensus plan gate before entering the",
+        "  implementation lane, then re-run preflight. Advisory only — does NOT block preflight.",
+    ]
+
+
 def render_preflight(
     *,
     task_id: str,
@@ -2701,6 +2741,8 @@ def render_preflight(
         "",
         render_validation_suggestions(validation).rstrip(),
     ]
+    if _task_is_ambiguous(task_id, repo_root=repo_root):
+        lines.extend(_render_ralplan_advisory(task_id))
     if write_prompts:
         prompt = render_prompt(task_id, repo_root=repo_root)
         review = render_review_prompt(task_id, changed_files=changed_files, repo_root=repo_root)

--- a/tests/test_agent_loop_ralplan_advisory.py
+++ b/tests/test_agent_loop_ralplan_advisory.py
@@ -1,0 +1,107 @@
+"""Tests for issue #1741 — ralplan plan-gate advisory at preflight (T-X3).
+
+The agent-loop preflight surfaces an advisory-only recommendation to crystallize
+an *ambiguous* task (one lacking BOTH an Acceptance Criteria section and any
+Validation Commands) with the ``/ralplan`` consensus plan gate before it enters
+the implementation lane. The advisory is call-only: it must never change
+preflight's exit code or block the loop.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+AMBIGUOUS_ID = "T-2026-9001"
+SPECIFIED_ID = "T-2026-9002"
+
+QUEUE_FIXTURE = f"""# Persistent Task Queue
+
+## {AMBIGUOUS_ID} — Ambiguous seed task
+
+- Title: Ambiguous seed task
+- Status: ready
+- Owner role: Implementer -> Reviewer
+
+Do something useful. No acceptance contract, no validation commands.
+
+## {SPECIFIED_ID} — Well-specified task
+
+- Title: Well-specified task
+- Status: ready
+- Owner role: Implementer -> Reviewer
+
+### Acceptance Criteria
+
+- [ ] The thing works.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+"""
+
+
+def _write_queue(repo_root: Path) -> None:
+    queue_path = repo_root / agent_loop.QUEUE_PATH
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(QUEUE_FIXTURE, encoding="utf-8")
+
+
+def test_task_is_ambiguous_detects_missing_contract(tmp_path: Path) -> None:
+    _write_queue(tmp_path)
+    assert agent_loop._task_is_ambiguous(AMBIGUOUS_ID, repo_root=tmp_path) is True
+    assert agent_loop._task_is_ambiguous(SPECIFIED_ID, repo_root=tmp_path) is False
+
+
+def test_task_is_ambiguous_unknown_or_missing_queue_is_false(tmp_path: Path) -> None:
+    # No queue file at all -> never blocks / never advises.
+    assert agent_loop._task_is_ambiguous(AMBIGUOUS_ID, repo_root=tmp_path) is False
+    _write_queue(tmp_path)
+    # Unknown task id -> False.
+    assert agent_loop._task_is_ambiguous("T-2026-0000", repo_root=tmp_path) is False
+
+
+def test_preflight_emits_ralplan_advisory_for_ambiguous_task(tmp_path: Path) -> None:
+    _write_queue(tmp_path)
+    _rc, rendered = agent_loop.render_preflight(
+        task_id=AMBIGUOUS_ID,
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=tmp_path,
+    )
+    assert "Plan gate (ralplan):" in rendered
+    assert "/ralplan" in rendered
+    assert AMBIGUOUS_ID in rendered
+    # Advisory-only: it does not block. rc is driven solely by the handoff check,
+    # so a present advisory must not be the reason for a non-zero exit code.
+    assert "does NOT block preflight" in rendered
+
+
+def test_preflight_omits_advisory_for_well_specified_task(tmp_path: Path) -> None:
+    _write_queue(tmp_path)
+    _rc, rendered = agent_loop.render_preflight(
+        task_id=SPECIFIED_ID,
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=tmp_path,
+    )
+    assert "Plan gate (ralplan):" not in rendered
+    assert "/ralplan" not in rendered
+
+
+def test_ralplan_advisory_does_not_change_exit_code(tmp_path: Path) -> None:
+    """Same handoff state, ambiguous vs specified -> identical rc (advisory only)."""
+    _write_queue(tmp_path)
+    rc_ambiguous, _ = agent_loop.render_preflight(
+        task_id=AMBIGUOUS_ID, changed_files=["scripts/agent_loop.py"], repo_root=tmp_path
+    )
+    rc_specified, _ = agent_loop.render_preflight(
+        task_id=SPECIFIED_ID, changed_files=["scripts/agent_loop.py"], repo_root=tmp_path
+    )
+    assert rc_ambiguous == rc_specified


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make 시작` agent-loop이 queue에서 task를 선정한 뒤 preflight로 넘어갈 때, Acceptance Criteria도 Validation Commands도 없는 **모호한(ambiguous) task**는 검증 가능한 acceptance contract 없이 그대로 구현 레인에 들어간다. `render_preflight`에 advisory-only 권고를 추가해, 그런 task일 때 `/ralplan` consensus 계획 게이트로 결정화하라고 안내한다. agent-loop 보조 도구 통합 plan(`docs/plans/agent-loop-integration-plan.md`) T-X3.

Closes #1741

## 2. 영향 파일

- `scripts/agent_loop.py` — **load-bearing**. `_task_is_ambiguous` + `_render_ralplan_advisory` 헬퍼 추가, `render_preflight`에 advisory 삽입(순수 additive).
- `tests/test_agent_loop_ralplan_advisory.py` — 신규 테스트.

## 3. 리스크

- 가장 가능성 높은 깨짐: 기존 preflight 출력에 줄이 추가되어 정확 매칭하는 기존 테스트가 깨질 수 있음 → `tests/test_agent_loop.py -k preflight` 9개 전부 통과 확인(advisory는 ambiguous task에만 출력, well-specified 픽스처 무영향).
- advisory는 제어 흐름·exit code·게이트 판정을 바꾸지 않음. 미존재/판독불가 queue·미지의 task id → `False`(절대 차단 안 함).

## 4. 테스트

- 신규 `tests/test_agent_loop_ralplan_advisory.py`: ambiguity 감지(있음/없음/미지 id/queue 부재), advisory presence/absence, exit-code 불변성.
- 변경 전: `render_preflight`에 advisory 없음 → 신규 assertion fail. 변경 후 pass.
- `make test-fast` green (3319 passed, 15 skipped).

## 5. Eval 영향

All `·` (동작 변화 없음). advisory-only 텍스트 추가로 retrieval/verifier/answer/eval path 동작 무변경 — load-bearing 파일(`scripts/agent_loop.py`)을 손댔으나 RAG 런타임/eval 표면과 무관한 agent-loop preflight advisory surface 한정. real-eval 미실행(동작 무변경이라 델타 없음).

## 6. 하위 호환

- 깨짐 없음. preflight 출력에 조건부 줄 추가(additive). CLI flag/스키마/답변 계약(ADR 0003) 무변경.

## 7. 범위 외

- ralplan을 agent-loop이 자동 subprocess 호출(토큰/지연/제어흐름 위험 — call-only 설계).
- `select_next_task` 선정 로직 변경, `tasks/queue.md` 스키마 변경.