### PR TITLE
test(demo): add Playwright headless UI smoke for Streamlit demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,8 @@ harness/real.yaml
 # (--runner omc, ADR 0087) writes .omc/state/team/...; this is per-clone runtime
 # state, never committed, and may carry local session metadata.
 .omc/
+
+# Node tooling for the Playwright UI smoke (scripts/ui_smoke.mjs, issue #1790).
+# package.json + package-lock.json ARE committed (reproducible install); the
+# installed modules are not. Playwright browser binaries live in ~/.cache.
+/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 .PHONY: case-propose case-propose-metadata case-review case-promote
 
 # API / demo (FastAPI + Streamlit; local + docker variants)
-.PHONY: api api-docker demo demo-docker docker-publish
+.PHONY: api api-docker demo demo-docker docker-publish ui-smoke
 
 # Tests
 .PHONY: test test-regression
@@ -1213,6 +1213,16 @@ api-docker:
 # Requires data/index to exist (run `make index` first).
 demo:
 	$(PYTHON) -m streamlit run demo/streamlit_app.py
+
+# Headless Playwright UI smoke for the Streamlit demo (issue #1790). Boots
+# `streamlit run` on :8501 on the demo's real default index backend (chroma,
+# ADR 0081), asserts the H1 + the three headline pipeline presets + the
+# "Run query" button, and writes a full-page screenshot to
+# reports/ui_smoke/demo.png (gitignored). Requires `npm install` (playwright,
+# + `npx playwright install chromium`), chromadb (requirements.txt), and a
+# prebuilt index (`make index`). Pass PYTHON=.venv/bin/python for a venv.
+ui-smoke:
+	PYTHON=$(PYTHON) node scripts/ui_smoke.mjs
 
 # Run the demo container with the Streamlit UI on :8501 (and FastAPI on
 # :8000 alongside). See docs/operations/deployment.md for Fly.io / HF Spaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "bidmate-docagent",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bidmate-docagent",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bidmate-docagent",
+  "version": "1.0.0",
+  "description": "RFP 문서 이해를 위한 Agentic RAG 시스템 — Node tooling for the Playwright UI smoke (scripts/ui_smoke.mjs).",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "scripts": {
+    "ui-smoke": "node scripts/ui_smoke.mjs",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hskim-solv/BidMate-DocAgent.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/hskim-solv/BidMate-DocAgent/issues"
+  },
+  "homepage": "https://github.com/hskim-solv/BidMate-DocAgent#readme",
+  "devDependencies": {
+    "playwright": "^1.60.0"
+  }
+}

