### PR TITLE
chore(scripts): cmux 트랙 세션 spawn 헬퍼 + make 타겟

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1510,6 +1510,8 @@ USE_EXISTING_ARM ?= 0
 TYPE ?= chore
 SLUG ?=
 LABELS ?=
+BASE ?= origin/main
+WT_PARENT ?= ..
 
 ship-start:
 	@if [ -z "$(TITLE)" ]; then \
@@ -1522,6 +1524,20 @@ ship-start:
 	  --type "$(TYPE)" \
 	  --slug "$(SLUG)" \
 	  --labels "$(LABELS)"
+
+# Spawn an isolated cmux track session (issue #1767): `git worktree add` off
+# origin/main + `cmux workspace create` cold-start `claude`. Thin mechanical
+# helper that captures the escaping / PATH / platform traps; see
+# scripts/spawn_track_session.sh. Issue creation stays with ship-start / gh.
+.PHONY: spawn-track
+spawn-track:
+	@if [ -z "$(ISSUE)" ] || [ -z "$(PROMPT)" ]; then \
+	  echo "Usage: make spawn-track ISSUE=N PROMPT='cold-start prompt' [TYPE=chore] [SLUG=slug] [BASE=origin/main] [WT_PARENT=..] [DRY_RUN=1]"; \
+	  exit 1; \
+	fi
+	@ISSUE="$(ISSUE)" PROMPT="$(PROMPT)" TYPE="$(TYPE)" SLUG="$(SLUG)" \
+	  BASE="$(BASE)" WT_PARENT="$(WT_PARENT)" DRY_RUN="$(DRY_RUN)" \
+	  bash scripts/spawn_track_session.sh
 
 ship-arm:
 	@$(PYTHON) scripts/claude-hooks/_ship_arm.py \

