### PR TITLE
docs: restore GitHub Pages (engineering notes) without reviving leaderboard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy engineering notes (GitHub Pages — Jekyll)
+
+# Publishes the docs/ Jekyll site ("engineering notes") to GitHub Pages.
+# Scoped to ./docs ONLY: no Python, no eval, no reports/, no leaderboard.
+#
+# Anti-revival guard (ADR 0030 / #1414): the former leaderboard.yml was a
+# CONTENT generator (it git-pushed reports/ + docs/eval/leaderboard.md) and
+# was removed on purpose. It was NEVER the Pages publisher. Do NOT add any
+# leaderboard / eval / reports step here — this workflow only builds the
+# static docs/ site. See issue #1786.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; never cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build Jekyll site (docs/ only)
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,12 @@ description: >-
   RFP DocAgent의 baseline 유지, 평가 surface 분리, 실패 분류 등 엔지니어링 결정의 배경을 정리한 노트.
   소스: https://github.com/hskim-solv/BidMate-DocAgent
 
+# GitHub Pages project-page URL. baseurl 이 없으면 minima 의 relative_url /
+# absolute_url 필터(네비게이션, RSS, permalink:pretty 블로그 URL)가
+# `/blog/...` 같은 root-absolute 경로를 만들어 project page 에서 404 가 된다.
+url: "https://hskim-solv.github.io"
+baseurl: "/BidMate-DocAgent"
+
 theme: minima
 
 # minima 2.5+의 hook — `_includes/custom-head.html`이 <head>에 주입된다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

GitHub Pages(`hskim-solv.github.io/BidMate-DocAgent/`)가 404 — README "engineering notes" 뱃지가 죽은 링크였다. `gh api .../pages` → 404 (Pages 사이트 미설정).

**진단 정정**: 처음엔 #1414 의 `leaderboard.yml` 삭제가 Pages 발행을 끊었다고 의심했으나, `git show 7cd72fd0^:.github/workflows/leaderboard.yml` 로 확인한 결과 그 워크플로는 content **generator**(`reports/` + `docs/eval/leaderboard.md` git push)였을 뿐 Pages 발행자가 아니었다. repo 전체 ref 에 Pages 발행 워크플로(deploy-pages/gh-pages/peaceiris)가 한 번도 없었다 → Pages 는 GitHub 내장 deploy-from-branch 소스로 서빙됐고 그 소스가 현재 비활성. 발행자 복원은 leaderboard 와 독립.

`docs/` Jekyll engineering-notes 사이트를 GitHub Actions 소스로 재발행한다. leaderboard 는 #1414 / ADR 0030 대로 **영구 제외**.

Closes #1786

## 2. 영향 파일
- `.github/workflows/pages.yml` (신규) — `docs/` Jekyll 발행, `./docs` 만 빌드(Python/eval/`reports/` 미실행)
- `docs/_config.yml` — `baseurl: /BidMate-DocAgent` + `url` 추가

load-bearing path (`scripts/_governance.py` `LOAD_BEARING_PATHS`) 변경 **없음**.

## 3. 리스크
- **첫 발행은 워크플로만으론 안 됨**: 머지 후 Pages 소스를 `workflow` 로 활성화해야 한다(`gh api -X POST repos/.../pages -f build_type=workflow`). 미실행 시 사이트 계속 404.
- **baseurl 오설정 시 내부 링크 깨짐**: project-page 는 `/BidMate-DocAgent` prefix 필요. 머지 후 블로그 URL 1건 렌더 검증으로 확인.
- **leaderboard 부활 위험 = 0**: 새 워크플로는 `./docs` 만 빌드, Python/eval step 없음. 헤더에 anti-revival 가드 주석 명시.

## 4. 테스트
CI 워크플로 + Jekyll 설정 추가라 단위 테스트 부적합. 검증: `pages.yml`/`_config.yml` YAML 파싱, anti-revival grep(실행 step 에 leaderboard/python 0건), git status 2파일. **머지 후 acceptance**: `pages.yml` run green → `gh api .../pages` 200 → 사이트 + 블로그 URL 1건 HTTP 200 → 새 `reports/`/`docs/eval/leaderboard.md` 커밋 미발생.

## 5. Eval 영향
All `·` — load-bearing / eval surface 무관. 문서 호스팅 복원만. leaderboard(과거 유일 eval-governance 산출)는 의도적으로 계속 제외(ADR 0030 / #1414 유지 — 변경 아님).

## 6. 하위 호환
- 답변 계약(ADR 0003)/스키마/CLI flag 무관 → `schema_version` bump 불요.
- `_config.yml` baseurl 추가는 Jekyll 빌드에만 영향(로컬 `jekyll serve` 시 `--baseurl ""` 필요할 수 있음, GitHub Pages 빌드엔 정상).
- 죽은 engineering-notes 뱃지가 살아남(개선).

## 7. 범위 외
- `docs/blog/index.md` 누락 → `./blog/` dead link (선존재, #566 에서 제거, #811 추적)
- Pages 소스 활성화(`gh api POST`) 자체 — 머지 후 maintainer 액션
- leaderboard / public synthetic eval surface 부활 (ADR 0030 / #1414 대로 영구 제외)
