### PR TITLE
feat(agent-loop): learning-capture advisory (wiki + memory-curator) on loop completion (T-X1)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -10462,6 +10462,34 @@ def _resolve_active_auto_loop_limit(
     return resolved, "auto: " + ", ".join(reasons)
 
 
+def _learning_capture_advisory(
+    *,
+    decision: str,
+    completed: Sequence[str],
+    deferred: Sequence[str],
+) -> dict[str, object]:
+    """Advisory-only learning-capture pointer emitted on loop completion (agent-loop
+    integration plan T-X1).
+
+    Call-only ("호출만"): it is recorded on the terminal loop state + completion
+    event but does NOT write to the wiki/memory or invoke any agent. It points the
+    operator / next session at the ``/wiki`` skill + the memory-curator agent to
+    accumulate this cycle's learning (what landed, what blocked, what deferred) so
+    knowledge compounds across sessions.
+    """
+    return {
+        "tools": ["/wiki", "memory-curator"],
+        "decision": decision,
+        "completed_task_ids": list(completed),
+        "deferred_task_ids": list(deferred),
+        "guidance": (
+            "Capture this cycle's learning before it is lost: run the `/wiki` skill to "
+            "record durable findings and the memory-curator agent to gate any new memory "
+            "entry. Advisory only — nothing was written to the wiki/memory automatically."
+        ),
+    }
+
+
 def write_active_auto_loop(
     *,
     mode: str = "full-ship",
@@ -11165,6 +11193,15 @@ def write_active_auto_loop(
     else:
         decision = "planned"
 
+    # T-X1 (agent-loop integration plan): advisory-only learning-capture pointer,
+    # recorded only when the loop actually ran a cycle. Never writes to the
+    # wiki/memory or invokes any agent (call-only); decision/control flow unchanged.
+    learning_advisory = (
+        _learning_capture_advisory(decision=decision, completed=completed, deferred=deferred_task_ids)
+        if cycles
+        else None
+    )
+
     state_payload = {
         "schema_version": 1,
         "generated_at": _isoformat(datetime.now(timezone.utc)),
@@ -11184,6 +11221,7 @@ def write_active_auto_loop(
         "deferred_task_ids": deferred_task_ids,
         "next_task_id": next_task.task_id if next_task else None,
         "cycles": cycles,
+        "learning_capture_advisory": learning_advisory,
         "blockers": _dedupe_preserve_order(blockers),
         "warnings": _dedupe_preserve_order(warnings),
     }
@@ -11230,6 +11268,7 @@ def write_active_auto_loop(
             "deferred_task_ids": deferred_task_ids,
             "next_task_id": next_task.task_id if next_task else None,
             "blockers": blockers,
+            "learning_capture_advisory": bool(learning_advisory),
         },
     )
     return ActiveAutoLoopResult(

--- a/tests/test_agent_loop_learning_capture_advisory.py
+++ b/tests/test_agent_loop_learning_capture_advisory.py
@@ -1,0 +1,117 @@
+"""Tests for issue #1745 — learning-capture advisory on loop completion (T-X1).
+
+When `write_active_auto_loop` finishes a run that actually ran a cycle, the
+terminal loop state + completion event carry an advisory-only pointer at the
+`/wiki` skill + memory-curator agent so the cycle's learning can be accumulated.
+The advisory is call-only: it never writes to the wiki/memory, never invokes an
+agent, and never changes the loop's decision or control flow.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+def _write_loop_repo(tmp_path: Path, *, task_id: str = "T-2026-9999", status: str = "ready") -> Path:
+    (tmp_path / "tasks").mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    queue = f"""# Persistent Task Queue
+
+## Ready Order
+
+| Order | ID | Status | Owner role | Why ready / not ready |
+|---:|---|---|---|---|
+| 1 | `{task_id}` | `{status}` | Implementer -> Reviewer | fixture ready task |
+
+## {task_id} — Agent loop automation
+
+- ID: {task_id}
+- Title: Agent loop automation
+- Status: {status}
+- Owner role: Implementer -> Reviewer
+
+### Goal
+
+Automate the existing operating loop without changing product behavior.
+
+### Acceptance Criteria
+
+- [ ] CLI renders prompts and checks handoffs.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/{task_id}-agent-loop.md`](../docs/plans/{task_id}-agent-loop.md)
+"""
+    (tmp_path / "tasks" / "queue.md").write_text(queue, encoding="utf-8")
+    (tmp_path / "docs" / "plans" / f"{task_id}-agent-loop.md").write_text(
+        f"# Plan: {task_id}\n\n- Status: running\n- Related task: `tasks/queue.md::{task_id}`\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_learning_capture_advisory_content() -> None:
+    adv = agent_loop._learning_capture_advisory(
+        decision="partial", completed=["T-2026-0001"], deferred=["T-2026-0002"]
+    )
+    assert adv["tools"] == ["/wiki", "memory-curator"]
+    assert adv["decision"] == "partial"
+    assert adv["completed_task_ids"] == ["T-2026-0001"]
+    assert adv["deferred_task_ids"] == ["T-2026-0002"]
+    assert "/wiki" in adv["guidance"]
+    assert "memory-curator" in adv["guidance"]
+    # Call-only contract is stated explicitly.
+    assert "Advisory only" in adv["guidance"]
+
+
+def test_advisory_present_in_state_when_a_cycle_ran(tmp_path: Path) -> None:
+    repo = _write_loop_repo(tmp_path)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    # execute_runner=False still records a (planned) cycle for the selected task.
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+    assert result.cycles  # a cycle was recorded
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    adv = state["learning_capture_advisory"]
+    assert adv is not None
+    assert adv["tools"] == ["/wiki", "memory-curator"]
+    assert adv["decision"] == result.decision
+
+
+def test_advisory_absent_when_no_cycle_ran(tmp_path: Path) -> None:
+    repo = _write_loop_repo(tmp_path, task_id="T-2026-1001")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    active_dir.mkdir(parents=True, exist_ok=True)
+    # Pre-seed the target as already reached so the loop stops without a cycle.
+    (active_dir / "auto_loop_state.json").write_text(
+        json.dumps({"completed_task_ids": ["T-2026-1001", "T-2026-1002"]}),
+        encoding="utf-8",
+    )
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=5,
+        target_completed_count=2,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+    assert result.cycles == ()  # target already reached, no cycle ran
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["learning_capture_advisory"] is None


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make 시작` agent-loop이 한 사이클을 마쳐도 그 사이클의 학습(landed/blocked/deferred)이 누적되지 않아 세션 간 지식 복리가 빠져 있었다(plan T-X1, 최대 갭). `write_active_auto_loop` 완료 핸들러에서 사이클이 실제로 돈 경우 `/wiki` + memory-curator로 학습을 갈무리하라는 **advisory-only** 권고를 terminal state(`learning_capture_advisory`) + 완료 이벤트에 additive 기록한다. 사용자 결정: advisory-only(자동 쓰기·Stop 훅 아님).

Closes #1745

## 2. 영향 파일

- `scripts/agent_loop.py` — **load-bearing**. `_learning_capture_advisory` 헬퍼 + 완료 핸들러 배선(additive). `render_active_auto_loop` 시그니처 미변경.
- `tests/test_agent_loop_learning_capture_advisory.py` — 신규 테스트.

## 3. 리스크

- 가장 가능성 높은 깨짐: state_payload에 키 추가로 exact-match assertion 기존 테스트가 깨질 수 있음 → `tests/test_agent_loop.py -k auto_loop` 36개 전부 통과 확인(state 스키마는 lane_autotune처럼 이미 조건부 키 허용).
- 권고는 decision/control flow 불변(decision 확정 이후 additive). 사이클 0(planned no-op)에선 미발생. schema_version 1 유지.
- self-modification 범주 → 사람이 격리 worktree에서 구현, 자율 `시작 omc` 루프 미위임.

## 4. 테스트

- 신규 `tests/test_agent_loop_learning_capture_advisory.py`: 권고 content 계약, 사이클 실행 시 state 포함, no-cycle(target 기달성) 시 미포함.
- 변경 전: state에 `learning_capture_advisory` 키 없음 → 신규 assertion fail. 변경 후 pass.
- `make test-fast` green (3317 passed, 15 skipped).

## 5. Eval 영향

All `·` (동작 변화 없음). 완료 state/event에 advisory 텍스트/필드만 additive — retrieval/verifier/answer/eval path 런타임 무변경. load-bearing 파일을 손댔으나 RAG/eval 런타임과 무관한 auto-loop 완료 state surface 한정. real-eval 미실행(동작 무변경).

## 6. 하위 호환

- 깨짐 없음. auto_loop_state.json에 additive 키(`learning_capture_advisory`, None 또는 dict), schema_version 1 유지. 완료 이벤트에 additive boolean. ADR 0003 무관.

## 7. 범위 외

- Claude Code Stop hook / wiki·memory 자동 쓰기(사용자가 advisory-only 선택).
- `render_active_auto_loop` 렌더러 시그니처 변경.