### PR TITLE
chore(queue): mark T-2026-0029 done after #1776 merge

### DIFF
--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -39,7 +39,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 26 | `T-2026-0026` | `in_progress` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1580; Chroma-backed `naive_baseline` canonical switch, separated from embedding-model baselines. |
 | 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
-| 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1764; page-aware re-measurement DONE (diagnostic-only). Page blocker resolved (coverage 0.0 -> 1.0) but doc-level retrieval collapsed (~12%); renderer BUG #1/#2 hardened; root cause spun off as T-2026-0076. |
+| 29 | `T-2026-0029` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1764; page-aware re-measurement DONE (diagnostic-only). Page blocker resolved (coverage 0.0 -> 1.0) but doc-level retrieval collapsed (~12%); renderer BUG #1/#2 hardened; root cause spun off as T-2026-0076. |
 | 30 | `T-2026-0030` | `ready` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | reopened after naive baseline remeasurement: rerender latency/cost envelope against the MiniLM page-aware v2 aggregate. |
 | 31 | `T-2026-0031` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | MiniLM page-aware checkpoint index now has non-zero page_span coverage; rerun only after refreshed baseline aggregate is available. |
 | 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | reopened after naive baseline remeasurement: rerun BGE-KO screening on the MiniLM page-aware v2 index before keeping no-winner status. |
@@ -2638,7 +2638,7 @@ make check-branch
 
 - ID: T-2026-0029
 - Title: Build retrieval diagnostic workbench
-- Status: review
+- Status: done
 - Priority: P0
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR #1776 (real100_v2 retrieval 재측정, diagnostic-only) 머지로 issue #1764 가 CLOSED 되었으나 `tasks/queue.md` 의 T-2026-0029 row 가 `review` 로 남아 있었다. queue row 29 + detail Status 를 `done` 으로 동기화한다. 근본 원인 follow-up 은 이미 T-2026-0076 (`ready`) 으로 분리되어 있다.

Closes #1778

## 2. 영향 파일

- `tasks/queue.md` — row 29 + T-2026-0029 detail Status: `review` -> `done` (load-bearing 아님)

## 3. 리스크

queue 메타데이터 텍스트 변경만 — 런타임/eval/CI 경로 무영향. 다른 task row 미변경 (29 단일 row + 해당 detail 만 수정함을 grep 으로 확인).

## 4. 테스트

N/A — 텍스트 상태 동기화로 behavior change 가 아니라 behavior test 부적용. branch/issue CI gate + pytest 회귀 통과로 무해성 보장.

## 5. Eval 영향

All `·` (무변경). load-bearing 경로 미변경, real100_v2 표면·eval delta 무관.

## 6. 하위 호환

N/A — 계약/스키마/CLI flag/doc-link 무변경.

## 7. 범위 외

T-2026-0076 (retrieval root-cause) 착수는 별도 task — 이 PR 은 queue 상태 동기화만 다룬다.