### PR TITLE
feat(agent-loop): adr-lifecycle-manager advisory for OVER_SLA proposed ADRs

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -32,7 +32,7 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from scripts._governance import is_load_bearing  # noqa: E402
+from scripts._governance import is_load_bearing, proposed_adr_age  # noqa: E402
 from scripts._ship_env import strip_ship_secret_env  # noqa: E402
 
 
@@ -10561,6 +10561,43 @@ def _learning_capture_advisory(
     }
 
 
+def _adr_lifecycle_advisory(*, repo_root: Path = ROOT_DIR) -> dict[str, object] | None:
+    """Advisory-only pointer at the adr-lifecycle-manager skill for OVER_SLA proposed
+    ADRs (ADR 0047's 30-day SLA), emitted on loop completion (sibling of the
+    learning-capture advisory; agent-loop integration follow-up #1757).
+
+    Call-only ("호출만"): it reads the ``proposed_adr_age`` collector
+    (scripts/_governance.py, --proposed-adr-age) read-only and records a pointer on
+    the terminal loop state, but does NOT mutate any ADR Status, append a
+    ``## Resolution`` section, touch the README index, open a PR, or invoke the
+    skill. Returns None when there are no OVER_SLA proposed ADRs (advisory absent)
+    or if the collector is unavailable — it must never block the loop.
+    """
+    try:
+        records = proposed_adr_age(repo_root / "docs" / "adr")
+    except Exception:
+        return None
+    over_sla = [r for r in records if r.over_sla]
+    if not over_sla:
+        return None
+    return {
+        "skill": "adr-lifecycle-manager",
+        "trigger": "proposed ADR(s) over the 30-day SLA (ADR 0047)",
+        "over_sla_adrs": [
+            {"number": f"{r.number:04d}", "age_days": r.age_days, "filename": r.filename}
+            for r in over_sla
+        ],
+        "guidance": (
+            f"{len(over_sla)} proposed ADR(s) are over the 30-day SLA (ADR 0047). "
+            "Run the adr-lifecycle-manager skill to resolve each "
+            "(promote / supersede / deprecate / append a Resolution section / "
+            "keep-open-with-justification) under explicit per-ADR confirmation. "
+            "Detection is via `python3 scripts/_governance.py --proposed-adr-age`. "
+            "Advisory only — nothing was mutated and the skill was not invoked."
+        ),
+    }
+
+
 def write_active_auto_loop(
     *,
     mode: str = "full-ship",
@@ -11290,6 +11327,11 @@ def write_active_auto_loop(
         if cycles
         else None
     )
+    # agent-loop integration follow-up (#1757): advisory-only adr-lifecycle pointer,
+    # recorded only when the loop actually ran a cycle. Reads the proposed_adr_age
+    # collector read-only; never mutates an ADR or invokes the skill (call-only);
+    # decision/control flow unchanged. Collector failure degrades to None.
+    adr_lifecycle_advisory = _adr_lifecycle_advisory(repo_root=repo_root) if cycles else None
 
     state_payload = {
         "schema_version": 1,
@@ -11311,6 +11353,7 @@ def write_active_auto_loop(
         "next_task_id": next_task.task_id if next_task else None,
         "cycles": cycles,
         "learning_capture_advisory": learning_advisory,
+        "adr_lifecycle_advisory": adr_lifecycle_advisory,
         "blockers": _dedupe_preserve_order(blockers),
         "warnings": _dedupe_preserve_order(warnings),
     }
@@ -11358,6 +11401,7 @@ def write_active_auto_loop(
             "next_task_id": next_task.task_id if next_task else None,
             "blockers": blockers,
             "learning_capture_advisory": bool(learning_advisory),
+            "adr_lifecycle_advisory": bool(adr_lifecycle_advisory),
         },
     )
     return ActiveAutoLoopResult(

--- a/tests/test_agent_loop_adr_lifecycle_advisory.py
+++ b/tests/test_agent_loop_adr_lifecycle_advisory.py
@@ -1,0 +1,187 @@
+"""Tests for issue #1757 — adr-lifecycle-manager advisory on loop completion.
+
+When `write_active_auto_loop` finishes a run that actually ran a cycle, the
+terminal loop state + completion event carry an advisory-only pointer at the
+adr-lifecycle-manager skill IF there are proposed ADRs over the 30-day SLA
+(ADR 0047). Sibling of the learning-capture advisory. Call-only: it reads the
+``proposed_adr_age`` collector read-only and never mutates an ADR, touches the
+README index, opens a PR, or invokes the skill, and never changes the loop's
+decision or control flow. A collector failure degrades to None (never blocks).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+from scripts._governance import ProposedADR  # noqa: E402
+
+
+def _over_sla_record(number: int = 88) -> ProposedADR:
+    return ProposedADR(
+        number=number,
+        filename=f"{number:04d}-x.md",
+        status="proposed",
+        first_commit=date(2026, 4, 1),
+        age_days=62,
+        grandfathered=False,
+        over_sla=True,
+        resolved_in_place=False,
+    )
+
+
+def _ok_record(number: int = 90) -> ProposedADR:
+    return ProposedADR(
+        number=number,
+        filename=f"{number:04d}-y.md",
+        status="proposed",
+        first_commit=date(2026, 6, 1),
+        age_days=1,
+        grandfathered=False,
+        over_sla=False,
+        resolved_in_place=False,
+    )
+
+
+def _write_loop_repo(tmp_path: Path, *, task_id: str = "T-2026-9999", status: str = "ready") -> Path:
+    (tmp_path / "tasks").mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    queue = f"""# Persistent Task Queue
+
+## Ready Order
+
+| Order | ID | Status | Owner role | Why ready / not ready |
+|---:|---|---|---|---|
+| 1 | `{task_id}` | `{status}` | Implementer -> Reviewer | fixture ready task |
+
+## {task_id} — Agent loop automation
+
+- ID: {task_id}
+- Title: Agent loop automation
+- Status: {status}
+- Owner role: Implementer -> Reviewer
+
+### Goal
+
+Automate the existing operating loop without changing product behavior.
+
+### Acceptance Criteria
+
+- [ ] CLI renders prompts and checks handoffs.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/{task_id}-agent-loop.md`](../docs/plans/{task_id}-agent-loop.md)
+"""
+    (tmp_path / "tasks" / "queue.md").write_text(queue, encoding="utf-8")
+    (tmp_path / "docs" / "plans" / f"{task_id}-agent-loop.md").write_text(
+        f"# Plan: {task_id}\n\n- Status: running\n- Related task: `tasks/queue.md::{task_id}`\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_adr_lifecycle_advisory_content_fires_when_over_sla(monkeypatch) -> None:
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [_over_sla_record(88)])
+    adv = agent_loop._adr_lifecycle_advisory()
+    assert adv is not None
+    assert adv["skill"] == "adr-lifecycle-manager"
+    assert adv["over_sla_adrs"][0]["number"] == "0088"
+    assert "30-day SLA" in adv["guidance"]
+    # Call-only contract is stated explicitly.
+    assert "Advisory only" in adv["guidance"]
+
+
+def test_adr_lifecycle_advisory_none_when_no_over_sla(monkeypatch) -> None:
+    # resolved_in_place / grandfathered / fresh ADRs do NOT carry over_sla.
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [_ok_record(90)])
+    assert agent_loop._adr_lifecycle_advisory() is None
+
+
+def test_adr_lifecycle_advisory_none_on_collector_failure(monkeypatch) -> None:
+    def _boom(*a, **k):
+        raise RuntimeError("git unavailable")
+
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", _boom)
+    # Must never block the loop: a collector crash degrades to None.
+    assert agent_loop._adr_lifecycle_advisory() is None
+
+
+def test_loop_state_carries_advisory_when_over_sla_and_cycle_ran(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [_over_sla_record(88)])
+    repo = _write_loop_repo(tmp_path)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+    assert result.cycles  # a cycle was recorded
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    adv = state["adr_lifecycle_advisory"]
+    assert adv is not None
+    assert adv["skill"] == "adr-lifecycle-manager"
+    assert adv["over_sla_adrs"][0]["number"] == "0088"
+
+
+def test_loop_state_advisory_absent_when_no_cycle_ran(monkeypatch, tmp_path: Path) -> None:
+    # Even with OVER_SLA ADRs present, no cycle => no advisory (the `if cycles` gate).
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [_over_sla_record(88)])
+    repo = _write_loop_repo(tmp_path, task_id="T-2026-1001")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    active_dir.mkdir(parents=True, exist_ok=True)
+    (active_dir / "auto_loop_state.json").write_text(
+        json.dumps({"completed_task_ids": ["T-2026-1001", "T-2026-1002"]}),
+        encoding="utf-8",
+    )
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=5,
+        target_completed_count=2,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo,
+    )
+    assert result.cycles == ()  # target already reached, no cycle ran
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["adr_lifecycle_advisory"] is None
+
+
+def test_loop_decision_invariant_to_advisory(monkeypatch, tmp_path: Path) -> None:
+    """The advisory cannot perturb the loop: OVER_SLA vs none yields the same
+    decision + completed set; the advisory only appears in the OVER_SLA run."""
+    repo_a = _write_loop_repo(tmp_path / "a")
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [_over_sla_record(88)])
+    result_over = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo_a,
+    )
+    repo_b = _write_loop_repo(tmp_path / "b")
+    monkeypatch.setattr(agent_loop, "proposed_adr_age", lambda *a, **k: [])
+    result_none = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=False,
+        execute_ship=False,
+        repo_root=repo_b,
+    )
+    assert result_over.decision == result_none.decision
+    assert result_over.completed_task_ids == result_none.completed_task_ids
+    state_a = json.loads((repo_a / "reports" / "agent_loop" / "active" / "auto_loop_state.json").read_text(encoding="utf-8"))
+    state_b = json.loads((repo_b / "reports" / "agent_loop" / "active" / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state_a["adr_lifecycle_advisory"] is not None
+    assert state_b["adr_lifecycle_advisory"] is None


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0072 advisory 계열의 마지막 미배선 자산. adr-lifecycle-manager skill을 learning-capture advisory의 **형제**로 `write_active_auto_loop`에 배선한다. 루프 완료 시(cycle이 실제로 돈 경우) proposed ADR이 ADR 0047의 30일 SLA를 초과하면, terminal loop state + completion event에 "adr-lifecycle-manager skill로 각 OVER_SLA ADR을 해소하라"는 **pointer-only** 권고를 싣는다. 기존 `proposed_adr_age` collector(`scripts/_governance.py`)를 read-only로 읽는다. #1755(eval-to-adr-bridge advisory)의 자매 PR.

Closes #1757

## 2. 영향 파일

- `scripts/agent_loop.py` — `_adr_lifecycle_advisory()` 추가 + import 한 단어(`proposed_adr_age`) + `write_active_auto_loop`에서 `if cycles` 게이트로 호출, state_payload + event에 additive 표면화. (**not load-bearing**)
- `tests/test_agent_loop_adr_lifecycle_advisory.py` — 신규 테스트.

## 3. 리스크

가장 가능성 높은 깨짐 경로 두 가지. (1) advisory가 루프 `decision`/defer-stop을 바꾸는 것 — `adr_lifecycle_advisory`는 state_payload·event에만 기입되고 `decision`(생성 전 계산) 및 `ActiveAutoLoopResult` 어디에도 등장하지 않음. 회귀 테스트가 OVER_SLA 유무에 `decision`·`completed`가 불변임을 검증. (2) collector(git 호출)가 루프를 막거나 죽이는 것 — `try/except Exception` 으로 None 강등(테스트로 검증), `if cycles` 게이트로 no-op run은 byte-identical.

## 4. 테스트

신규 6종: content / OVER_SLA에서 발화 / 비-OVER_SLA(grandfathered·resolved_in_place·fresh)에서 부재 / no-cycle에서 부재 / collector 실패 시 non-blocking / decision 불변. `proposed_adr_age`를 monkeypatch해 결정론 확보(실제 git/clock 비의존). learning-capture 형제 3종도 함께 통과(미회귀) — 9 passed.

## 5. Eval 영향

All `·` (동작 변화 없음). `agent_loop.py`는 load-bearing 미포함. 본 PR은 load-bearing `scripts/_governance.py`의 공개 함수 `proposed_adr_age`를 **import만** 하고 수정하지 않음 → `_governance.py` 동작 불변, real-data 영향 없음. RAG 검색/검증/답변/eval 산출 무관. real-eval 미실행(사유: 비-load-bearing, eval/런타임 동작 불변).

## 6. 하위 호환

깨짐 없음. loop state JSON + event에 신규 key(`adr_lifecycle_advisory`)를 additive 추가(기존 key 불변), answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요. renderer 시그니처 불변(learning-capture 형제와 동일하게 state+event만, markdown 미표면화 — 의도적 범위 선택). CLI flag 변경 없음.

## 7. 범위 외

- `queue.md` 완료 기록 — #1755 + 본 PR 머지 후 별도 chore(queue) PR로 일괄 기록(T-2026-0072 = PR #1752 선례).
- renderer markdown 표면화 — 형제 learning-capture와 parity 위해 의도적 보류(필요 시 별도 PR, renderer 시그니처 변경).
- 신규 ADR 없음 — 4개 advisory 선례(#1743/#1744/#1747/#1748) 모두 ADR 미생성, 비-load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