--- a/scripts/ui_smoke.mjs
+++ b/scripts/ui_smoke.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Playwright headless UI smoke for the Streamlit demo (issue #1790).
+ *
+ * Boots `streamlit run demo/streamlit_app.py` on :8501, waits for the
+ * Streamlit health endpoint, then asserts the reviewer-facing surface:
+ *   - page <title> contains "BidMate-DocAgent"
+ *   - the H1 heading renders
+ *   - the three headline pipeline presets are listed (naive_baseline,
+ *     agentic_full, agentic_full_llm) — see rag_pipeline_presets.pipeline_cli_choices
+ *   - the "Run query" primary button is present (proves the main pane rendered,
+ *     which only happens if the sidebar's get_index() succeeded first)
+ * Saves a full-page screenshot to reports/ui_smoke/demo.png.
+ *
+ * Exit 0 = all assertions passed; 1 = streamlit failed to boot or an
+ * assertion failed (the screenshot + the last streamlit log are still emitted).
+ *
+ * Requires: `npm install` (playwright) + `npx playwright install chromium`,
+ * the chroma backend deps (chromadb, in requirements.txt), and a prebuilt
+ * index at data/index/ (run `make index` first).
+ * Run via `make ui-smoke`.
+ */
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { mkdirSync } from 'node:fs';
+
+const PORT = Number(process.env.UI_SMOKE_PORT || 8501);
+const BASE = `http://localhost:${PORT}`;
+const PY = process.env.PYTHON || 'python3';
+const ART_DIR = 'reports/ui_smoke';
+const SHOT = `${ART_DIR}/demo.png`;
+const BOOT_TIMEOUT_MS = 180_000;
+
+mkdirSync(ART_DIR, { recursive: true });
+
+let slLog = '';
+const streamlit = spawn(
+  PY,
+  ['-m', 'streamlit', 'run', 'demo/streamlit_app.py',
+    '--server.headless', 'true',
+    '--server.port', String(PORT),
+    '--server.fileWatcherType', 'none',
+    '--browser.gatherUsageStats', 'false'],
+  {
+    // Inherit env with NO BIDMATE_INDEX_BACKEND override, so the demo boots its
+    // real default index backend — chroma (ADR 0081). The smoke exercises the
+    // actual deployed path; chromadb is required (it's in requirements.txt). Set
+    // BIDMATE_INDEX_BACKEND in the environment to smoke a different backend.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  },
+);
+streamlit.stdout.on('data', (d) => { slLog += d.toString(); });
+streamlit.stderr.on('data', (d) => { slLog += d.toString(); });
+
+function shutdown(code) {
+  // detached:true → kill the whole process group (streamlit spawns children).
+  try { process.kill(-streamlit.pid, 'SIGKILL'); } catch { /* already gone */ }
+  try { streamlit.kill('SIGKILL'); } catch { /* already gone */ }
+  process.exit(code);
+}
+process.on('SIGINT', () => shutdown(130));
+process.on('SIGTERM', () => shutdown(143));
+
+async function waitForHealth(deadlineMs) {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    if (streamlit.exitCode !== null) return false; // process died early
+    try {
+      const r = await fetch(`${BASE}/_stcore/health`);
+      if (r.ok) return true;
+    } catch { /* not up yet */ }
+    await sleep(1000);
+  }
+  return false;
+}
+
+const checks = [];
+async function check(label, locator) {
+  try {
+    await locator.first().waitFor({ state: 'visible', timeout: 20_000 });
+    checks.push([label, true]);
+  } catch {
+    checks.push([label, false]);
+  }
+}
+
+(async () => {
+  console.log(`[ui-smoke] booting streamlit on ${BASE} …`);
+  const ready = await waitForHealth(BOOT_TIMEOUT_MS);
+  if (!ready) {
+    console.error('[ui-smoke] streamlit did not become healthy in time.');
+    console.error('--- last streamlit log ---');
+    console.error(slLog.slice(-2000));
+    shutdown(1);
+  }
+  console.log('[ui-smoke] streamlit healthy — launching chromium.');
+
+  const browser = await chromium.launch();
+  let exitCode = 0;
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+    await page.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+    // Streamlit renders client-side; wait for the H1 before asserting.
+    await page.getByRole('heading', { name: /BidMate-DocAgent/ })
+      .first().waitFor({ state: 'visible', timeout: 60_000 });
+
+    await check('h1 heading', page.getByRole('heading', { name: /BidMate-DocAgent/ }));
+    for (const preset of ['naive_baseline', 'agentic_full', 'agentic_full_llm']) {
+      await check(`preset radio: ${preset}`, page.getByText(preset, { exact: true }));
+    }
+    await check('Run query button', page.getByRole('button', { name: /Run query/ }));
+
+    const title = await page.title();
+    checks.push(['page title ~ BidMate-DocAgent', /BidMate-DocAgent/.test(title)]);
+
+    await page.screenshot({ path: SHOT, fullPage: true });
+  } catch (err) {
+    console.error(`[ui-smoke] unexpected error: ${err?.message || err}`);
+    exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+
+  for (const [label, ok] of checks) console.log(`${ok ? '✅' : '❌'} ${label}`);
+  console.log(`[ui-smoke] screenshot: ${SHOT}`);
+  if (checks.filter(([, ok]) => !ok).length > 0) exitCode = 1;
+  if (exitCode === 0) {
+    console.log(`[ui-smoke] PASSED — ${checks.length}/${checks.length} assertions.`);
+  } else {
+    console.error('[ui-smoke] FAILED.');
+  }
+  shutdown(exitCode);
+})();


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1790

"눈으로 보는 UI 시연"(Streamlit 데모)이 실제로 렌더되고 핵심 컨트롤이 보이는지 자동 검증할 수단이 없었다. Playwright(Node headless chromium)로 로컬 `streamlit run` 을 띄워 데모의 reviewer-facing surface(타이틀·파이프라인 preset·Run query 버튼)를 단언하고 full-page 스크린샷을 남기는 UI 스모크를 추가한다. HF Spaces 원격은 이미 `curl /health` 200 으로 커버되므로(cold-start 불안정), 재현성·CI 친화 위해 로컬 경로를 택했다.

## 2. 영향 파일

- `scripts/ui_smoke.mjs` (신규) — Playwright UI 스모크 러너
- `Makefile` — `ui-smoke` 타겟 + `.PHONY` 등록
- `package.json`, `package-lock.json` (신규) — playwright devDependency (재현 가능 설치)
- `.gitignore` — `/node_modules/` 무시

load-bearing 파일 변경 없음.

## 3. 리스크

- **Streamlit 클라이언트 렌더 타이밍** — 가장 가능성 높은 깨짐(요소 단언이 렌더 전 실행). `/_stcore/health` 폴링 + H1 `waitFor` + 각 단언 20s `waitFor(visible)` 로 완화.
- **포트 8501 충돌** — 러너가 독립 `streamlit` 프로세스를 spawn 후 process-group SIGKILL teardown. 동시 실행 시 충돌 가능(MVP 범위 밖, `UI_SMOKE_PORT` override 제공).
- **백엔드 의존** — 스모크는 데모의 실제 기본 백엔드인 **chroma**(ADR 0081)로 띄운다 → `chromadb` 필요(requirements.txt). 진단 중 chromadb 미설치 환경에서 `get_index()` RuntimeError → "Run query" 버튼 미렌더(5/6)를 실제로 재현/확인하고, memory 우회 대신 chromadb 설치로 해결(실제 배포 경로 충실).

## 4. 테스트

이 PR 자체가 테스트(UI 스모크) 추가다. 로컬 `make ui-smoke PYTHON=.venv/bin/python` → **6/6 단언 통과**(H1, preset 3종, Run query 버튼, page title), **chroma 백엔드**. 데모 앱(`demo/streamlit_app.py`) 코드는 변경하지 않음 — 동작 변경 없는 순수 검증 추가.

## 5. Eval 영향

동작 변화 없음 — load-bearing path 무변경, RAG/eval 코드 미변경. UI 렌더 스모크는 retrieval/answer/verifier 경로를 타지 않으며 데모 기본 인덱스를 로드해 페이지만 띄운다. real-eval 불필요. CI eval delta: All `·`.

## 6. 하위 호환

신규 타겟·파일만 추가. 기존 계약/스키마/CLI flag/answer-contract(ADR 0003) 무변경. `schema_version` bump 불필요.

## 7. 범위 외

의도적으로 보류(별도 follow-up):
- **CI 통합** — 로컬 동작 확인 후 별도 issue(이 PR 은 로컬 MVP). node+playwright+chromadb 를 별도 non-blocking workflow 로, pr-eval.yml(경량 hashing)과 분리.
- **HF Spaces 원격 Playwright** — curl 200 으로 충분.
- **픽셀 visual regression** — 요소 단언만(스크린샷은 산출물, gitignored).
- **다른 백엔드 스모크** — `BIDMATE_INDEX_BACKEND` override 로 memory/qdrant 도 가능하나 기본은 데모 실제 경로(chroma).
