### PR TITLE
feat(agent-loop): codex:rescue/tracer escalation advisory when repair lane exhausted (T-X4)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -10462,6 +10462,35 @@ def _resolve_active_auto_loop_limit(
     return resolved, "auto: " + ", ".join(reasons)
 
 
+def _repair_escalation_advisory(
+    task_id: str,
+    *,
+    repair_decision: str,
+    attempts: Sequence[str],
+) -> dict[str, object]:
+    """Advisory-only escalation pointer for an auto-repair lane that did not land
+    after its attempts (agent-loop integration plan T-X4).
+
+    Call-only ("호출만"): it is recorded on the cycle record but does NOT spawn a
+    subprocess, change the loop's defer/stop control flow, or auto-invoke anything.
+    It points a human at the codex:rescue subagent (deeper fix / diagnosis pass) or
+    the tracer agent (evidence-driven root-cause) once the built-in claude->codex
+    repair fallback is exhausted without landing a patch.
+    """
+    return {
+        "tools": ["codex:rescue", "tracer"],
+        "trigger": f"repair lane did not land (decision={repair_decision})",
+        "attempts": list(attempts),
+        "guidance": (
+            f"The auto-repair lane for {task_id} did not land after "
+            f"{len(attempts)} attempt(s) ({', '.join(attempts) or 'n/a'}). Escalate to the "
+            "codex:rescue subagent for a deeper fix/diagnosis pass, or the tracer agent for "
+            "evidence-driven root-cause analysis, before retrying. Advisory only — the loop "
+            "has deferred the task; nothing was auto-invoked."
+        ),
+    }
+
+
 def write_active_auto_loop(
     *,
     mode: str = "full-ship",
@@ -10771,6 +10800,24 @@ def write_active_auto_loop(
                 )
         if task.task_id not in deferred_task_ids:
             deferred_task_ids.append(task.task_id)
+        # T-X4 (agent-loop integration plan): advisory-only escalation pointer once the
+        # auto-repair lane (claude->codex fallback) is exhausted without landing a patch.
+        # Recorded on the cycle; never spawns a subprocess or changes the defer/stop flow.
+        repair_attempts: list[str] = []
+        if first_repair_agent:
+            repair_attempts.append(first_repair_agent)
+        elif write_agent:
+            repair_attempts.append(str(write_agent))
+        fallback_used = cycle.get("repair_fallback_agent")
+        if isinstance(fallback_used, str) and fallback_used:
+            repair_attempts.append(fallback_used)
+        cycle["escalation_advisory"] = _repair_escalation_advisory(
+            task.task_id, repair_decision=repair.decision, attempts=repair_attempts
+        )
+        warnings.append(
+            f"{task.task_id}: auto-repair lane did not land ({repair.decision}); "
+            "escalate to codex:rescue / tracer (advisory only)"
+        )
         return False
 
     iteration = 0

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5652,6 +5652,79 @@ def test_active_auto_loop_infinite_auto_repair_failures_trip_consecutive_guard(m
     assert any("2 consecutive blocked task(s)" in w for w in result.warnings)
 
 
+def test_active_auto_loop_failed_repair_records_escalation_advisory(monkeypatch, tmp_path: Path) -> None:
+    # T-X4 (agent-loop integration plan): when the auto-repair lane does not land a patch,
+    # the deferred cycle carries an advisory-only codex:rescue / tracer escalation pointer.
+    # Advisory only — no subprocess is spawned and the existing defer/stop flow is unchanged.
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Repair fail")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", _infinite_fake_runner(active_dir))
+    monkeypatch.setattr(
+        agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir, ready_for=set())
+    )
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=False,
+        auto_repair=True,
+        repo_root=repo,
+    )
+
+    assert result.cycles, "expected at least one recorded cycle"
+    adv = result.cycles[0].get("escalation_advisory")
+    assert adv is not None
+    assert adv["tools"] == ["codex:rescue", "tracer"]
+    assert "T-2026-1001" in adv["guidance"]
+    assert any("escalate to codex:rescue / tracer" in str(w) for w in result.warnings)
+
+
+def test_active_auto_loop_successful_repair_has_no_escalation_advisory(monkeypatch, tmp_path: Path) -> None:
+    # A repair that lands a patch must NOT carry the escalation advisory (T-X4).
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Repair apply task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        mode = kwargs.get("mode", "read-only")
+        report = active_dir / ("auto_repair.md" if mode == "patch" else "codex_runner.md")
+        state = active_dir / ("auto_repair_state.json" if mode == "patch" else "codex_runner_state.json")
+        runs = active_dir / ("patch_runs" if mode == "patch" else "codex_runs")
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(f"# {mode}\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": False, "privacy_clean": True}
+
+    def fake_apply(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "active_apply.md"
+        state = active_dir / "active_apply_state.json"
+        report.write_text("# apply\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveApplyResult(report, state, "applied", "feature/T-2026-1001-integration", True, (), ())
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+    monkeypatch.setattr(agent_loop, "write_active_apply", fake_apply)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=False,
+        auto_repair=True,
+        repo_root=repo,
+    )
+
+    assert result.completed_task_ids == ("T-2026-1001",)
+    assert result.cycles[0].get("escalation_advisory") is None
+
+
 def test_active_auto_loop_infinite_wall_clock_budget_bounds_runner_timeout(monkeypatch, tmp_path: Path) -> None:
     # ADR 0085 finding fix: with a wall-clock budget the runner subprocess receives the
     # *remaining* budget as its timeout, so a hung session cannot stall the loop forever.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make 시작` agent-loop의 auto-repair 레인(`run_repair_apply`)이 claude→codex fallback까지 패치를 land하지 못하면 task를 조용히 defer만 하고, 더 깊은 진단/구조로 에스컬레이션하라는 백스톱이 없었다(plan T-X4). repair가 land 실패해 deferral로 떨어지는 지점에서 codex:rescue / tracer 에스컬레이션 **advisory-only** 권고를 `cycle["escalation_advisory"]` + warning에 부착한다. 사용자 결정: advisory-only(자동 subprocess 호출 아님), N=기존 fallback 소진 지점.

Closes #1746

## 2. 영향 파일

- `scripts/agent_loop.py` — **load-bearing**. `_repair_escalation_advisory` 헬퍼 + `run_repair_apply` deferral 배선(additive).
- `tests/test_agent_loop.py` — 신규 테스트 2개(repair 실패/성공).

## 3. 리스크

- 가장 가능성 높은 깨짐: repair 분기 동작 변경으로 기존 repair 테스트가 깨질 수 있음 → `tests/test_agent_loop.py -k "auto_loop or repair"` 43개 전부 통과 확인.
- 권고는 기존 defer/stop 제어 흐름 불변(이미 deferral 경로에서 부착, return False 유지). intentional blocked-handoff 경로(별도 return)·성공 repair-apply 경로엔 미부착 — 테스트로 guard.
- self-modification 범주 → 사람이 격리 worktree에서 구현, 자율 `시작 omc` 루프 미위임.

## 4. 테스트

- 신규 `tests/test_agent_loop.py`: `test_active_auto_loop_failed_repair_records_escalation_advisory`(실패 deferral → advisory+warning present), `test_active_auto_loop_successful_repair_has_no_escalation_advisory`(repair-applied → 미부착). 기존 repair-loop 헬퍼(`_infinite_fake_runner`/`_infinite_fake_gate`) 재사용.
- 변경 전: cycle에 `escalation_advisory` 키 없음 → 신규 assertion fail. 변경 후 pass.
- `make test-fast` green (3316 passed, 15 skipped).

## 5. Eval 영향

All `·` (동작 변화 없음). repair deferral cycle에 advisory 텍스트/필드만 additive — retrieval/verifier/answer/eval path 런타임 무변경. load-bearing 파일을 손댔으나 RAG/eval 런타임과 무관한 auto-repair 분기 advisory surface 한정. real-eval 미실행(동작 무변경).

## 6. 하위 호환

- 깨짐 없음. cycle dict에 additive 키(`escalation_advisory`) + warning 1줄. defer/stop 제어 흐름·반환값 불변. ADR 0003 무관.

## 7. 범위 외

- N회 실패 후 codex:rescue/tracer 자동 subprocess 호출(사용자가 advisory-only 선택).
- blocked-handoff 경로 에스컬레이션(의도적 핸드오프이지 repair 실패 아님), 임계값 N 재설계.