### PR TITLE
fix(hooks): SessionStart 정리에 origin/main fetch + repo guard 보강

### DIFF
--- a/scripts/claude-hooks/sessionstart-worktree-hygiene.sh
+++ b/scripts/claude-hooks/sessionstart-worktree-hygiene.sh
@@ -36,9 +36,21 @@ set -u
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT" || exit 0
 
+# Only act inside the BidMate repo: the hygiene script + make target live here.
+# If this hook is ever inherited by another context, no-op rather than running
+# `make` somewhere it does not belong (review M-2, issue #1793).
+[[ -f "$REPO_ROOT/.githooks/_pre-push-worktree-hygiene.sh" ]] || exit 0
+
 # Lower the patch-id walk budget for session start (latency cap); honour an
 # explicit override if the user set one.
 export BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET="${BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET:-5}"
+
+# Refresh origin/main so the hygiene script's ancestor / patch-equiv merge
+# signals see branches merged since the last local fetch (e.g. from another
+# machine or a just-merged PR), improving cleanup hit-rate. --quiet + || true
+# keep session start fast and never fail on a missing remote / network / lock;
+# git's own connection timeout bounds the wait (review M-1, issue #1793).
+git fetch origin main --quiet || true
 
 # Soft: capture output, never let a cleanup failure block the session start.
 output=$(make worktree-cleanup 2>&1 || true)

--- a/tests/test_hook_sessionstart_worktree_hygiene.py
+++ b/tests/test_hook_sessionstart_worktree_hygiene.py
@@ -154,6 +154,14 @@ class TestSessionStartWorktreeHygiene(unittest.TestCase):
         self.assertIn("current worktree", skill.lower())
         self.assertIn("0096", skill)
 
+    def test_sessionstart_hook_fetches_and_guards_repo(self) -> None:
+        # Review follow-up (#1793): two 1-line hardenings of the same hook.
+        body = HOOK.read_text(encoding="utf-8")
+        # M-1: refresh origin/main so merge signals see just-merged branches.
+        self.assertIn("git fetch origin main", body)
+        # M-2: no-op outside the BidMate repo — never run `make` elsewhere.
+        self.assertIn('.githooks/_pre-push-worktree-hygiene.sh"', body)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## 무엇을 / 왜

PR #1787 (SessionStart 머지 worktree 자동정리, ADR 0096) 사후 코드리뷰 후속. 리뷰에서 나온 Medium 2건을 반영한다. 둘 다 `scripts/claude-hooks/sessionstart-worktree-hygiene.sh` 1줄 변경이고 같은 파일이라 묶었다.

## 변경

- **M-1 (기능 보강)** — cleanup 전 `git fetch origin main --quiet || true`. SessionStart 가 fetch 를 안 해 stale `origin/main` 기준으로 머지판정하던 문제. 다른 머신/방금 머지된 PR 의 브랜치를 못 잡아 생기던 정리 누락(적중률)을 개선. `--quiet` + `|| true` + git 자체 connection timeout 으로 세션시작 지연/실패를 흡수 — 안전엔 무영향(누락은 원래 안전 방향이었음).
- **M-2 (방어)** — `[[ -f "$REPO_ROOT/.githooks/_pre-push-worktree-hygiene.sh" ]] || exit 0` guard. BidMate repo 외 컨텍스트에서 `make` 오발동 방지.

## 테스트

- `tests/test_hook_sessionstart_worktree_hygiene.py` + `tests/test_hook_pre_push_worktree_hygiene.py` → **24 passed** (full chain: hook → make → hygiene, 실제 git worktree). fetch/guard 정적 회귀 테스트 추가.
- `ruff check` clean.
- 기존 3가드(self-skip / clean / 머지확정) + soft 계약(항상 exit 0) **무손상**.

## 범위

load-bearing 아님 → ADR 불요. remote delete 범위 밖(로컬만) 유지. 리뷰의 나머지 findings(M-3 카운터 / L-* 문서·매직넘버)는 cosmetic 이라 스킵, L-3(dry-run)은 자동삭제 default 설계와 모순이라 의도적 제외.

closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)