### PR TITLE
feat(agent-loop): ledger/lease write crash-atomic (ADR 0094 substrate 1/7) — closes #1766

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -23,9 +23,15 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from typing import Callable, Iterable, Sequence
+
+try:
+    import fcntl  # POSIX-only; non-POSIX degrades to atomic-rename-only
+except ImportError:  # pragma: no cover - exercised only on non-POSIX CI
+    fcntl = None  # type: ignore[assignment]
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -977,6 +983,30 @@ def _repo_path(path: Path, repo_root: Path) -> str:
 
 def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Crash-atomic text write: temp file in the same dir + os.replace (atomic
+    rename), holding an exclusive flock during the write on POSIX. Non-POSIX
+    degrades to atomic-rename-only (os.replace is still atomic). The on-disk
+    bytes are identical to ``path.write_text(content, encoding="utf-8")`` — only
+    the write *path* changes (ADR 0094 PR-A1; ADR 0001 byte-identical gate)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _normalize_field(label: str) -> str:
@@ -10768,10 +10798,9 @@ def write_active_auto_loop(
         if lane_autotune_config is not None:
             checkpoint_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
             checkpoint_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
-        state_path.parent.mkdir(parents=True, exist_ok=True)
-        state_path.write_text(
+        _atomic_write_text(
+            state_path,
             json.dumps(_sanitize_json_value(checkpoint_payload), indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
         )
 
     # Infinite-mode safety state. ``consecutive_blockers`` is reset to zero on every
@@ -11364,8 +11393,7 @@ def write_active_auto_loop(
     if lane_autotune_config is not None:
         state_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
         state_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _atomic_write_text(state_path, json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n")
     rendered = render_active_auto_loop(
         decision=decision,
         execute_runner=execute_runner,
@@ -15938,8 +15966,7 @@ def _write_active_leases(path: Path, *, leases: list[dict[str, object]], now: da
         "generated_at": _isoformat(now),
         "leases": [_sanitize_json_value(item) for item in leases],
     }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _atomic_write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
     return path
 
 

--- a/tests/test_atomic_ledger_write_regression.py
+++ b/tests/test_atomic_ledger_write_regression.py
@@ -1,0 +1,174 @@
+"""Atomic ledger/lease write regression (issue #1766, ADR 0094 PR-A1).
+
+``agent_loop._atomic_write_text`` is the crash-atomic substrate brick for
+ledger / lease writes: it writes to a temp file in the same directory, holds an
+exclusive flock during the write on POSIX, then ``os.replace`` (atomic rename)
+into place. The senior contract this guards:
+
+* **Byte-identity (ADR 0001 gate)** — the on-disk bytes MUST equal what
+  ``path.write_text(content, encoding="utf-8")`` produces. Only the write
+  *path* changes, never the output.
+* **No partial files** — a crash/exception mid-write (here: ``os.replace``
+  raising) leaves the prior bytes intact and drops no temp artifact.
+* **No torn reads under contention** — concurrent writers race on the same
+  path but a reader always sees one complete payload (last-writer-wins is
+  fine; a torn/partial file is the bug).
+
+We pin payloads explicitly so the test is deterministic across machines and
+needs no external model / network.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts import agent_loop
+
+
+def test_atomic_write_temp_then_replace_roundtrips_identical(tmp_path: Path) -> None:
+    """_atomic_write_text output is byte-identical to write_text(...)."""
+    content = json.dumps({"b": 2, "a": 1, "nested": [1, 2, 3]}, indent=2, sort_keys=True) + "\n"
+    target = tmp_path / "ledger.json"
+    reference = tmp_path / "ledger_reference.json"
+
+    agent_loop._atomic_write_text(target, content)
+    reference.write_text(content, encoding="utf-8")
+
+    assert target.read_text(encoding="utf-8") == content
+    # The byte-identity proof vs the plain write_text path it replaces.
+    assert target.read_bytes() == reference.read_bytes()
+
+
+def test_atomic_write_no_partial_file_on_failure(monkeypatch, tmp_path: Path) -> None:
+    """An os.replace failure re-raises, preserves OLD bytes, leaves no temp."""
+    target = tmp_path / "leases.json"
+    old_bytes = (json.dumps({"schema_version": 1, "leases": []}, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    target.write_bytes(old_bytes)
+
+    def _boom(src, dst):  # noqa: ANN001 - signature mirrors os.replace
+        raise OSError("simulated crash between fsync and rename")
+
+    monkeypatch.setattr(agent_loop.os, "replace", _boom)
+
+    new_content = json.dumps({"schema_version": 1, "leases": [{"lease_id": "x"}]}, indent=2, sort_keys=True) + "\n"
+    with pytest.raises(OSError):
+        agent_loop._atomic_write_text(target, new_content)
+
+    # Target untouched (old bytes survive) and the temp file was cleaned up.
+    assert target.read_bytes() == old_bytes
+    assert list(target.parent.glob(".leases.json.*")) == []
+
+
+def test_atomic_write_leaves_no_temp_artifacts(tmp_path: Path) -> None:
+    """A successful _write_active_leases drops no .<name>.* temp artifact."""
+    path = tmp_path / "active" / "leases.json"
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    leases = [
+        {
+            "lease_id": "lease-1",
+            "status": "active",
+            "lease_type": "write",
+            "owner_session": "implementer",
+            "branch": "chore/issue-1766-atomic-ledger-write",
+            "worktree": ".",
+            "expires_at": "2026-06-02T13:00:00Z",
+        }
+    ]
+
+    result_path = agent_loop._write_active_leases(path, leases=leases, now=now)
+
+    assert result_path == path
+    assert list(path.parent.glob(".leases.json.*")) == []
+    # Content is well-formed JSON.
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    assert parsed["schema_version"] == 1
+    assert parsed["leases"][0]["lease_id"] == "lease-1"
+
+
+def test_write_active_leases_content_unchanged_after_retrofit(tmp_path: Path) -> None:
+    """_write_active_leases bytes equal the pre-retrofit json.dumps(...) form.
+
+    This pins the exact on-disk bytes the function produced before the atomic
+    swap, recomputed from the same payload-building logic, proving the retrofit
+    is output-preserving (ADR 0094 PR-A1 / ADR 0001 byte-identical gate).
+    """
+    path = tmp_path / "active" / "leases.json"
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    leases = [
+        {
+            "lease_id": "lease-1",
+            "status": "active",
+            "lease_type": "write",
+            "owner_session": "implementer",
+            "active_agent": None,
+            "branch": "chore/issue-1766-atomic-ledger-write",
+            "worktree": ".",
+            "last_heartbeat": "2026-06-02T12:00:00Z",
+            "lease_expires_at": "2026-06-02T13:00:00Z",
+        },
+        {
+            "lease_id": "lease-2",
+            "status": "recovery-needed",
+            "lease_type": "read",
+            "owner_session": "reviewer",
+            "branch": "chore/issue-1766-atomic-ledger-write",
+            "worktree": ".",
+            "expires_at": "2026-06-02T11:00:00Z",
+        },
+    ]
+
+    # Mirror the exact payload-building logic in _write_active_leases so the
+    # expected bytes are derived the same way the production code derives them.
+    expected_payload = {
+        "schema_version": 1,
+        "generated_at": agent_loop._isoformat(now),
+        "leases": [agent_loop._sanitize_json_value(item) for item in leases],
+    }
+    expected_bytes = (
+        json.dumps(expected_payload, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+
+    agent_loop._write_active_leases(path, leases=leases, now=now)
+
+    assert path.read_bytes() == expected_bytes
+
+
+def test_atomic_write_concurrent_writers_yield_complete_file(tmp_path: Path) -> None:
+    """N threads write distinct payloads to ONE path; reader sees no torn file.
+
+    Last-writer-wins is acceptable; the guarantee is that the final file is a
+    complete, parseable payload equal to exactly one candidate — never a
+    half-written / interleaved blob.
+    """
+    target = tmp_path / "active" / "leases.json"
+    n = 16
+    candidates = [
+        json.dumps(
+            {"schema_version": 1, "writer": i, "leases": [{"lease_id": f"lease-{i}"}]},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+        for i in range(n)
+    ]
+
+    def _run(content: str) -> None:
+        agent_loop._atomic_write_text(target, content)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
+        futures = [ex.submit(_run, candidates[i]) for i in range(n)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    final = target.read_text(encoding="utf-8")
+    # Parses cleanly (never torn) ...
+    parsed = json.loads(final)
+    assert parsed["schema_version"] == 1
+    # ... and is exactly one of the full candidate payloads.
+    assert final in candidates
+    # No temp artifacts survive the race.
+    assert list(target.parent.glob(".leases.json.*")) == []


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1766

ADR 0094 동시성 substrate brick 1/7. `make 시작` bounded 루프의 병렬화(XYZ) 활성화 **이전**에, lock 없는 ledger/lease 쓰기(last-writer-wins, 부분파일 노출 위험)를 crash-atomic 으로 닫는다. `_atomic_write_text` 헬퍼(same-dir temp + POSIX flock + `os.replace`) 도입 후 3개 in-scope write site 를 retrofit. **출력 byte-identical (X=1/M=8, ADR 0001)** — 순수 durability 하드닝, 동작 변화 없음.

## 2. 영향 파일

- `scripts/agent_loop.py` — import guard(`tempfile` + POSIX-guarded `fcntl`) + `_atomic_write_text` 헬퍼 + 3 retrofit(`write_cycle_checkpoint`, terminal state write, `_write_active_leases`). **NOT load-bearing** (ADR 0080/0085/0087, `scripts/_governance.py` SSoT).
- `tests/test_atomic_ledger_write_regression.py` — NEW, 5 positive-shape 회귀 테스트.

load-bearing 파일(`rag_*`, `ingestion`, `eval/`, `api/`, `docs/adr/`, `build_index.py`) 무변경.

## 3. 리스크

- **출력 바이트 변화 → ADR 0001 위반** (가장 가능성 높은 깨짐): 배제 = 헬퍼가 **pre-serialized 문자열**을 받고(`json.dumps(...) + "\n"` 표현식 불변), `os.fdopen(..., "w", encoding="utf-8")`(newline=None)가 `Path.write_text(..., encoding="utf-8")`와 byte-equal. 기존 ledger/lease/auto_loop 51 테스트 green = 통합 byte-identical 증명.
- **비-POSIX(fcntl 없음)**: import guard → `fcntl is None` 시 flock 생략, `os.replace` 단독으로도 atomic-rename 유지.
- **temp cross-device → os.replace 실패**: same-dir `mkstemp(dir=path.parent)` 로 동일 파일시스템 보장.

## 4. 테스트

신규 `tests/test_atomic_ledger_write_regression.py` (5): byte-identity vs `write_text` / 실패 시 no-partial(원본 보존+temp 잔재 0) / temp artifact 0 / lease content 불변 / concurrent writers no-torn-file. 기존 51 ledger·lease·auto_loop 테스트 green(변경 전후). `py_compile` OK, `git diff --check` clean.

## 5. Eval 영향

`agent_loop.py` 는 LOAD_BEARING_PATHS 아님(ADR 0080) — RAG retrieval/verifier/answer/eval 런타임 미접촉. **동작 변화 없음, real-eval delta 없음.** All `·` (RAG 외 변경).

## 6. 하위 호환

계약/스키마/CLI flag 무변경. `_write_active_leases` 시그니처 보존(PR-B `claim_disjoint` 가 compose). `auto_loop_state.json`/`leases.json` 페이로드 byte-identical → `schema_version` bump 불필요.

## 7. 범위 외

- A2(LedgerState 단일 직렬 writer) / B(LeaseManager.claim_disjoint flock critical section) / C(global `BoundedSemaphore(M)`) / D(Y default-on) / E(X dark) / F(flip) — 후속 stacked PR.
- `codex_runner_state.json` writers(~14140/14794/15130/15448, 다른 파일) 의도적 미접촉.
- pre-existing Pyright 경고(handoff `Eval surface` literal, `object`-iterability 등) — PR-A1 무관, 별도 정리.
