### PR TITLE
feat(hooks): delegation-gate hook 병렬-aware 확장

### DIFF
--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -29,7 +29,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 | [`pretooluse-memory-lines.sh`](./pretooluse-memory-lines.sh) | graduated | `Edit\|MultiEdit\|Write` | MEMORY.md 라인 수 ≥AWARE 경고 / ≥BLOCK 차단 (issue #720) |
 | [`stop-ship.sh`](./stop-ship.sh) | pipeline | Stop | armed 상태일 때 commit→push→PR→CI→squash-merge 5-stage 자동 실행 (auto-ship) |
 | [`stop-agent-loop.sh`](./stop-agent-loop.sh) | pipeline | Stop | `.claude/.agent-loop-watch` 또는 `BIDMATE_AGENT_LOOP_STOP_HOOK=1` 일 때 ignored agent-loop status reports (`gate_status`, `loop_state`, `auto_pass`) 갱신 |
-| [`userpromptsubmit-delegation-gate.sh`](./userpromptsubmit-delegation-gate.sh) | nudge | UserPromptSubmit `.*` | non-trivial 변경 키워드 감지 시 Plan/Explore 위임 힌트 주입 (issue #1014) |
+| [`userpromptsubmit-delegation-gate.sh`](./userpromptsubmit-delegation-gate.sh) | nudge | UserPromptSubmit `.*` | non-trivial 변경 + 측정/진단/조사/분석/병렬 키워드 감지 시 Plan/Explore/병렬 spawn 위임 힌트 주입 (issue #1014, #1753) |
 
 ## Opt-in (자동 등록 아님)
 

--- a/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
+++ b/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
@@ -7,15 +7,27 @@
 # See scripts/claude-hooks/README.md for the full enforcement taxonomy.
 #
 # Registered in `.claude/settings.json` with matcher `.*`. Inspects every
-# user prompt for non-trivial change-intent keywords (Korean + English) and,
-# when matched, emits a CLAUDE.md "위임 기본값" suggestion to stdout — which
-# Claude receives as additional context for the next turn. Never blocks the
-# user; only nudges (always exits 0).
+# user prompt for non-trivial change-intent or measurement/analysis keywords
+# (Korean + English) and, when matched, emits a CLAUDE.md "위임 기본값"
+# suggestion to stdout — which Claude receives as additional context for the
+# next turn. Never blocks the user; only nudges (always exits 0).
 #
 # Why this hook exists: Q2-2026 self-review axis #2 (Agent 위임) graded △
 # because Plan/Explore subagents were under-called on non-trivial diffs.
 # CLAUDE.md already documents the rule; this hook makes the rule visible
 # right at prompt time instead of relying on Claude to remember.
+#
+# Keyword groups (issue #1753 expansion):
+#   Group A — code change-intent (original): 리팩토링|refactor|구현해|
+#     implement|다 고쳐|전체.*수정|all files|새 기능|new feature|
+#     마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|
+#     재설계|redesign
+#   Group B — measurement/investigation/parallel (new): 측정|진단|조사|
+#     분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analyz|
+#     benchmark|eval|multiple|parallel|concurrent|several
+# Conservative tuning: single typo fixes, yes/no questions, and
+# one-liner prompts should NOT trigger. Multi-word compound patterns
+# (전체.*수정) kept from Group A for specificity.
 #
 # A line is appended to `.claude/.hook-fires.log` in the ADR 0060 5-field
 # format (`<ts>|nudged|delegation-gate|agent-delegation|<path>`) via
@@ -46,16 +58,21 @@ p = d.get("prompt") or d.get("user_prompt") or d.get("user_message") or ""
 print(p)
 ' 2>/dev/null)
 
-# Non-trivial change-intent keywords (Korean + English). Tuned conservatively
-# to keep the false-positive rate low — single typo fixes and one-liner
-# question prompts should NOT trigger.
-if printf '%s' "$prompt" | grep -qiE "리팩토링|refactor|구현해|implement|다 고쳐|전체.*수정|all files|새 기능|new feature|마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|재설계|redesign"; then
+# Non-trivial change-intent + measurement/investigation/parallel keywords
+# (Korean + English). Tuned conservatively to keep the false-positive rate
+# low — single typo fixes and one-liner question prompts should NOT trigger.
+#
+# Group A: code change-intent (original set)
+# Group B: measurement / investigation / parallel tasks (issue #1753)
+if printf '%s' "$prompt" | grep -qiE "리팩토링|refactor|구현해|implement|다 고쳐|전체.*수정|all files|새 기능|new feature|마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|재설계|redesign|측정|진단|조사|분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analyz|benchmark|eval|multiple|parallel|concurrent|several"; then
   # stdout → prepended to Claude's next-turn context.
   cat <<'EOF'
 
-[agent-delegation-gate]: 비-trivial 변경 의도 감지. CLAUDE.md "위임 기본값" 적용 권장:
+[agent-delegation-gate]: 비-trivial 변경 또는 다중 작업 의도 감지. CLAUDE.md "위임 기본값" 적용 권장:
   • Plan subagent: >1 파일 또는 >50 LOC 예상 시 — 설계 검증 + 대안 평가
   • Explore subagent: 누적 Read ≥5회 또는 단일 파일 >200줄 예상 시 — 컨텍스트 보호
+  • 병렬 spawn: 독립 작업 2개 이상 감지 시 — Agent 도구로 background 병렬 spawn
+    (run_in_background 활용), 의존 관계 없는 작업은 동시에 실행 권장
 
 Trivial 변경(오타/단일 라인/단일 함수)은 직접 진행 OK.
 EOF

--- a/tests/test_hook_delegation_gate.py
+++ b/tests/test_hook_delegation_gate.py
@@ -1,0 +1,217 @@
+"""Regression: UserPromptSubmit delegation-gate hook (issue #1014, #1753).
+
+Verifies the keyword-match / no-match contract for
+``scripts/claude-hooks/userpromptsubmit-delegation-gate.sh``:
+
+  - **Nudge path**: prompts containing non-trivial change-intent OR
+    measurement/investigation/parallel keywords emit a nudge to stdout
+    and exit 0.
+  - **Pass-through path**: trivial prompts (single typo fix, yes/no,
+    one-liner questions) produce no stdout and exit 0.
+  - **Invariant**: hook never exits non-zero regardless of prompt content.
+  - **Parallel text**: nudge output includes "병렬 spawn" guidance.
+
+The hook is copied into a per-test temp REPO_ROOT so
+``.hook-fires.log`` writes are isolated from the developer's machine.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / "scripts" / "claude-hooks" / "userpromptsubmit-delegation-gate.sh"
+GOVERNANCE = REPO / "scripts" / "_governance.py"
+
+# Keyword groups for parameterised cases.
+_GROUP_A_TRIGGERS = [
+    # original code-change keywords (Group A)
+    "이 코드를 리팩토링해줘",
+    "새 기능을 구현해",
+    "refactor this module",
+    "implement the new feature",
+    "다 고쳐줘",
+    "전체 파일 수정해줘",
+    "all files need updating",
+    "새 기능 추가",
+    "new feature request",
+    "마이그레이션 진행",
+    "migrate the data",
+    "레거시 코드 처리",
+    "legacy code cleanup",
+    "아키텍처 변경",
+    "architecture overhaul",
+    "재설계 필요",
+    "redesign this system",
+]
+
+_GROUP_B_TRIGGERS = [
+    # measurement / investigation / parallel keywords (Group B — issue #1753)
+    "성능 측정 해줘",
+    "measure the latency",
+    "진단 스크립트 작성",
+    "diagnose the issue",
+    "조사해줘",
+    "investigate the failure",
+    "분석 보고서 작성",
+    "analyze the results",
+    "벤치마크 실행",
+    "benchmark this function",
+    "평가 결과 확인",
+    "eval the model",
+    "여러 파일을 동시에",
+    "multiple files at once",
+    "병렬로 처리",
+    "parallel processing",
+    "동시에 실행",
+    "concurrent execution",
+    "several tasks",
+]
+
+_NON_TRIGGERS = [
+    # trivial / yes-no / single-word — must NOT fire
+    "ok",
+    "네",
+    "yes",
+    "no",
+    "감사합니다",
+    "오타 고쳐줘",                    # typo fix only
+    "이 변수명 바꿔줘",               # single rename
+    "좋아",
+    "이게 뭐야?",                      # pure question
+    "what does this function do?",  # pure question
+    "git status 알려줘",              # simple lookup
+    "버전 확인해줘",
+]
+
+
+class TestDelegationGateHook(unittest.TestCase):
+    """Keyword-match contract for the delegation-gate UserPromptSubmit hook."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp()
+        self._tmp_repo = Path(self._tmp) / "repo"
+        (self._tmp_repo / ".claude").mkdir(parents=True)
+        (self._tmp_repo / "scripts" / "claude-hooks").mkdir(parents=True)
+        (self._tmp_repo / "scripts").mkdir(exist_ok=True)
+        shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        shutil.copy(GOVERNANCE, self._tmp_repo / "scripts" / GOVERNANCE.name)
+        self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _run(self, prompt: str) -> subprocess.CompletedProcess:
+        payload = json.dumps({"prompt": prompt})
+        return subprocess.run(
+            ["bash", str(self._hook)],
+            input=payload, text=True,
+            capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+
+    def _assert_nudged(self, result: subprocess.CompletedProcess, prompt: str) -> None:
+        self.assertEqual(result.returncode, 0, f"hook must exit 0 — prompt: {prompt!r}")
+        self.assertIn(
+            "agent-delegation-gate",
+            result.stdout,
+            f"expected nudge for prompt: {prompt!r}",
+        )
+
+    def _assert_no_nudge(self, result: subprocess.CompletedProcess, prompt: str) -> None:
+        self.assertEqual(result.returncode, 0, f"hook must exit 0 — prompt: {prompt!r}")
+        self.assertNotIn(
+            "agent-delegation-gate",
+            result.stdout,
+            f"unexpected nudge for trivial prompt: {prompt!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # Group A: original code-change keywords
+    # ------------------------------------------------------------------
+
+    def test_group_a_triggers_nudge(self) -> None:
+        """All original change-intent keywords should fire the nudge."""
+        for prompt in _GROUP_A_TRIGGERS:
+            with self.subTest(prompt=prompt):
+                result = self._run(prompt)
+                self._assert_nudged(result, prompt)
+
+    # ------------------------------------------------------------------
+    # Group B: measurement / investigation / parallel keywords (issue #1753)
+    # ------------------------------------------------------------------
+
+    def test_group_b_triggers_nudge(self) -> None:
+        """Expanded measurement/investigation/parallel keywords should fire the nudge."""
+        for prompt in _GROUP_B_TRIGGERS:
+            with self.subTest(prompt=prompt):
+                result = self._run(prompt)
+                self._assert_nudged(result, prompt)
+
+    # ------------------------------------------------------------------
+    # Non-triggers: trivial / yes-no / simple questions
+    # ------------------------------------------------------------------
+
+    def test_trivial_prompts_no_nudge(self) -> None:
+        """Trivial prompts must not trigger the nudge."""
+        for prompt in _NON_TRIGGERS:
+            with self.subTest(prompt=prompt):
+                result = self._run(prompt)
+                self._assert_no_nudge(result, prompt)
+
+    # ------------------------------------------------------------------
+    # Invariants
+    # ------------------------------------------------------------------
+
+    def test_exit_zero_always(self) -> None:
+        """Hook must exit 0 for any input — nudge-only invariant."""
+        for prompt in _GROUP_A_TRIGGERS + _GROUP_B_TRIGGERS + _NON_TRIGGERS:
+            with self.subTest(prompt=prompt):
+                result = self._run(prompt)
+                self.assertEqual(result.returncode, 0)
+
+    def test_nudge_includes_parallel_guidance(self) -> None:
+        """Nudge text must include the parallel-spawn recommendation (issue #1753)."""
+        result = self._run("병렬로 처리해줘")
+        self.assertIn("병렬 spawn", result.stdout)
+        self.assertIn("run_in_background", result.stdout)
+
+    def test_nudge_includes_plan_and_explore(self) -> None:
+        """Nudge text must still include Plan/Explore recommendations."""
+        result = self._run("리팩토링해줘")
+        self.assertIn("Plan subagent", result.stdout)
+        self.assertIn("Explore subagent", result.stdout)
+
+    def test_malformed_json_exits_zero(self) -> None:
+        """Malformed JSON input must not crash the hook (exit 0, no nudge)."""
+        malformed = subprocess.run(
+            ["bash", str(self._hook)],
+            input="not-json", text=True,
+            capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+        self.assertEqual(malformed.returncode, 0)
+
+    def test_empty_input_exits_zero(self) -> None:
+        """Empty stdin must exit 0 without nudge."""
+        result = subprocess.run(
+            ["bash", str(self._hook)],
+            input="", text=True,
+            capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("agent-delegation-gate", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Summary

`scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` 의 3가지 갭을 개선합니다.

- **갭1/갭2 해소**: 트리거 키워드에 Group B 추가 — 측정/진단/조사/분석/벤치/평가/여러/병렬/동시 + 영문 measure|diagnos|investigat|analyz|benchmark|eval|multiple|parallel|concurrent|several
- **갭1 nudge 문구 보완**: 병렬 spawn 권장 항목 추가 (독립 작업 2개 이상 → Agent background 병렬 spawn, run_in_background)
- **README 동기화**: hook 인벤토리 표 설명 + issue #1753 참조

Closes #1753

## 2. Changes

| File | Change |
|---|---|
| `scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` | 키워드 Group B 추가, nudge 문구에 병렬 spawn 항목 추가, docstring 업데이트 |
| `scripts/claude-hooks/README.md` | 인벤토리 표 설명 갱신 (issue #1753 참조) |
| `tests/test_hook_delegation_gate.py` | 신규: Group A/B fire + trivial miss + invariant 회귀 테스트 (8 tests / 96 subtests) |

## 3. Test Plan

- [x] `python3 -m pytest tests/test_hook_delegation_gate.py -v` — 8 passed, 96 subtests passed
- [x] `python3 -m pytest tests/test_governance.py tests/test_hook_pretooluse_bash_guard.py` — 60 passed, 3 skipped (기존 회귀 없음)
- [x] nudge-only 불변 유지 확인: 항상 exit 0
- [x] `.claude/settings.json` 변경 없음 (matcher 동일)

## 4. Invariants Preserved

- nudge-only: 절대 블록 없음, 항상 exit 0
- ADR 0060 5-field 텔레메트리 (`delegation-gate | agent-delegation`) 유지
- conservative tuning: 단순 질문/오타/yes-no 미스

## 5. Eval Impact

N/A — load-bearing 파일 변경 없음 (`scripts/_governance.py` LOAD_BEARING_PATHS 미포함). RAG 파이프라인 동작 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)