--- a/scripts/spawn_track_session.sh
+++ b/scripts/spawn_track_session.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Spawn an isolated cmux track session for a side task (issue #1767).
+#
+# Two-layer design (memory project_skill_authoring: 기계적=도구재사용 /
+# 스킬=판단레이어). This is the THIN MECHANICAL layer: it captures the
+# escaping / PATH / platform traps of nesting
+#   cmux workspace create --command "claude '<prompt>'"
+# The *judgment* layer (which track-surface rules to synthesize into the
+# prompt: real100_v2-only / chroma baseline / BGE-M3 OOM …) is a separate
+# skill, intentionally deferred until the pattern repeats — over-engineering
+# guard: 빈도≠가치 (one session, 3 tracks on 2026-06-02 is not yet a pattern).
+#
+# What it does:
+#   1. Assemble an ADR-0007 branch name, then VALIDATE it via the SSoT
+#      (scripts/check_branch_and_issue.py) — never copies the regex.
+#   2. `git worktree add` an origin/main-based isolated worktree. This never
+#      touches the caller's HEAD (memory project_omc_teleport_adr0007).
+#   3. If inside cmux, `cmux workspace create` a cold-start `claude` session
+#      in that worktree, focus kept on the caller. Outside cmux, print a
+#      manual resume command and exit 0 (fallback is a normal path).
+#
+# Issue creation is OUT of scope (decided 2026-06-02). `make ship-start`
+# does `git switch -c` on the *current* tree + refuses a dirty tree, which is
+# incompatible with worktree isolation — so it cannot be reused here. Create
+# the issue first (make ship-start / gh issue create) and pass ISSUE=N.
+#
+# Run from the repository root.
+#
+# Usage:
+#   ISSUE=1764 PROMPT='measure retrieval recall on real100 v2' \
+#     bash scripts/spawn_track_session.sh
+#   make spawn-track ISSUE=1764 TYPE=eval SLUG=retrieval-remeasure PROMPT='...'
+#   DRY_RUN=1 ...   # echo the git/cmux commands instead of running them
+#
+# Env:
+#   ISSUE      (required) existing issue number the track will close
+#   PROMPT     (required) cold-start prompt; see the escaping guard below
+#   TYPE       branch type (default chore); ADR-0007 whitelist enforced
+#   SLUG       optional kebab slug appended to the branch + worktree dir name
+#   BASE       base ref for the new branch (default origin/main)
+#   WT_PARENT  parent dir for the new worktree (default .. = sibling)
+#   CMUX_BIN   cmux CLI path (default the macOS app-bundle absolute path)
+#   DRY_RUN    1 = print the git/cmux commands without executing (default 0)
+
+ISSUE="${ISSUE:?ISSUE=N (existing issue number) required}"
+PROMPT="${PROMPT:?PROMPT='cold-start prompt' required}"
+TYPE="${TYPE:-chore}"
+SLUG="${SLUG:-}"
+BASE="${BASE:-origin/main}"
+WT_PARENT="${WT_PARENT:-..}"
+DRY_RUN="${DRY_RUN:-0}"
+# Absolute path: a bare `cmux` is not on PATH in eval/subprocess contexts
+# (issue #1767 실측). Tests override this with a stub.
+CMUX_BIN="${CMUX_BIN:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+
+# --- Escaping guard (issue #1767 실측) -------------------------------------
+# The cold-start command is the NESTED form  --command "claude '<prompt>'".
+# Inside that single-quoted inner string a backtick / $ / ! / " / ' breaks
+# the quoting and corrupts the spawned command. We REJECT (never sanitize) so
+# the prompt's meaning is not silently altered. `#` is safe inside single
+# quotes and is allowed (ADR numbers, issue refs like #1767).
+bad=""
+case "$PROMPT" in
+  *'`'*)  bad='backtick (`)' ;;
+  *'$'*)  bad='dollar ($)' ;;
+  *'!'*)  bad='bang (!)' ;;
+  *'"'*)  bad='double-quote (")' ;;
+  *"'"*)  bad="apostrophe (')" ;;
+esac
+if [ -n "$bad" ]; then
+  echo "spawn: PROMPT contains a forbidden char: $bad" >&2
+  echo "spawn: nested cmux --command \"claude '...'\" cannot escape it." >&2
+  echo "spawn: rewrite the prompt without it ('#' is allowed)." >&2
+  exit 1
+fi
+
+# --- Branch name: assemble, then validate via SSoT (no regex copy) ---------
+BRANCH="${TYPE}/issue-${ISSUE}${SLUG:+-${SLUG}}"
+if ! python3 scripts/check_branch_and_issue.py --branch "$BRANCH"; then
+  echo "spawn: assembled branch '$BRANCH' fails the ADR-0007 convention." >&2
+  echo "spawn: fix TYPE (whitelist) or SLUG (kebab a-z0-9-) and retry." >&2
+  exit 1
+fi
+
+WT="${WT_PARENT}/issue-${ISSUE}-${SLUG:-track}"
+
+# DRY_RUN echoes a command with %q-quoted args instead of running it. Simple
+# sequential commands only — `declare -a` arrays lose PATH in eval contexts
+# (issue #1767 실측: `command not found: git`).
+run() {
+  if [ "$DRY_RUN" = 1 ]; then
+    printf 'DRY_RUN:'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+# --- Isolated worktree (memory project_omc_teleport_adr0007) ---------------
+# Fetch first so origin/main is fresh (stale-ref false-negative gotcha), then
+# add the worktree off origin/main for isolation. worktree add never moves the
+# caller's HEAD, so spawning from any worktree is safe.
+run git fetch origin main
+run git worktree add "$WT" -b "$BRANCH" "$BASE"
+
+# --- cmux detect → spawn / fallback ---------------------------------------
+if "$CMUX_BIN" identify --json >/dev/null 2>&1; then
+  # Permission is fixed: `claude '<prompt>'` with NO permission flags
+  # (--dangerously-skip-permissions etc. are never injected — measurement /
+  # guard work keeps destructive ops human-gated). --focus false keeps the
+  # caller's focus.
+  run "$CMUX_BIN" workspace create --cwd "$WT" --command "claude '${PROMPT}'" --focus false
+  echo "spawn: track session created in $WT (focus kept on caller)." >&2
+else
+  echo "spawn: not inside cmux — worktree is ready, resume manually:" >&2
+  echo "  cd \"$WT\" && claude '${PROMPT}'"
+fi

--- a/tests/test_spawn_track_session_script.py
+++ b/tests/test_spawn_track_session_script.py
@@ -1,0 +1,157 @@
+"""Guard: scripts/spawn_track_session.sh — cmux track-session spawn helper (issue #1767).
+
+The helper nests `cmux workspace create --command "claude '<prompt>'"`, whose
+single-quoted inner string cannot escape a backtick / $ / ! / " / '. Two guard
+families mirror tests/test_test_sh_bash32_regression.py:
+
+  1. Static: the escaping guard, the cmux absolute path, the fixed
+     `claude '<prompt>'` (no permission flag), the origin/main base, and the
+     SSoT branch validation (no regex copy) must all be present in the source.
+  2. Behavioral: run the script with DRY_RUN=1 and a stubbed `cmux` to confirm
+     forbidden prompts are rejected (exit 1), `#` is allowed, the in-cmux path
+     echoes `workspace create ... --focus false`, and the non-cmux fallback
+     prints a manual `claude '<prompt>'` resume line instead of spawning.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "spawn_track_session.sh"
+
+
+def _source() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def _code() -> str:
+    """Source with full-line comments and blank lines stripped.
+
+    The negative guards ("must NOT contain …") below check the executable
+    body, not the prose — the comments intentionally *name* `declare -a` and
+    `--dangerously-skip-permissions` to document the traps being avoided, so a
+    raw substring scan of the whole file would false-positive on them.
+    """
+    return "\n".join(
+        line
+        for line in _source().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+
+
+def _stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestSpawnTrackStatic(unittest.TestCase):
+    def test_strict_bash_mode(self) -> None:
+        self.assertIn("set -euo pipefail", _source())
+
+    def test_cmux_absolute_path_default(self) -> None:
+        self.assertIn("/Applications/cmux.app/Contents/Resources/bin/cmux", _source())
+
+    def test_focus_false_keeps_caller(self) -> None:
+        self.assertIn("--focus false", _source())
+
+    def test_permission_is_fixed_no_skip_flag(self) -> None:
+        self.assertIn("claude '", _source())  # cold-start command is hardcoded
+        self.assertNotIn("--dangerously", _code())  # never injects a skip flag
+
+    def test_base_default_origin_main(self) -> None:
+        self.assertIn('BASE="${BASE:-origin/main}"', _source())
+
+    def test_reuses_branch_ssot_not_regex_copy(self) -> None:
+        src = _source()
+        self.assertIn("check_branch_and_issue.py --branch", src)
+        # The branch whitelist regex lives only in the SSoT; never copied here.
+        self.assertNotIn("feat|fix|docs", src)
+
+    def test_escape_guard_rejects_five_chars_allows_hash(self) -> None:
+        src = _source()
+        for needle in ("*'`'*)", "*'$'*)", "*'!'*)", "*'\"'*)", "*\"'\"*)"):
+            self.assertIn(needle, src, f"escape guard must cover the case {needle!r}")
+        # `#` must NOT be in the reject set (it is safe inside single quotes).
+        self.assertNotIn("*'#'*)", src)
+
+    def test_no_declare_a_array(self) -> None:
+        # `declare -a` arrays lose PATH in eval contexts (issue #1767 실측).
+        self.assertNotIn("declare -a", _code())
+
+
+class TestSpawnTrackBehavior(unittest.TestCase):
+    def _run(self, prompt: str, *, cmux_ok: bool = True, drop_issue: bool = False):
+        tmp = tempfile.mkdtemp(prefix="spawn-track-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        binp = Path(tmp)
+        # stub `cmux`: `identify` exits 0 (in-cmux) or 1 (outside). Any other
+        # subcommand echoes a marker — only reached when DRY_RUN=0, which the
+        # tests never use (DRY_RUN=1 echoes the command instead of running it).
+        code = "0" if cmux_ok else "1"
+        _stub(
+            binp / "cmux",
+            f'#!/bin/sh\nif [ "$1" = identify ]; then exit {code}; fi\n'
+            f'echo "CMUX_STUB:$*"\nexit 0\n',
+        )
+        env = dict(os.environ)
+        env["PATH"] = f"{binp}{os.pathsep}{env['PATH']}"
+        env["CMUX_BIN"] = str(binp / "cmux")
+        env["DRY_RUN"] = "1"  # never touch the real git / cmux
+        env["PROMPT"] = prompt
+        env["TYPE"] = "chore"
+        env["SLUG"] = "demo"
+        if drop_issue:
+            env.pop("ISSUE", None)
+        else:
+            env["ISSUE"] = "1767"
+        bash = "/bin/bash" if Path("/bin/bash").exists() else "bash"
+        return subprocess.run(
+            [bash, str(SCRIPT)],
+            cwd=REPO,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_forbidden_backtick_rejected(self) -> None:
+        r = self._run("use `backticks` here")
+        self.assertEqual(1, r.returncode)
+        self.assertIn("forbidden char", r.stderr)
+        self.assertIn("backtick", r.stderr)
+
+    def test_forbidden_apostrophe_rejected(self) -> None:
+        r = self._run("don't do this")
+        self.assertEqual(1, r.returncode)
+        self.assertIn("apostrophe", r.stderr)
+
+    def test_hash_is_allowed(self) -> None:
+        r = self._run("close issue #1767 and measure recall")
+        self.assertEqual(0, r.returncode, r.stderr)
+
+    def test_in_cmux_echoes_workspace_create(self) -> None:
+        r = self._run("measure retrieval recall on real100 v2", cmux_ok=True)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("workspace create", r.stdout)
+        self.assertIn("--focus false", r.stdout)
+
+    def test_fallback_prints_manual_resume_when_not_in_cmux(self) -> None:
+        r = self._run("measure retrieval recall", cmux_ok=False)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("claude '", r.stdout)  # manual resume command
+        self.assertNotIn("workspace create", r.stdout)  # spawn skipped
+
+    def test_missing_issue_fails(self) -> None:
+        r = self._run("measure recall", drop_issue=True)
+        self.assertNotEqual(0, r.returncode)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

cmux 트랙 세션 spawn 워크플로(2026-06-02 세션에서 별도 트랙 3종을 수동 spawn)를 재유도 없이 재사용하도록, 기계적 함정을 캡슐화한 얇은 헬퍼를 추가한다. `git worktree add` 격리 + `cmux workspace create` cold-start 의 이스케이프/PATH/플랫폼 트랩을 한 곳에 가둔다. 두 층 설계(헬퍼=기계적 / 스킬=판단) 중 **헬퍼 층만** — 판단 스킬은 over-engineering 가드(빈도≠가치, 유일 사용례 1세션)로 후속 issue 보류.

Closes #1767

## 2. 영향 파일

- `scripts/spawn_track_session.sh` (신규, +x) — 헬퍼 본체. worktree 격리 → cmux cold-start spawn / fallback
- `Makefile` (+16) — `spawn-track` 타겟 + `BASE`/`WT_PARENT` 변수 + `.PHONY`
- `tests/test_spawn_track_session_script.py` (신규) — 14 테스트 (정적 8 + stub 동작 6)

load-bearing 경로 없음 (`scripts/_governance.py --is-load-bearing` 으로 3경로 모두 not-load-bearing 확인).

## 3. 리스크

- **이스케이프 깨짐**: 중첩 `--command "claude '<prompt>'"` 에서 백틱/$/!/"/' → 거부(exit 1)로 차단, sanitize 안 함(조용한 의미 변질 방지). `#` 는 안전(실측, make 경유 포함).
- **현재 트리 오염**: ship-start 의 `git switch -c`(현재 트리 전환 + dirty 거부) 재사용을 피하고 `git worktree add` 로 격리 — 호출자 HEAD 불변.
- **PATH 손실**: `declare -a` 배열 회피(eval-context PATH 손실 실측), 단순 순차 명령만.
- **권한 우회**: `claude '<prompt>'` 하드코딩, 권한 플래그 주입 입구 없음(측정/가드는 destructive op human-gate).
- 브랜치 타입은 `check_branch_and_issue.py` SSoT 로 검증(regex 복붙 없음) — 비허용 타입 거부 실측.

## 4. 테스트

신규 `tests/test_spawn_track_session_script.py` 14개:
- **정적 8**: `set -euo pipefail`, cmux 절대경로, `--focus false`, `claude '` 하드코딩 + `--dangerously` 부재, `BASE` 기본 origin/main, SSoT 호출 + regex 복붙 부재, 5 금지문자 case + `#` 허용, `declare -a` 부재.
- **동작 6** (stub cmux + `DRY_RUN=1`): 백틱/apostrophe 거부, `#` 허용, in-cmux `workspace create` echo, 비-cmux fallback resume, `ISSUE` 누락 실패.

## 5. Eval 영향

동작 변화 없음 — RAG/검색/eval path 미변경(개발 편의 도구). load-bearing 경로 0 → real-eval delta 불요. CI eval delta: All `·`.

## 6. 하위 호환

영향 없음 — 신규 헬퍼/타겟 추가만. 기존 계약/스키마/CLI flag/Make 타겟 불변.

## 7. 범위 외

- **판단 스킬 층**: 트랙별 표면 경계(real100_v2 전용 / chroma baseline / BGE-M3 OOM) 주입 + cold-start 프롬프트 합성. over-engineering 가드로 후속 issue 보류 — 트랙 종류/반복 입증 후.
- **issue 생성**: ship-start / gh 담당(`ISSUE=N` 인자). 헬퍼가 흡수하지 않음(ship-start 의 `switch -c` 가 worktree 격리와 양립 불가하므로).

---
Local gate: `make test-fast` — real-model `slow` tests excluded locally (FlagEmbedding installed), covered by CI. 3360 passed, 15 skipped + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
