### PR TITLE
ci(demo): non-blocking Playwright UI smoke workflow

### DIFF
--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -1,0 +1,82 @@
+name: Demo UI smoke (Playwright)
+
+# Non-blocking headless render smoke for the Streamlit demo (issues #1790, #1798).
+# Boots `make ui-smoke` (streamlit on :8501, real chroma backend) and asserts the
+# reviewer-facing surface via headless chromium. NOT a required check — kept off
+# branch protection during the flaky-observation window, and separate from
+# pr-eval.yml so the chromadb/chromium weight stays out of the lightweight
+# hashing eval path. Promote to a required check via a follow-up once it proves
+# stable. The smoke itself lives in scripts/ui_smoke.mjs (`make ui-smoke`).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'demo/**'
+      - 'scripts/ui_smoke.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ui-smoke.yml'
+  pull_request:
+    paths:
+      - 'demo/**'
+      - 'scripts/ui_smoke.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ui-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A new push supersedes an in-flight run on the same PR/ref.
+concurrency:
+  group: ui-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ui-smoke:
+    name: Streamlit demo render smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python deps (streamlit + chromadb + demo runtime)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install Playwright + chromium
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Build demo index (hashing — keeps CI light, no model download)
+        run: >-
+          python scripts/build_index.py
+          --input_dir eval/fixtures/smoke_rfp/raw
+          --output_dir data/index
+          --embedding_backend hashing
+
+      - name: Run UI smoke (real chroma backend)
+        run: make ui-smoke
+
+      - name: Upload screenshot (always — diagnoses failures too)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: demo-ui-screenshot
+          path: reports/ui_smoke/demo.png
+          if-no-files-found: warn


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1798

#1790 에서 추가한 `make ui-smoke`(Playwright headless Streamlit 데모 렌더 스모크)가 로컬 수동 실행만 가능했다. 데모는 포트폴리오 hero 표면이라 렌더 회귀를 머지 전에 잡을 가치가 높다. `demo/**` · `scripts/ui_smoke.mjs` 를 건드리는 PR/push 에서 `make ui-smoke` 를 자동 실행하는 별도 워크플로를 추가한다. 이 PR 자체가 `ui-smoke.yml` 을 건드리므로 PR CI 에서 self-test 된다.

## 2. 영향 파일

- `.github/workflows/ui-smoke.yml` (신규) — non-blocking 데모 UI 스모크 워크플로

load-bearing 파일 변경 없음.

## 3. 리스크

- **헤드리스 브라우저 flaky** — 가장 큰 우려. **non-blocking**(required status check 미등록)으로 완화: fail 해도 머지 차단 안 함, 관찰 기간 후 안정되면 required 승격(별도 issue).
- **CI 설치 무게**(chromadb + chromium ~150MB) — `pr-eval.yml`(경량 hashing)과 **별도 job** 분리 + `paths` 필터(데모 표면 변경 시에만) + pip/npm 캐시로 격리.
- **인덱스 빌드** — `--embedding_backend hashing` 명시(모델 다운로드 회피). 데모는 그 인덱스를 실제 chroma 백엔드로 로드.

## 4. 테스트

이 PR 이 `ui-smoke.yml` 을 추가하므로 **PR CI 에서 워크플로가 self-trigger** 되어 자체 검증된다(green 확인 후 머지). 로컬 `make ui-smoke` → 6/6(#1790 에서 확인).

## 5. Eval 영향

동작 변화 없음 — load-bearing path / RAG / eval 코드 미변경. CI-only 추가. eval delta: All `·`.

## 6. 하위 호환

신규 워크플로만 추가. 기존 워크플로/계약/스키마 무변경.

## 7. 범위 외

- **required 승격** — 안정 관찰 후 별도 issue.
- **HF Spaces 원격 Playwright / 픽셀 visual regression** — #1790 에서 보류.
- **pages.yml 액션 Node 20→24 bump** — dependabot github-actions(weekly) 자동 처리 예정(별개).
