### PR TITLE
feat(agent-loop): eval-to-adr-bridge advisory at gate evidence

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -16580,6 +16580,34 @@ def _eval_anomaly_advisory(eval_files: Sequence[str]) -> dict[str, object]:
     }
 
 
+def _eval_to_adr_advisory(eval_files: Sequence[str]) -> dict[str, object]:
+    """Advisory-only pointer at the eval-to-adr-bridge agent (sibling of the
+    eval-anomaly advisory; agent-loop integration follow-up #1755).
+
+    Call-only ("호출만"): it is recorded in the gate-evidence audit record but does
+    NOT run the eval, read eval_summary.json, judge the ADR threshold, reserve an
+    ADR number, or invoke the agent. After the eval run, if a result MEETS the
+    CLAUDE.md ADR threshold, it points a human at the eval-to-adr-bridge agent to
+    draft an ADR candidate (Status: Proposed). It never flips an ADR to Accepted
+    and never creates a PR.
+    """
+    return {
+        "agent": "eval-to-adr-bridge",
+        "trigger": "eval/benchmark surface touched",
+        "eval_files": list(eval_files),
+        "guidance": (
+            "After the eval run (e.g. `make real-eval`, or a /retrieval-eval or "
+            "/eval-framework-progressive-audit phase report), if a measurement MEETS "
+            "the CLAUDE.md ADR threshold (removes or replaces a load-bearing decision — "
+            "baseline / pipeline / answer-contract / eval surface — or introduces a new "
+            "measurement surface), run the eval-to-adr-bridge agent to draft an ADR "
+            "candidate (Status: Proposed) with collision-safe number reservation. "
+            "Advisory only — does NOT run the eval, judge the threshold, reserve a "
+            "number, or invoke the agent."
+        ),
+    }
+
+
 def write_active_gate_evidence(
     *,
     task_id: str,
@@ -16609,6 +16637,7 @@ def write_active_gate_evidence(
     load_bearing_touched = any(is_load_bearing(path) for path in files)
     eval_files = _eval_surface_touched(files)
     eval_anomaly = _eval_anomaly_advisory(eval_files) if eval_files else None
+    eval_to_adr = _eval_to_adr_advisory(eval_files) if eval_files else None
 
     topology = "four-role"
     sessions: list[dict[str, object]] = []
@@ -16674,6 +16703,7 @@ def write_active_gate_evidence(
         "work_units": rolling,
         "privacy": privacy,
         "eval_anomaly_advisory": eval_anomaly,
+        "eval_to_adr_advisory": eval_to_adr,
         "ship": "not-triggered (use the existing human-gated ship path: ship-pr / make ship-arm)",
     }
     gate_dir = out_dir if out_dir is not None else active_dir / "gate_evidence" / task_id
@@ -16720,6 +16750,20 @@ def write_active_gate_evidence(
                 "  `docs/audits/<slug>-inspection.md`. Advisory only — does NOT run the eval or invoke the agent.",
             ]
         )
+    if eval_to_adr:
+        lines.extend(
+            [
+                "",
+                "## Eval-to-ADR advisory",
+                "",
+                f"- Eval/benchmark surface touched: {', '.join('`' + p + '`' for p in eval_files)}",
+                "- After the eval run, if a measurement MEETS the CLAUDE.md ADR threshold (removes or",
+                "  replaces a load-bearing decision, or introduces a new measurement surface), run the",
+                "  `eval-to-adr-bridge` agent to draft an ADR candidate (Status: Proposed) with",
+                "  collision-safe number reservation. Advisory only — does NOT run the eval, judge the",
+                "  threshold, reserve a number, or invoke the agent.",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -16735,6 +16779,7 @@ def write_active_gate_evidence(
             "ready": ready,
             "privacy_clean": privacy["clean"],
             "eval_anomaly": bool(eval_anomaly),
+            "eval_to_adr": bool(eval_to_adr),
         },
     )
     return evidence_path, {
@@ -16743,6 +16788,7 @@ def write_active_gate_evidence(
         "privacy_clean": privacy["clean"],
         "load_bearing_touched": load_bearing_touched,
         "eval_anomaly_advisory": eval_anomaly,
+        "eval_to_adr_advisory": eval_to_adr,
     }
 
 

--- a/tests/test_agent_loop_eval_to_adr_advisory.py
+++ b/tests/test_agent_loop_eval_to_adr_advisory.py
@@ -1,0 +1,107 @@
+"""Tests for issue #1755 — eval-to-adr-bridge advisory at gate evidence.
+
+When the active loop bundles its Conservative-Gate evidence for a task that
+touched an eval/benchmark surface, the audit record carries an advisory-only
+pointer at the ``eval-to-adr-bridge`` agent (sibling of the eval-anomaly
+advisory). The advisory is call-only: it is recorded but never runs the eval,
+judges the ADR threshold, reserves an ADR number, invokes the agent, or changes
+the gate's ready decision.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+def _repo(tmp_path: Path) -> Path:
+    # The active dir exists in a real run; create it so every path op has a home.
+    (tmp_path / "reports" / "agent_loop" / "active").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_eval_to_adr_advisory_content() -> None:
+    adv = agent_loop._eval_to_adr_advisory(["eval/config.yaml"])
+    assert adv["agent"] == "eval-to-adr-bridge"
+    assert adv["trigger"]
+    assert adv["eval_files"] == ["eval/config.yaml"]
+    guidance = adv["guidance"]
+    assert "ADR threshold" in guidance
+    assert "Proposed" in guidance
+    # Call-only contract is explicit.
+    assert "Advisory only" in guidance
+
+
+def test_gate_evidence_emits_eval_to_adr_advisory_on_eval_surface(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    out_dir = repo / "gate"
+    path, summary = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["eval/config.yaml", "rag_core.py"],
+        repo_root=repo,
+        out_dir=out_dir,
+    )
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    adv = ev["eval_to_adr_advisory"]
+    assert adv is not None
+    assert adv["agent"] == "eval-to-adr-bridge"
+    # Only the eval-surface file is listed, not the product-runtime one.
+    assert "eval/config.yaml" in adv["eval_files"]
+    assert "rag_core.py" not in adv["eval_files"]
+    assert "ADR threshold" in adv["guidance"]
+    assert summary["eval_to_adr_advisory"] is not None
+
+    md = (out_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "## Eval-to-ADR advisory" in md
+    assert "eval-to-adr-bridge" in md
+    # Call-only: the human-gated ship note must still be present and unchanged.
+    assert "Ship is NOT triggered here" in md
+
+
+def test_gate_evidence_omits_eval_to_adr_advisory_without_eval_surface(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    out_dir = repo / "gate"
+    path, summary = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        # Load-bearing (rag_core.py) but NOT an eval surface, plus a docs file.
+        changed_files=["rag_core.py", "docs/operations/long-session-workflow.md"],
+        repo_root=repo,
+        out_dir=out_dir,
+    )
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    assert ev["eval_to_adr_advisory"] is None
+    assert summary["eval_to_adr_advisory"] is None
+    # load-bearing alone must NOT trigger the eval-to-adr advisory.
+    assert ev["load_bearing_touched"] is True
+
+    md = (out_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "Eval-to-ADR advisory" not in md
+
+
+def test_eval_to_adr_advisory_does_not_change_gate_ready_decision(tmp_path: Path) -> None:
+    """The advisory is additive: with the same (empty) registry, the ready
+    decision is identical whether or not an eval surface was touched."""
+    repo = _repo(tmp_path)
+    _path_a, summary_eval = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["eval/config.yaml"],
+        repo_root=repo,
+        out_dir=repo / "gate_a",
+    )
+    _path_b, summary_noeval = agent_loop.write_active_gate_evidence(
+        task_id="T-2026-0042",
+        changed_files=["docs/operations/x.md"],
+        repo_root=repo,
+        out_dir=repo / "gate_b",
+    )
+    assert summary_eval["ready"] == summary_noeval["ready"]
+    # And the eval-to-adr advisory only appears on the eval-surface run.
+    assert summary_eval["eval_to_adr_advisory"] is not None
+    assert summary_noeval["eval_to_adr_advisory"] is None


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0072가 보조도구 4종을 agent-loop에 advisory-only로 배선했으나, 같은 계열 자산 2종(eval-to-adr-bridge, adr-lifecycle-manager)이 미배선으로 남아 있었다(grep `agent_loop.py`: 0 hits). 본 PR은 그 중 첫째 — eval-to-adr-bridge advisory를 eval-anomaly advisory의 **형제**로 `write_active_gate_evidence`에 추가한다. eval/benchmark surface를 건드린 task의 gate-evidence audit record에 "eval run 후 측정이 CLAUDE.md ADR 임계값을 충족하면 eval-to-adr-bridge agent로 ADR candidate(Status: Proposed)를 작성하라"는 **pointer-only** 권고를 싣는다.

Closes #1755

## 2. 영향 파일

- `scripts/agent_loop.py` — `_eval_to_adr_advisory()` 추가 + `write_active_gate_evidence`에서 기존 `_eval_surface_touched` 게이트로 호출, evidence dict / markdown / event / summary에 additive 표면화. (**not load-bearing**)
- `tests/test_agent_loop_eval_to_adr_advisory.py` — 신규 테스트.

## 3. 리스크

가장 가능성 높은 깨짐 경로 = advisory가 gate `ready` 결정/exit code/defer-stop을 바꾸는 것. 배제 근거: `eval_to_adr`는 evidence dict·lines·event·summary에만 기입되고 어떤 boolean/`return` 제어식에도 등장하지 않음(`ready`는 advisory 생성 전 계산, 재계산 없음). eval-anomaly 형제와 동일한 write-only 데이터 경로. 회귀 테스트가 eval-surface 유무에 따라 `ready` 불변임을 검증.

## 4. 테스트

신규 `tests/test_agent_loop_eval_to_adr_advisory.py` 4종: content / eval-surface에서 발화 / 비-eval-surface에서 부재(load-bearing 단독은 미발화) / ready-decision 불변. eval-anomaly 형제 테스트 4종도 함께 통과(미회귀 확인) — 8 passed.

## 5. Eval 영향

All `·` (동작 변화 없음). `agent_loop.py`는 load-bearing 경로가 아니며(단일 출처 `scripts/_governance.py` `LOAD_BEARING_PATHS` 미포함), 변경은 audit record에 권고 문자열을 additive로 추가할 뿐 RAG 검색/검증/답변/eval 산출에 영향 없음. real-eval 미실행(사유: 비-load-bearing, 런타임/eval 동작 불변).

## 6. 하위 호환

깨짐 없음. gate-evidence JSON에 신규 key(`eval_to_adr_advisory`)를 additive로 추가(기존 key 불변), answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요. CLI flag/doc link 변경 없음.

## 7. 범위 외

- adr-lifecycle-manager advisory(자매 통합) — 별도 후속 PR.
- `queue.md` 완료 기록 행 — 2종 통합 후 일괄 기록(T-2026-0072 방식).
- 신규 ADR 없음 — 4개 advisory 선례(#1743/#1744/#1747/#1748) 모두 ADR 미생성, 비-load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
