### PR TITLE
feat(agent-loop): LedgerState single serialized writer for ledger facts (closes #1773)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1009,6 +1009,87 @@ def _atomic_write_text(path: Path, content: str) -> None:
         raise
 
 
+class LedgerState:
+    """Single serialized writer for the bounded-loop ledger (ADR 0094 PR-A2).
+
+    Owns the append-only ledger facts (completed / deferred / cycles / blockers /
+    consecutive_blockers) behind ONE in-process threading.Lock so every mutation
+    is serialized — eliminating the unlocked snapshot+rewrite last-writer-wins /
+    lost-update race before the X task-pool (PR-E) is enabled. At X=1 there is
+    exactly one writer, so snapshot()/persist() emit bytes identical to today's
+    inline closure mutables (ADR 0001 byte-identical gate). This lock serializes
+    the LEDGER only; it must NOT be held across a subprocess spawn or a future
+    semaphore acquire (PR-C), and is independent of the lease flock (PR-B)."""
+
+    def __init__(self, *, completed: Sequence[str] = (), deferred: Sequence[str] = ()) -> None:
+        self._lock = threading.Lock()
+        self._completed: list[str] = list(completed)
+        self._deferred: list[str] = list(deferred)
+        self._cycles: list[dict[str, object]] = []
+        self._blockers: list[str] = []
+        self._consecutive_blockers: int = 0
+
+    @property
+    def completed(self) -> list[str]: return self._completed       # live list (read sites)
+    @property
+    def deferred(self) -> list[str]: return self._deferred         # live list
+    @property
+    def cycles(self) -> list[dict[str, object]]: return self._cycles  # live list (in-place mutated)
+    @property
+    def blockers(self) -> list[str]: return self._blockers         # live list
+    @property
+    def consecutive_blockers(self) -> int: return self._consecutive_blockers
+
+    def record_completed(self, task_id: str) -> None:
+        with self._lock:
+            if task_id not in self._completed:
+                self._completed.append(task_id)
+            self._deferred[:] = [x for x in self._deferred if x != task_id]
+            self._consecutive_blockers = 0
+
+    def record_deferred(self, task_id: str) -> None:
+        with self._lock:
+            if task_id not in self._deferred:
+                self._deferred.append(task_id)
+
+    def append_cycle(self, cycle: dict[str, object]) -> None:
+        with self._lock:
+            self._cycles.append(cycle)   # BY REFERENCE — caller keeps mutating it
+
+    def extend_blockers(self, messages: Sequence[str]) -> None:
+        with self._lock:
+            self._blockers.extend(messages)
+
+    def append_blocker(self, message: str) -> None:
+        with self._lock:
+            self._blockers.append(message)
+
+    def bump_consecutive_blocker(self) -> int:
+        with self._lock:
+            self._consecutive_blockers += 1
+            return self._consecutive_blockers
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            return {
+                "completed_task_ids": list(self._completed),
+                "deferred_task_ids": list(self._deferred),
+                "cycles": list(self._cycles),
+                "blockers": _dedupe_preserve_order(self._blockers),
+            }
+
+    def persist(self, path: Path, payload: dict[str, object]) -> None:
+        # Callers run snapshot() and persist() under SEPARATE lock scopes, not one
+        # critical section: holding the lock across fsync/os.replace would serialize
+        # every ledger op during disk I/O. The snapshot↔persist pair being non-atomic
+        # is a deliberate non-goal until the X task-pool lands (PR-E).
+        with self._lock:
+            _atomic_write_text(
+                path,
+                json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True) + "\n",
+            )
+
+
 def _normalize_field(label: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", label.lower())
 
@@ -10695,7 +10776,11 @@ def write_active_auto_loop(
     out_path = _active_path(out, repo_root=repo_root)
     state_path = _active_path(state, repo_root=repo_root)
     prior_completed, prior_deferred, warnings = _load_active_auto_ledger(state_path)
-    completed: list[str] = list(prior_completed)
+    ledger = LedgerState(completed=prior_completed, deferred=prior_deferred)
+    completed = ledger.completed
+    deferred_task_ids = ledger.deferred
+    cycles = ledger.cycles
+    blockers = ledger.blockers
     # ADR 0092 (PR1): resolve the lane-autotune config. A caller (the CLI) may inject one;
     # otherwise fall back to env (so `make 시작` env still drives it). None == OFF, which
     # gates every autotune side effect below so off-mode stays byte-identical (AC1/R4).
@@ -10728,9 +10813,6 @@ def write_active_auto_loop(
     )
     warnings.append(f"max-iterations resolved to {max_iterations} ({limit_reason})")
     infinite_mode = max_iterations == INFINITE_MAX_ITERATIONS
-    blockers: list[str] = []
-    cycles: list[dict[str, object]] = []
-    deferred_task_ids: list[str] = list(prior_deferred)
     requested_files = tuple(sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path))
     branch_task_id = _task_from_branch(_current_branch(repo_root))
 
@@ -10772,6 +10854,7 @@ def write_active_auto_loop(
     max_attempts = max(1, max_iterations, int(auto_max_iterations_cap))
 
     def write_cycle_checkpoint(decision: str) -> None:
+        snap = ledger.snapshot()
         checkpoint_payload = {
             "schema_version": 1,
             "generated_at": _isoformat(datetime.now(timezone.utc)),
@@ -10786,11 +10869,11 @@ def write_active_auto_loop(
             "target_completed_count": target_completed_count,
             "max_attempts": max_attempts,
             "max_iterations_reason": limit_reason,
-            "completed_task_ids": completed,
-            "deferred_task_ids": deferred_task_ids,
+            "completed_task_ids": snap["completed_task_ids"],
+            "deferred_task_ids": snap["deferred_task_ids"],
             "next_task_id": None,
-            "cycles": cycles,
-            "blockers": _dedupe_preserve_order(blockers),
+            "cycles": snap["cycles"],
+            "blockers": snap["blockers"],
             "warnings": _dedupe_preserve_order(warnings),
         }
         # ADR 0092 (AC8/AC13): only emit the recommendations + cooldown_state keys when
@@ -10798,21 +10881,16 @@ def write_active_auto_loop(
         if lane_autotune_config is not None:
             checkpoint_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
             checkpoint_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
-        _atomic_write_text(
-            state_path,
-            json.dumps(_sanitize_json_value(checkpoint_payload), indent=2, sort_keys=True) + "\n",
-        )
+        ledger.persist(state_path, checkpoint_payload)
 
     # Infinite-mode safety state. ``consecutive_blockers`` is reset to zero on every
     # completion so a long-running drain is only aborted by an *unbroken* streak of
-    # blocked tasks, not by isolated failures interleaved with progress.
-    consecutive_blockers = [0]
+    # blocked tasks, not by isolated failures interleaved with progress. The counter
+    # now lives inside ``ledger`` (LedgerState) so the reset and the completed/deferred
+    # mutations happen under one lock (ADR 0094 PR-A2).
 
     def mark_task_completed(task_id: str) -> None:
-        if task_id not in completed:
-            completed.append(task_id)
-        deferred_task_ids[:] = [item for item in deferred_task_ids if item != task_id]
-        consecutive_blockers[0] = 0
+        ledger.record_completed(task_id)
 
     def register_task_blocker(task: TaskEntry, messages: Sequence[str]) -> bool:
         """Record a per-task blocker and decide whether to stop the whole loop.
@@ -10823,15 +10901,14 @@ def write_active_auto_loop(
         only when consecutive blockers reach ``max_consecutive_blockers``. Returns ``True``
         when the caller should ``break``.
         """
-        blockers.extend(messages)
+        ledger.extend_blockers(messages)
         if not infinite_mode:
             return True
-        consecutive_blockers[0] += 1
-        if task.task_id not in deferred_task_ids:
-            deferred_task_ids.append(task.task_id)
-        if consecutive_blockers[0] >= max_consecutive_blockers:
+        new_streak = ledger.bump_consecutive_blocker()
+        ledger.record_deferred(task.task_id)
+        if new_streak >= max_consecutive_blockers:
             stop_message = (
-                f"infinite mode: {consecutive_blockers[0]} consecutive blocked task(s) "
+                f"infinite mode: {new_streak} consecutive blocked task(s) "
                 f"reached the BIDMATE_AGENT_LOOP_MAX_CONSECUTIVE_BLOCKERS guard "
                 f"({max_consecutive_blockers}); stopping"
             )
@@ -10839,11 +10916,11 @@ def write_active_auto_loop(
             # A safety-guard abort is a blocked outcome, never a clean "limit-reached":
             # record it as a blocker so the run decision reflects the abort even when the
             # tripping task carried no per-task message (e.g. the ship-disabled lane).
-            blockers.append(stop_message)
+            ledger.append_blocker(stop_message)
             return True
         warnings.append(
             f"{task.task_id}: blocked in infinite mode; deferred and continuing "
-            f"(consecutive blockers {consecutive_blockers[0]}/{max_consecutive_blockers})"
+            f"(consecutive blockers {new_streak}/{max_consecutive_blockers})"
         )
         write_cycle_checkpoint("running")
         return False
@@ -10916,8 +10993,7 @@ def write_active_auto_loop(
                 if _patch_declares_blocked_handoff(patch_path):
                     cycle["completion_decision"] = "repair-applied-blocked-handoff"
                     cycle["completed"] = False
-                    if task.task_id not in deferred_task_ids:
-                        deferred_task_ids.append(task.task_id)
+                    ledger.record_deferred(task.task_id)
                     warnings.append(
                         f"{task.task_id}: repair patch only recorded a blocked handoff; deferred for another repair cycle"
                     )
@@ -10934,8 +11010,7 @@ def write_active_auto_loop(
                     f"{task.task_id}: repair patch did not apply cleanly: "
                     + "; ".join(apply_result.blockers[:3])
                 )
-        if task.task_id not in deferred_task_ids:
-            deferred_task_ids.append(task.task_id)
+        ledger.record_deferred(task.task_id)
         # T-X4 (agent-loop integration plan): advisory-only escalation pointer once the
         # auto-repair lane (claude->codex fallback) is exhausted without landing a patch.
         # Recorded on the cycle; never spawns a subprocess or changes the defer/stop flow.
@@ -10982,7 +11057,7 @@ def write_active_auto_loop(
                 warnings.append(stop_message)
                 # Safety-guard abort -> blocked outcome (mirrors the consecutive-blocker
                 # guard); ``wall_clock_exceeded`` stays the machine-readable signal.
-                blockers.append(stop_message)
+                ledger.append_blocker(stop_message)
                 break
         iteration += 1
         retrying_deferred = False
@@ -11029,14 +11104,14 @@ def write_active_auto_loop(
                     warnings.append(f"retrying deferred task `{task.task_id}` after fresh task selection stopped: {exc}")
                 except ValueError as retry_exc:
                     if iteration == 1 and not (infinite_mode and not explicit_target_completed_count):
-                        blockers.append(str(exc))
+                        ledger.append_blocker(str(exc))
                     elif iteration != 1:
                         warnings.append(f"no next task selected after iteration {iteration - 1}: {exc}")
                     warnings.append(f"deferred retry selection stopped: {retry_exc}")
                     break
             else:
                 if iteration == 1 and not (infinite_mode and not explicit_target_completed_count):
-                    blockers.append(str(exc))
+                    ledger.append_blocker(str(exc))
                 elif iteration == 1:
                     # Open-ended infinite mode with an already-drained ready queue is a clean
                     # no-op, not a blocked run (ADR 0085).
@@ -11055,7 +11130,7 @@ def write_active_auto_loop(
             "completed": False,
             "retry_deferred": retrying_deferred,
         }
-        cycles.append(cycle)
+        ledger.append_cycle(cycle)
 
         start = write_active_start(
             mode=mode,
@@ -11329,7 +11404,7 @@ def write_active_auto_loop(
             # target counts against the run.
             if not infinite_mode and not target_reached:
                 warnings.append(f"next task selection stopped: {exc}")
-                blockers.append(
+                ledger.append_blocker(
                     f"target completion count not reached "
                     f"({len(completed)}/{target_completed_count}); {exc}"
                 )
@@ -11362,6 +11437,7 @@ def write_active_auto_loop(
     # decision/control flow unchanged. Collector failure degrades to None.
     adr_lifecycle_advisory = _adr_lifecycle_advisory(repo_root=repo_root) if cycles else None
 
+    snap = ledger.snapshot()
     state_payload = {
         "schema_version": 1,
         "generated_at": _isoformat(datetime.now(timezone.utc)),
@@ -11377,13 +11453,13 @@ def write_active_auto_loop(
         "target_completed_count": target_completed_count,
         "max_attempts": max_attempts,
         "max_iterations_reason": limit_reason,
-        "completed_task_ids": completed,
-        "deferred_task_ids": deferred_task_ids,
+        "completed_task_ids": snap["completed_task_ids"],
+        "deferred_task_ids": snap["deferred_task_ids"],
         "next_task_id": next_task.task_id if next_task else None,
-        "cycles": cycles,
+        "cycles": snap["cycles"],
         "learning_capture_advisory": learning_advisory,
         "adr_lifecycle_advisory": adr_lifecycle_advisory,
-        "blockers": _dedupe_preserve_order(blockers),
+        "blockers": snap["blockers"],
         "warnings": _dedupe_preserve_order(warnings),
     }
     # ADR 0092 (AC8/AC13): emit recommendations + cooldown_state on the terminal state write
@@ -11393,7 +11469,7 @@ def write_active_auto_loop(
     if lane_autotune_config is not None:
         state_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
         state_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
-    _atomic_write_text(state_path, json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n")
+    ledger.persist(state_path, state_payload)
     rendered = render_active_auto_loop(
         decision=decision,
         execute_runner=execute_runner,

--- a/tests/test_ledger_state_writer_regression.py
+++ b/tests/test_ledger_state_writer_regression.py
@@ -1,0 +1,230 @@
+"""LedgerState single-serialized-writer regression (issue #1773, ADR 0094 PR-A2).
+
+``agent_loop.LedgerState`` is the substrate brick that moves the bounded-loop
+ledger facts (completed / deferred / cycles / blockers / consecutive_blockers)
+behind ONE in-process ``threading.Lock`` so every mutation is serialized. The
+senior contract this guards:
+
+* **Byte-identity (ADR 0001 gate)** — ``persist(path, payload)`` writes on-disk
+  bytes identical to ``json.dumps(_sanitize_json_value(payload), indent=2,
+  sort_keys=True) + "\\n"`` and drops no temp artifact, so at X=1 (one writer)
+  the ``auto_loop_state.json`` payload is the same byte sequence as the
+  pre-refactor inline ``_atomic_write_text`` call it replaced.
+* **Snapshot contract** — ``snapshot()`` emits exactly the 4 ledger keys
+  (``completed_task_ids`` / ``deferred_task_ids`` / ``cycles`` / ``blockers``),
+  blockers deduped *at snapshot only* (the raw ``_blockers`` keeps duplicates),
+  and ``consecutive_blockers`` is never serialized (transient guard).
+* **Coupled completion** — ``record_completed`` performs three coupled mutations
+  under one lock: guarded completed-append + deferred filter-remove + consecutive
+  reset.
+* **Lost-update-free under contention** — N threads recording disjoint task ids
+  all land (no last-writer-wins / lost update), and the same id from many threads
+  appears exactly once. This is THE property PR-A2 guarantees before the X
+  task-pool (PR-E) is enabled.
+
+Payloads are pinned explicitly so the tests are deterministic across machines
+and need no external model / network.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import threading
+from pathlib import Path
+from typing import cast
+
+from scripts import agent_loop
+
+
+def test_persist_bytes_identical_and_no_temp_artifact(tmp_path: Path) -> None:
+    """LedgerState.persist output == json.dumps(...sort_keys) and leaves no temp.
+
+    Pins the exact on-disk bytes against the same serialization expression the
+    production checkpoint/terminal writes use, proving the LedgerState.persist
+    swap is output-preserving (ADR 0094 PR-A2 / ADR 0001 byte-identical gate).
+    """
+    path = tmp_path / "active" / ".auto_loop_state.json"
+    # A payload shaped like the loop's checkpoint/terminal state (unsorted keys on
+    # purpose: sort_keys=True makes construction order irrelevant to the bytes).
+    payload = {
+        "schema_version": 1,
+        "decision": "running",
+        "completed_task_ids": ["T-2026-0002", "T-2026-0001"],
+        "deferred_task_ids": ["T-2026-0003"],
+        "next_task_id": None,
+        "cycles": [{"iteration": 1, "task_id": "T-2026-0001", "completed": True}],
+        "blockers": ["b1", "b2"],
+        "warnings": ["max-iterations resolved to 1 (cli)"],
+    }
+    expected_bytes = (
+        json.dumps(agent_loop._sanitize_json_value(payload), indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+
+    ledger = agent_loop.LedgerState()
+    ledger.persist(path, payload)
+
+    assert path.read_bytes() == expected_bytes
+    # No .<name>.* temp artifact survives the atomic temp+replace write.
+    assert list(path.parent.glob(".auto_loop_state.json.*")) == []
+
+
+def test_snapshot_contract_dedupes_blockers_only_at_snapshot() -> None:
+    """snapshot() emits the 4 ledger keys; blockers deduped at snapshot only."""
+    ledger = agent_loop.LedgerState()
+    ledger.record_completed("T-2026-0001")
+    ledger.record_completed("T-2026-0001")  # guard: no duplicate
+    ledger.record_completed("T-2026-0002")
+    ledger.record_deferred("T-2026-0003")
+    ledger.record_deferred("T-2026-0003")  # guard: no duplicate
+    ledger.extend_blockers(["b1", "b1", "b2"])
+
+    snap = ledger.snapshot()
+
+    # Exactly the 4 ledger keys — consecutive_blockers is never serialized.
+    assert set(snap) == {"completed_task_ids", "deferred_task_ids", "cycles", "blockers"}
+    # completed keeps insertion order and the guard collapsed the duplicate.
+    assert snap["completed_task_ids"] == ["T-2026-0001", "T-2026-0002"]
+    # deferred guard collapsed the duplicate; the deferred id was never completed.
+    assert snap["deferred_task_ids"] == ["T-2026-0003"]
+    # blockers deduped AT SNAPSHOT ...
+    assert snap["blockers"] == ["b1", "b2"]
+    # ... while the live raw list still holds the duplicate (dedupe-at-snapshot).
+    assert ledger.blockers == ["b1", "b1", "b2"]
+    # snapshot returns copies: mutating it must not leak into ledger state.
+    cast("list[str]", snap["completed_task_ids"]).append("T-9999-9999")
+    assert ledger.completed == ["T-2026-0001", "T-2026-0002"]
+
+
+def test_record_completed_is_three_coupled_mutations() -> None:
+    """record_completed: completed-append + deferred-remove + consecutive reset."""
+    ledger = agent_loop.LedgerState(deferred=["T-2026-1001"])
+    assert ledger.bump_consecutive_blocker() == 1
+    assert ledger.bump_consecutive_blocker() == 2
+    assert ledger.consecutive_blockers == 2
+
+    ledger.record_completed("T-2026-1001")
+
+    # 1) completed-append (guarded).
+    assert ledger.completed == ["T-2026-1001"]
+    # 2) deferred filter-remove — the now-completed id is gone.
+    assert ledger.deferred == []
+    # 3) consecutive_blockers reset to zero on completion.
+    assert ledger.consecutive_blockers == 0
+
+
+def test_append_cycle_holds_dict_by_reference() -> None:
+    """append_cycle stores the cycle dict BY REFERENCE: in-place mutations made
+    AFTER the append (the loop marks completion on the same dict it appended) are
+    visible to snapshot(). A defensive copy here would silently drop them."""
+    ledger = agent_loop.LedgerState()
+    cycle: dict[str, object] = {"iteration": 1, "task_id": "T-2026-0001"}
+    ledger.append_cycle(cycle)
+    # The loop mutates the SAME dict after appending it (e.g. records the outcome).
+    cycle["completed"] = True
+    cycle["stop_reason"] = None
+
+    snap = ledger.snapshot()
+    cycles = cast("list[dict[str, object]]", snap["cycles"])
+    assert cycles == [
+        {"iteration": 1, "task_id": "T-2026-0001", "completed": True, "stop_reason": None}
+    ]
+
+
+def test_record_completed_lost_update_free_under_contention() -> None:
+    """64 threads record disjoint ids -> all land (no lost update / last-writer-wins).
+
+    This is THE property PR-A2 guarantees: before the lock, the unlocked
+    snapshot+rewrite ledger dropped concurrent updates. Under the lock every
+    disjoint completion is preserved.
+    """
+    n = 64
+    ledger = agent_loop.LedgerState()
+    ids = [f"T-2026-{i:04d}" for i in range(n)]
+    barrier = threading.Barrier(n)
+
+    def _run(task_id: str) -> None:
+        barrier.wait()  # maximize overlap on the write path
+        ledger.record_completed(task_id)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
+        futures = [ex.submit(_run, task_id) for task_id in ids]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    snap = ledger.snapshot()
+    # Every disjoint id landed exactly once — nothing lost to a racing rewrite.
+    assert len(cast("list[str]", snap["completed_task_ids"])) == n
+    assert set(cast("list[str]", snap["completed_task_ids"])) == set(ids)
+
+    # Same id from many threads must appear exactly once (the in-set guard holds
+    # under the lock — without it, concurrent "not in" checks would double-append).
+    ledger2 = agent_loop.LedgerState()
+    barrier2 = threading.Barrier(n)
+
+    def _run_same() -> None:
+        barrier2.wait()
+        ledger2.record_completed("T-2026-7777")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
+        futures = [ex.submit(_run_same) for _ in range(n)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    assert ledger2.snapshot()["completed_task_ids"] == ["T-2026-7777"]
+
+
+def test_lock_serializes_snapshot_never_torn(tmp_path: Path) -> None:
+    """Interleaved writers + concurrent snapshots -> every snapshot is serializable.
+
+    A reader (snapshot) must never observe a half-applied mutation (a torn dict
+    that json.dumps cannot serialize or that mixes states). The lock guarantees
+    each snapshot is a consistent, JSON-dumpable view.
+    """
+    ledger = agent_loop.LedgerState()
+    writers = 24
+    snapshotters = 24
+    barrier = threading.Barrier(writers + snapshotters)
+    errors: list[BaseException] = []
+    err_lock = threading.Lock()
+
+    def _writer(i: int) -> None:
+        barrier.wait()
+        try:
+            ledger.record_deferred(f"T-2026-{i:04d}")
+            ledger.append_cycle({"iteration": i, "task_id": f"T-2026-{i:04d}"})
+            ledger.extend_blockers([f"blk-{i}"])
+            ledger.record_completed(f"T-2026-{i:04d}")
+        except BaseException as exc:  # noqa: BLE001 - surface any thread failure
+            with err_lock:
+                errors.append(exc)
+
+    def _snapshotter() -> None:
+        barrier.wait()
+        try:
+            for _ in range(50):
+                snap = ledger.snapshot()
+                # Must be json-dumpable every time (never a torn / partial dict).
+                json.dumps(agent_loop._sanitize_json_value(snap), sort_keys=True)
+                assert set(snap) == {
+                    "completed_task_ids",
+                    "deferred_task_ids",
+                    "cycles",
+                    "blockers",
+                }
+        except BaseException as exc:  # noqa: BLE001
+            with err_lock:
+                errors.append(exc)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=writers + snapshotters) as ex:
+        futures = [ex.submit(_writer, i) for i in range(writers)]
+        futures += [ex.submit(_snapshotter) for _ in range(snapshotters)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    assert errors == []
+    # Final state is consistent and persists byte-identically.
+    final = ledger.snapshot()
+    assert len(cast("list[str]", final["completed_task_ids"])) == writers
+    out = tmp_path / "active" / ".auto_loop_state.json"
+    ledger.persist(out, final)
+    assert json.loads(out.read_text(encoding="utf-8"))["completed_task_ids"]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0094 동시성 substrate의 brick 2/7. bounded-loop ledger facts(completed / deferred / cycles / blockers / consecutive_blockers)를 단일 `threading.Lock` 뒤의 `LedgerState` 클래스로 이동해 모든 mutation을 직렬화한다. 직렬 루프가 *암묵적으로* 의존하던 "단일 writer라 lost-update 없음" 불변식을, X task-pool(PR-E) 도입 전에 **명시적 locking 계약**으로 대체한다. X=1에서는 writer가 정확히 하나이므로 `snapshot()`/`persist()`는 기존 inline closure mutable과 byte-identical하다(ADR 0001 게이트).

Closes #1773

## 2. 영향 파일

- `scripts/agent_loop.py` (+156/-40) — `LedgerState` 클래스 추가 + `write_active_auto_loop`의 7개 mutation site를 클래스 메서드로 재배선(reads는 live-list property alias 유지). **off LOAD_BEARING_PATHS** (ADR 0080/0085/0087).
- `tests/test_ledger_state_writer_regression.py` (신규, +230) — byte-identity / snapshot 계약 / coupled-completion / lost-update-free / by-reference cycles / torn-snapshot regression.

load-bearing 파일 변경 없음.

## 3. 리스크

가장 가능성 높은 깨짐 = ledger state 파일 byte drift(ADR 0001 위반) 또는 미묘한 semantic 회귀. 배제 근거:
- **byte-identical**: `test_persist_bytes_identical_and_no_temp_artifact`가 `json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True)+"\n"` 리터럴 표현식에 대해 on-disk 바이트를 핀. `sort_keys=True`로 payload key 구성 순서 무관.
- **5개 미묘 불변식 보존**: consecutive_blockers 비직렬화 / blockers dedupe-at-snapshot only / cycles by-reference / record_completed 3-coupled-mutation 원순서 / warnings loop-local — 각각 테스트로 assert.
- **lock 규율**: persist는 snapshot을 내부 호출하지 않음(caller가 payload 선조립) → `threading.Lock` 비재진입 데드락 회피. lock은 ledger 전용, subprocess/semaphore acquire 가로질러 보유 안 함.
- **Pyright 210→210 net-zero** (origin/main 베이스라인 대비, `git stash` 측정). 독립 code-reviewer(opus): APPROVE-WITH-NITS (CRITICAL/HIGH/MEDIUM 0), nit 4건 반영.

## 4. 테스트

`tests/test_ledger_state_writer_regression.py` 6개 (positive-shape):
- byte-identical persist + no-temp-artifact
- snapshot 4-key 계약 + dedupe-at-snapshot
- record_completed 3-coupled-mutation
- append_cycle by-reference 가시성
- 64-thread lost-update-free (disjoint 전부 landing + same-id 정확히 1회) — **unlocked baseline 대비 same-id case가 fail하는 진짜 witness**
- 24-writer/24-snapshotter torn-snapshot-free

기존 `test_agent_loop.py` ledger assertion(39+) green = 통합 byte-identical 증명. `test_atomic_ledger_write_regression.py`(A1) + `test_concurrency_regression.py` green.

## 5. Eval 영향

**동작 변화 없음.** `agent_loop.py`는 off LOAD_BEARING_PATHS(ADR 0080/0085/0087)이며 RAG 파이프라인(retrieval/verifier/answer/query/ingestion/eval)을 전혀 건드리지 않는다. ledger state 파일 출력은 X=1에서 byte-identical(§3). CI eval delta 예상 = All `·`.

## 6. 하위 호환

깨짐 없음. ledger state 파일 스키마(4 ledger keys) 불변, CLI flag/doc link 무변경. 답변 계약(ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외

- `BoundedSemaphore`/global M (PR-C), `LeaseManager.claim_disjoint` (PR-B), X/Y flip + `ThreadPoolExecutor` (PR-E) — 후속 brick.
- **PR-E carry-forward**: ~12개 unlocked read-alias 사이트(`*completed`/`*deferred_task_ids` splat, `for prior_cycle in cycles`)는 X>1에서 snapshot-for-read 또는 lock-guarded read 필요 — 본 brick의 의도된 deferral. PR-E acceptance item으로 기록.
