### PR TITLE
feat(agent-loop): eval-anomaly-investigator advisory at gate evidence on eval-surface touch (T-X2)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -16408,6 +16408,50 @@ def write_active_apply(
     )
 
 
+EVAL_ANOMALY_SURFACE_TAGS = frozenset(
+    {
+        "benchmark-reporting",
+        "eval-harness",
+        "private-real-eval",
+        "public-synthetic-benchmark",
+        "public-fixture-smoke",
+    }
+)
+
+
+def _eval_surface_touched(files: Sequence[str]) -> list[str]:
+    """Changed files that map to an eval/benchmark surface via ``_surface_for_path``.
+
+    These are the surfaces whose runs feed ``eval_summary.json``'s
+    ``failure_category_counts`` — the input the eval-anomaly-investigator slices.
+    """
+    return [path for path in files if set(_surface_for_path(path)) & EVAL_ANOMALY_SURFACE_TAGS]
+
+
+def _eval_anomaly_advisory(eval_files: Sequence[str]) -> dict[str, object]:
+    """Advisory-only pointer at the eval-anomaly-investigator agent (agent-loop
+    integration plan T-X2).
+
+    Call-only ("호출만"): it is recorded in the gate-evidence audit record but does
+    NOT run the eval, compute a regression delta, or invoke the agent. It tells the
+    operator to slice a dominant/regressed failure category under the ADR 0005
+    boundary if one shows up after the eval run.
+    """
+    return {
+        "agent": "eval-anomaly-investigator",
+        "trigger": "eval/benchmark surface touched",
+        "eval_files": list(eval_files),
+        "guidance": (
+            "After the eval run (e.g. `make real-eval`), if eval_summary.json shows a "
+            "dominant, regressed, or surprising failure_category_count, run the "
+            "eval-anomaly-investigator agent to slice that category under the ADR 0005 "
+            "boundary (LOC-count only, no per-case text) and draft "
+            "docs/audits/<slug>-inspection.md. Advisory only — does NOT run the eval "
+            "or invoke the agent."
+        ),
+    }
+
+
 def write_active_gate_evidence(
     *,
     task_id: str,
@@ -16435,6 +16479,8 @@ def write_active_gate_evidence(
     else:
         files = [_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path]
     load_bearing_touched = any(is_load_bearing(path) for path in files)
+    eval_files = _eval_surface_touched(files)
+    eval_anomaly = _eval_anomaly_advisory(eval_files) if eval_files else None
 
     topology = "four-role"
     sessions: list[dict[str, object]] = []
@@ -16499,6 +16545,7 @@ def write_active_gate_evidence(
         "apply": apply_summary,
         "work_units": rolling,
         "privacy": privacy,
+        "eval_anomaly_advisory": eval_anomaly,
         "ship": "not-triggered (use the existing human-gated ship path: ship-pr / make ship-arm)",
     }
     gate_dir = out_dir if out_dir is not None else active_dir / "gate_evidence" / task_id
@@ -16530,6 +16577,23 @@ def write_active_gate_evidence(
             f"- Apply: `{apply_summary or 'none'}`",
             f"- Work units: claude {rolling['claude']}, codex {rolling['codex']}",
             f"- Privacy: {'clean' if privacy['clean'] else str(privacy['issue_count']) + ' issue(s)'}",
+        ]
+    )
+    if eval_anomaly:
+        lines.extend(
+            [
+                "",
+                "## Eval-anomaly advisory",
+                "",
+                f"- Eval/benchmark surface touched: {', '.join('`' + p + '`' for p in eval_files)}",
+                "- After the eval run, if `eval_summary.json` shows a dominant / regressed / surprising",
+                "  `failure_category_count`, run the `eval-anomaly-investigator` agent to slice that",
+                "  category under the ADR 0005 boundary (LOC-count only, no per-case text) and draft",
+                "  `docs/audits/<slug>-inspection.md`. Advisory only — does NOT run the eval or invoke the agent.",
+            ]
+        )
+    lines.extend(
+        [
             "",
             "Ship is NOT triggered here — use the existing human-gated path (`ship-pr` / `make ship-arm`).",
         ]
@@ -16537,13 +16601,20 @@ def write_active_gate_evidence(
     (gate_dir / "evidence.md").write_text(_sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n", encoding="utf-8")
     _append_active_event(
         _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
-        {"event": "gate-evidence", "task_id": task_id, "ready": ready, "privacy_clean": privacy["clean"]},
+        {
+            "event": "gate-evidence",
+            "task_id": task_id,
+            "ready": ready,
+            "privacy_clean": privacy["clean"],
+            "eval_anomaly": bool(eval_anomaly),
+        },
     )
     return evidence_path, {
         "ready": ready,
         "required_roles": [str(i["role"]) for i in gate_roles],
         "privacy_clean": privacy["clean"],
         "load_bearing_touched": load_bearing_touched,
+        "eval_anomaly_advisory": eval_anomaly,
     }
 
 

--- a/tests/test_agent_loop_eval_anomaly_advisory.py
+++ b/tests/test_agent_loop_eval_anomaly_advisory.py
@@ -1,0 +1,106 @@
+"""Tests for issue #1742 — eval-anomaly-investigator advisory at gate evidence (T-X2).
+
+When the active loop bundles its Conservative-Gate evidence for a task that
+touched an eval/benchmark surface, the audit record carries an advisory-only
+pointer at the ``eval-anomaly-investigator`` agent. The advisory is call-only:
+it is recorded but never runs the eval, computes a regression delta, invokes the
+agent, or changes the gate's ready decision.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+def _repo(tmp_path: Path) -> Path:
+    # The active dir exists in a real run; create it so every path op has a home.
+    (tmp_path / "reports" / "agent_loop" / "active").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_eval_surface_touched_filters_to_eval_surfaces() -> None:
+    files = [
+        "eval/run_eval.py",  # eval-harness
+        "reports/eval_summary.json",  # public-fixture-smoke + benchmark-reporting
+        "rag_core.py",  # product-runtime
+        "docs/operations/long-session-workflow.md",  # docs-only
+    ]
+    hits = agent_loop._eval_surface_touched(files)
+    assert "eval/run_eval.py" in hits
+    assert "reports/eval_summary.json" in hits
+    assert "rag_core.py" not in hits
+    assert "docs/operations/long-session-workflow.md" not in hits
+
+
+def test_gate_evidence_emits_eval_anomaly_advisory_on_eval_surface(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    out_dir = repo / "gate"
+    path, summary = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["eval/config.yaml", "rag_core.py"],
+        repo_root=repo,
+        out_dir=out_dir,
+    )
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    adv = ev["eval_anomaly_advisory"]
+    assert adv is not None
+    assert adv["agent"] == "eval-anomaly-investigator"
+    # Only the eval-surface file is listed, not the product-runtime one.
+    assert "eval/config.yaml" in adv["eval_files"]
+    assert "rag_core.py" not in adv["eval_files"]
+    assert "ADR 0005" in adv["guidance"]
+    assert summary["eval_anomaly_advisory"] is not None
+
+    md = (out_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "## Eval-anomaly advisory" in md
+    assert "eval-anomaly-investigator" in md
+    assert "ADR 0005" in md
+    # Call-only: the human-gated ship note must still be present and unchanged.
+    assert "Ship is NOT triggered here" in md
+
+
+def test_gate_evidence_omits_eval_anomaly_advisory_without_eval_surface(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    out_dir = repo / "gate"
+    path, summary = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        # Load-bearing (rag_core.py) but NOT an eval surface, plus a docs file.
+        changed_files=["rag_core.py", "docs/operations/long-session-workflow.md"],
+        repo_root=repo,
+        out_dir=out_dir,
+    )
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    assert ev["eval_anomaly_advisory"] is None
+    assert summary["eval_anomaly_advisory"] is None
+    # load-bearing alone must NOT trigger the eval advisory.
+    assert ev["load_bearing_touched"] is True
+
+    md = (out_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "Eval-anomaly advisory" not in md
+
+
+def test_eval_advisory_does_not_change_gate_ready_decision(tmp_path: Path) -> None:
+    """The advisory is additive: with the same (empty) registry, the ready
+    decision is identical whether or not an eval surface was touched."""
+    repo = _repo(tmp_path)
+    _path_a, summary_eval = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["eval/config.yaml"],
+        repo_root=repo,
+        out_dir=repo / "gate_a",
+    )
+    _path_b, summary_noeval = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["eval/config.yaml", "docs/operations/x.md"],
+        repo_root=repo,
+        out_dir=repo / "gate_b",
+    )
+    assert summary_eval["ready"] == summary_noeval["ready"]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make 시작` agent-loop의 review 게이트(`write_active_gate_evidence`, audit record)는 변경 파일과 role 통과만 본다. eval/benchmark surface를 건드린 task가 게이트에 도달해도, `make real-eval` 후 dominant/regressed `failure_category_count` 이상치를 root-cause 슬라이스하라는 안내가 없었다. 변경 파일에 eval/benchmark surface가 포함되면(`_surface_for_path` 재사용) `eval-anomaly-investigator` agent를 가리키는 advisory-only 권고를 evidence.json/md/event/summary에 additive 기록한다. agent-loop 보조 도구 통합 plan(`docs/plans/agent-loop-integration-plan.md`) T-X2.

Closes #1742

## 2. 영향 파일

- `scripts/agent_loop.py` — **load-bearing**. `EVAL_ANOMALY_SURFACE_TAGS` 상수 + `_eval_surface_touched` + `_eval_anomaly_advisory` 헬퍼 추가, `write_active_gate_evidence`에 advisory 기록(additive).
- `tests/test_agent_loop_eval_anomaly_advisory.py` — 신규 테스트.

## 3. 리스크

- 가장 가능성 높은 깨짐: evidence.json/md 구조 변경으로 기존 gate-evidence 테스트가 깨질 수 있음 → `tests/test_agent_loop.py -k gate_evidence` 5개 전부 통과 확인(advisory는 eval-surface 변경 시에만, eval_summary 기본 픽스처는 changed_files가 eval surface 아님 → 무영향).
- 권고는 `ready`/conservative_gate 판정을 바꾸지 않음(eval_anomaly는 ready 계산 이후 additive). load-bearing이지만 eval surface 아닌 변경(`rag_core.py`)은 트리거 안 함 — 테스트로 guard.
- evidence.json `schema_version` 1 유지(순수 additive, 기존 키 불변).

## 4. 테스트

- 신규 `tests/test_agent_loop_eval_anomaly_advisory.py`: surface 필터(`_eval_surface_touched`), advisory presence(eval surface)/absence(load-bearing 비-eval), ready-decision 불변성.
- 변경 전: evidence에 `eval_anomaly_advisory` 키 없음 → 신규 assertion fail. 변경 후 pass.
- `make test-fast` green (3318 passed, 15 skipped).

## 5. Eval 영향

All `·` (동작 변화 없음). gate evidence audit record에 advisory 텍스트/필드만 additive 추가 — retrieval/verifier/answer/eval path 런타임 동작 무변경. load-bearing 파일(`scripts/agent_loop.py`)을 손댔으나 RAG/eval 런타임과 무관한 audit-record advisory surface 한정. real-eval 미실행(동작 무변경이라 델타 없음).

## 6. 하위 호환

- 깨짐 없음. evidence.json은 additive 키 1개(`eval_anomaly_advisory`, None 또는 dict) 추가, schema_version 1 유지. evidence.md는 조건부 블록 추가. 반환 summary에 additive 키 1개. 답변 계약(ADR 0003) 무관.

## 7. 범위 외

- eval-anomaly-investigator를 agent-loop이 자동 subprocess 호출(call-only 설계).
- eval 회귀 자동 비교/baseline diff 엔진 신설(investigator agent 영역).
- 게이트 ready/blocking 판정 로직 변경.