### PR TITLE
feat(agent-loop): global BoundedSemaphore(M) spawn throttle (ADR 0094 brick 4/7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,17 @@ ACTIVE_CODEX_TIMEOUT_SECONDS ?= 0
 # bound when desired.
 ACTIVE_CLAUDE_WRITE_TIMEOUT_SECONDS ?= $(ACTIVE_CODEX_TIMEOUT_SECONDS)
 export ACTIVE_CLAUDE_WRITE_TIMEOUT_SECONDS
+# ADR 0094 PR-C: M = global ceiling on concurrent agent-loop CLI subprocess spawns.
+# Default 8; fail-closed M<=0 -> 1. Ships DARK + byte-identical at X=1/M=8 (the
+# semaphore is uncontended when the loop spawns one child at a time). The runtime
+# read path is os.getenv("BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY"); ACTIVE_GLOBAL_CONCURRENCY
+# is the operator front-door knob, bridged to that env var below so
+# `make ... ACTIVE_GLOBAL_CONCURRENCY=N` actually reaches the runtime. A direct
+# BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY already in the env still wins (via ?=).
+ACTIVE_GLOBAL_CONCURRENCY ?= 8
+export ACTIVE_GLOBAL_CONCURRENCY
+BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY ?= $(ACTIVE_GLOBAL_CONCURRENCY)
+export BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY
 # ADR 0085: 0 == unlimited. The per-session command cap is dropped on the operator front
 # door so the autonomous loop is bounded by timeout + attempt/queue + safety guards, not an
 # arbitrary command count. Set a positive value to re-impose a cap.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1091,6 +1091,79 @@ class LedgerState:
             )
 
 
+DEFAULT_GLOBAL_CONCURRENCY = 8
+GLOBAL_CONCURRENCY_ENV = "BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY"
+
+
+def _resolve_global_concurrency(raw: str | None = None) -> int:
+    """Resolve the global CLI-spawn ceiling M (ADR 0094 PR-C). env
+    BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY overrides DEFAULT (8). Unset / blank /
+    non-int -> DEFAULT (8). fail-closed: a parsed value <=0 clamps to 1 (the
+    ceiling must never be 0/unbounded by misconfig)."""
+    source = os.getenv(GLOBAL_CONCURRENCY_ENV) if raw is None else raw
+    if source is None or not str(source).strip():
+        return DEFAULT_GLOBAL_CONCURRENCY
+    try:
+        value = int(str(source).strip())
+    except ValueError:
+        return DEFAULT_GLOBAL_CONCURRENCY
+    return value if value >= 1 else 1  # fail-closed: M<=0 -> 1
+
+
+class GlobalConcurrencyLimiter:
+    """Single global ceiling on concurrent agent-loop CLI subprocess spawns
+    (ADR 0094 PR-C). Every CLI agent spawn (claude write / codex patch /
+    read-review) acquires this ONE process-wide BoundedSemaphore(M) before
+    spawning and releases after, so X*Y*Z fan-out cannot multiply into hundreds
+    of children. M = BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY (Makefile
+    ACTIVE_GLOBAL_CONCURRENCY), default 8, fail-closed M<=0 -> 1.
+
+    Lock-ordering (mirrors LedgerState ~1012 / LeaseManager): this semaphore is
+    acquired AFTER any LeaseManager flock is released and while the LedgerState
+    lock is NOT held — never hold either across acquire()/the spawn. Order:
+    flock -> claim -> RELEASE -> acquire semaphore -> spawn -> release semaphore
+    -> ledger lock. BoundedSemaphore (not Semaphore) so an over-release raises
+    ValueError instead of silently raising the ceiling. At X=1/M=8 the loop
+    spawns one child at a time so the semaphore is uncontended -> acquire is
+    instant and every on-disk artifact + task selection is byte-identical
+    (ADR 0001 gate). Ships DARK until PR-D/E enable X>1. In-process (threading)
+    only — cross-worktree/process coordination is the flock's job, not this."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._sem = threading.BoundedSemaphore(limit)
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @contextlib.contextmanager
+    def slot(self) -> "Iterator[None]":
+        self._sem.acquire()
+        try:
+            yield
+        finally:
+            self._sem.release()
+
+
+_GLOBAL_CONCURRENCY_LIMITER: "GlobalConcurrencyLimiter | None" = None
+_GLOBAL_CONCURRENCY_LOCK = threading.Lock()
+
+
+def global_concurrency_limiter() -> GlobalConcurrencyLimiter:
+    """Lazily build + memoize the process-wide limiter (double-checked under a
+    lock so concurrent first-touch threads share ONE semaphore)."""
+    global _GLOBAL_CONCURRENCY_LIMITER
+    limiter = _GLOBAL_CONCURRENCY_LIMITER
+    if limiter is None:
+        with _GLOBAL_CONCURRENCY_LOCK:
+            limiter = _GLOBAL_CONCURRENCY_LIMITER
+            if limiter is None:
+                limiter = GlobalConcurrencyLimiter(_resolve_global_concurrency())
+                _GLOBAL_CONCURRENCY_LIMITER = limiter
+    return limiter
+
+
 def _normalize_field(label: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", label.lower())
 
@@ -14626,165 +14699,235 @@ def write_active_codex_runner(
         factory = popen_factory if popen_factory is not None else subprocess.Popen
 
         def spawn_and_wait(batch: Sequence[dict[str, object]]) -> None:
+            # ADR 0094 PR-C: each codex-read child holds the ONE process-wide CLI-spawn
+            # slot for its full lifetime (Phase-1 spawn through Phase-2 wait). The slot
+            # is acquired manually at spawn (acquire and release live in different loops,
+            # so the contextmanager does not fit) and stashed as a one-shot release in the
+            # batch_spawned tuple so EVERY Phase-2 exit path (normal / timeout /
+            # blocker-break / blocker-cleanup) releases EXACTLY once.
+            _limiter = global_concurrency_limiter()
+
+            def _one_shot_release() -> "Callable[[], None]":
+                released = False
+
+                def _release() -> None:
+                    nonlocal released
+                    if not released:
+                        released = True
+                        _limiter._sem.release()
+
+                return _release
+
             batch_spawned: list[
-                tuple[dict[str, object], object, "threading.Thread | None", object, float]
+                tuple[dict[str, object], object, "threading.Thread | None", object, float, "Callable[[], None]"]
             ] = []
-            for item in batch:
-                session_id = str(item["session_id"])
-                role = str(item["role"])
-                session_agent = str(item.get("agent") or "codex")
-                run_dir = runs_path / session_id
-                assignment_path = assignments_path / f"{session_id}.md"
-                prompt_path = run_dir / "prompt.md"
-                stdout_path = run_dir / "stdout.jsonl"
-                stderr_path = run_dir / "stderr.log"
-                last_message_path = run_dir / "last_message.md"
-                run_dir.mkdir(parents=True, exist_ok=True)
-                if session_agent == "claude":
-                    item["status"] = "running"
-                    spawn_start_at = time.monotonic()
-                    _emit_progress(f"[spawn] session={session_id} role={role} agent=claude")
-                    try:
-                        result = write_agent_turn(
-                            session_id=session_id,
-                            role=role,
-                            agent="claude",
-                            task_id=str(item.get("task_id") or "") or None,
-                            base=base,
-                            execute=True,
-                            registry=registry,
-                            events=DEFAULT_ACTIVE_EVENTS,
-                            agent_mix_path=DEFAULT_ACTIVE_AGENT_MIX,
-                            claude_runner=claude_runner,
-                            repo_root=repo_root,
-                            # ADR 0085 Finding 2: thread the runner's per-call budget into the
-                            # Claude read lane so a hung review session is bounded by the
-                            # wall-clock budget when one is set (0 == unlimited otherwise).
-                            timeout_seconds=timeout_seconds,
-                            # ADR 0092 (PR2, AC9): apply the opt-in lane-autotune effort for this
-                            # (role, claude) lane; None == today's role-table effort.
-                            effort_override=_lane_effort_for(role, "claude"),
+            # ADR 0094 PR-C: a child acquired in Phase 1 but not yet stashed in
+            # batch_spawned (e.g. Thread.start() raises after Popen succeeds, or
+            # stdin I/O raises OSError before the append) is invisible to the
+            # batch_spawned drain; track its permit AND its proc/stderr handle here
+            # so the finally both reclaims the straggler permit and stops+closes the
+            # orphan child (else the just-spawned proc keeps running untracked).
+            # One-shot / None-guarded, so all three are inert once the child reaches
+            # batch_spawned.
+            pending_release: "Callable[[], None] | None" = None
+            pending_proc: object = None
+            pending_stderr: object = None
+            try:
+                for item in batch:
+                    session_id = str(item["session_id"])
+                    role = str(item["role"])
+                    session_agent = str(item.get("agent") or "codex")
+                    run_dir = runs_path / session_id
+                    assignment_path = assignments_path / f"{session_id}.md"
+                    prompt_path = run_dir / "prompt.md"
+                    stdout_path = run_dir / "stdout.jsonl"
+                    stderr_path = run_dir / "stderr.log"
+                    last_message_path = run_dir / "last_message.md"
+                    run_dir.mkdir(parents=True, exist_ok=True)
+                    if session_agent == "claude":
+                        item["status"] = "running"
+                        _emit_progress(f"[spawn] session={session_id} role={role} agent=claude")
+                        # ADR 0094 PR-C: hold the ONE process-wide CLI-spawn slot across the
+                        # claude read spawn->wait. spawn_start_at is set AFTER acquire so any
+                        # semaphore wait never leaks into elapsed_s. Uncontended at X=1/M=8.
+                        with global_concurrency_limiter().slot():
+                            spawn_start_at = time.monotonic()
+                            try:
+                                result = write_agent_turn(
+                                    session_id=session_id,
+                                    role=role,
+                                    agent="claude",
+                                    task_id=str(item.get("task_id") or "") or None,
+                                    base=base,
+                                    execute=True,
+                                    registry=registry,
+                                    events=DEFAULT_ACTIVE_EVENTS,
+                                    agent_mix_path=DEFAULT_ACTIVE_AGENT_MIX,
+                                    claude_runner=claude_runner,
+                                    repo_root=repo_root,
+                                    # ADR 0085 Finding 2: thread the runner's per-call budget into the
+                                    # Claude read lane so a hung review session is bounded by the
+                                    # wall-clock budget when one is set (0 == unlimited otherwise).
+                                    timeout_seconds=timeout_seconds,
+                                    # ADR 0092 (PR2, AC9): apply the opt-in lane-autotune effort for this
+                                    # (role, claude) lane; None == today's role-table effort.
+                                    effort_override=_lane_effort_for(role, "claude"),
+                                )
+                            except Exception as exc:  # fail closed; the loop can route repair/retry.
+                                item["status"] = "failed"
+                                item["returncode"] = 1
+                                stderr_path.write_text(_sanitize_dynamic_text(str(exc)) + "\n", encoding="utf-8")
+                                blockers.append(f"claude session {session_id} failed: {exc}")
+                                _emit_progress(f"[done] session={session_id} agent=claude failed")
+                                continue
+                        item["returncode"] = 0 if result.decision == "executed" else 1
+                        item["artifact"] = _repo_path(result.artifact_path, repo_root) if result.artifact_path else ""
+                        item["verdict"] = result.verdict
+                        if result.artifact_path and result.artifact_path.exists():
+                            stdout_path.write_text(result.artifact_path.read_text(encoding="utf-8"), encoding="utf-8")
+                        status_for_gate = "approved" if result.verdict in {"approved", "clear"} else result.verdict or "blocked"
+                        last_message_path.write_text(
+                            _sanitize_dynamic_text(
+                                "\n".join(
+                                    [
+                                        f"Session id: `{session_id}`",
+                                        f"Role: `{role}`",
+                                        "Agent: `claude`",
+                                        f"Artifact: `{item.get('artifact') or ''}`",
+                                        f"Gate verdict: {status_for_gate}",
+                                        "",
+                                    ]
+                                )
+                            ),
+                            encoding="utf-8",
                         )
-                    except Exception as exc:  # fail closed; the loop can route repair/retry.
-                        item["status"] = "failed"
-                        item["returncode"] = 1
-                        stderr_path.write_text(_sanitize_dynamic_text(str(exc)) + "\n", encoding="utf-8")
-                        blockers.append(f"claude session {session_id} failed: {exc}")
-                        _emit_progress(f"[done] session={session_id} agent=claude failed")
+                        elapsed = time.monotonic() - spawn_start_at
+                        # Persist per-lane wall-clock so the opt-in lane-autotune controller
+                        # (ADR 0092) can sense relative slowness within an agent. Display-only
+                        # before; now flows item -> planned -> ActiveCodexRunnerResult.sessions
+                        # alongside role/agent/status. claude elapsed includes artifact/heartbeat
+                        # overhead, so comparisons stay within-agent (never claude vs codex).
+                        # Gated so the runner state file stays byte-identical when autotune is OFF.
+                        if lane_autotune_on:
+                            item["elapsed_s"] = round(elapsed, 3)
+                        if result.decision == "executed":
+                            item["status"] = "completed"
+                            _emit_progress(f"[done] session={session_id} agent=claude verdict={result.verdict} elapsed={elapsed:.1f}s")
+                        else:
+                            item["status"] = "failed"
+                            blockers.extend(f"claude session {session_id}: {blocker}" for blocker in result.blockers)
+                            if not result.blockers:
+                                blockers.append(f"claude session {session_id} decision was {result.decision}")
+                            _emit_progress(f"[done] session={session_id} agent=claude decision={result.decision} elapsed={elapsed:.1f}s")
                         continue
-                    item["returncode"] = 0 if result.decision == "executed" else 1
-                    item["artifact"] = _repo_path(result.artifact_path, repo_root) if result.artifact_path else ""
-                    item["verdict"] = result.verdict
-                    if result.artifact_path and result.artifact_path.exists():
-                        stdout_path.write_text(result.artifact_path.read_text(encoding="utf-8"), encoding="utf-8")
-                    status_for_gate = "approved" if result.verdict in {"approved", "clear"} else result.verdict or "blocked"
-                    last_message_path.write_text(
-                        _sanitize_dynamic_text(
-                            "\n".join(
-                                [
-                                    f"Session id: `{session_id}`",
-                                    f"Role: `{role}`",
-                                    "Agent: `claude`",
-                                    f"Artifact: `{item.get('artifact') or ''}`",
-                                    f"Gate verdict: {status_for_gate}",
-                                    "",
-                                ]
-                            )
-                        ),
-                        encoding="utf-8",
+                    prompt = _render_active_codex_prompt(
+                        session_id=session_id,
+                        role=role,
+                        assignment_path=assignment_path,
+                        repo_root=repo_root,
                     )
-                    elapsed = time.monotonic() - spawn_start_at
-                    # Persist per-lane wall-clock so the opt-in lane-autotune controller
-                    # (ADR 0092) can sense relative slowness within an agent. Display-only
-                    # before; now flows item -> planned -> ActiveCodexRunnerResult.sessions
-                    # alongside role/agent/status. claude elapsed includes artifact/heartbeat
-                    # overhead, so comparisons stay within-agent (never claude vs codex).
-                    # Gated so the runner state file stays byte-identical when autotune is OFF.
-                    if lane_autotune_on:
-                        item["elapsed_s"] = round(elapsed, 3)
-                    if result.decision == "executed":
-                        item["status"] = "completed"
-                        _emit_progress(f"[done] session={session_id} agent=claude verdict={result.verdict} elapsed={elapsed:.1f}s")
-                    else:
-                        item["status"] = "failed"
-                        blockers.extend(f"claude session {session_id}: {blocker}" for blocker in result.blockers)
-                        if not result.blockers:
-                            blockers.append(f"claude session {session_id} decision was {result.decision}")
-                        _emit_progress(f"[done] session={session_id} agent=claude decision={result.decision} elapsed={elapsed:.1f}s")
-                    continue
-                prompt = _render_active_codex_prompt(
-                    session_id=session_id,
-                    role=role,
-                    assignment_path=assignment_path,
-                    repo_root=repo_root,
-                )
-                prompt_path.write_text(prompt, encoding="utf-8")
-                command = _active_codex_exec_command(
-                    codex_executable=str(resolved_executable or codex_executable),
-                    model=str(item.get("model") or model or _CODEX_DEFAULT_PROFILE[0]),
-                    sandbox=sandbox,
-                    last_message_path=last_message_path,
-                    repo_root=repo_root,
-                    # ADR 0092 (PR2, AC10): inject the opt-in lane-autotune effort for this
-                    # (role, codex) lane as `-c model_reasoning_effort`; None == byte-identical.
-                    effort=_lane_effort_for(role, session_agent),
-                )
-                stderr_file = None
-                try:
-                    stderr_file = stderr_path.open("w", encoding="utf-8")
-                    proc = _popen_codex_process(
-                        factory,
-                        command,
-                        cwd=repo_root,
-                        stdin=subprocess.PIPE,
-                        stdout=subprocess.PIPE,
-                        stderr=stderr_file,
-                        text=True,
-                        env=strip_ship_secret_env(dict(os.environ)),
+                    prompt_path.write_text(prompt, encoding="utf-8")
+                    command = _active_codex_exec_command(
+                        codex_executable=str(resolved_executable or codex_executable),
+                        model=str(item.get("model") or model or _CODEX_DEFAULT_PROFILE[0]),
+                        sandbox=sandbox,
+                        last_message_path=last_message_path,
+                        repo_root=repo_root,
+                        # ADR 0092 (PR2, AC10): inject the opt-in lane-autotune effort for this
+                        # (role, codex) lane as `-c model_reasoning_effort`; None == byte-identical.
+                        effort=_lane_effort_for(role, session_agent),
                     )
-                    stdin = getattr(proc, "stdin", None)
-                    if stdin is not None:
-                        stdin.write(prompt)
-                        stdin.close()
-                except OSError as exc:
-                    if stderr_file is not None:
-                        try:
-                            stderr_file.close()
-                        except Exception:  # pragma: no cover - close failures non-fatal
-                            pass
-                    item["status"] = "spawn-failed"
-                    blockers.append(f"failed to spawn session {session_id}: {exc}")
-                    return
-                item["status"] = "running"
-                item["pid"] = getattr(proc, "pid", None)
-                reader_thread = _spawn_codex_reader_thread(
-                    proc,
-                    session_id,
-                    stdout_path,
-                    max_command_executions=max_commands_per_session,
-                    item=item,
-                )
-                spawn_start_at = time.monotonic()
-                _emit_progress(
-                    f"[spawn] session={session_id} role={role} pid={item['pid']}"
-                )
-                batch_spawned.append((item, proc, reader_thread, stderr_file, spawn_start_at))
-                spawned.append((item, proc))
-            for item, proc, reader_thread, stderr_file, spawn_start_at in batch_spawned:
-                if blockers:
-                    _stop_codex_process(proc)
-                    break
-                wait = getattr(proc, "wait", None)
-                try:
-                    if callable(wait):
-                        rc = wait(timeout=timeout_seconds or None)
-                    else:
-                        rc = getattr(proc, "returncode", 0)
-                except subprocess.TimeoutExpired:
-                    item["status"] = "timeout"
-                    item["returncode"] = None
-                    blockers.append(f"session {item['session_id']} timed out after {timeout_seconds} seconds")
-                    _stop_codex_process(proc)
+                    stderr_file = None
+                    # ADR 0094 PR-C: acquire the process-wide CLI-spawn slot for THIS child
+                    # before the spawn; it is held until a Phase-2 path releases it. The slot
+                    # is parked in pending_release the instant it is acquired so the finally
+                    # reclaims it even if an exception fires before batch_spawned.append (e.g.
+                    # _spawn_codex_reader_thread's Thread.start() raises) — the only window
+                    # the batch_spawned drain cannot see.
+                    release = _one_shot_release()
+                    _limiter._sem.acquire()
+                    pending_release = release
+                    pending_proc = None
+                    pending_stderr = None
+                    try:
+                        stderr_file = stderr_path.open("w", encoding="utf-8")
+                        pending_stderr = stderr_file
+                        proc = _popen_codex_process(
+                            factory,
+                            command,
+                            cwd=repo_root,
+                            stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            stderr=stderr_file,
+                            text=True,
+                            env=strip_ship_secret_env(dict(os.environ)),
+                        )
+                        pending_proc = proc
+                        stdin = getattr(proc, "stdin", None)
+                        if stdin is not None:
+                            stdin.write(prompt)
+                            stdin.close()
+                    except OSError as exc:
+                        if stderr_file is not None:
+                            try:
+                                stderr_file.close()
+                            except Exception:  # pragma: no cover - close failures non-fatal
+                                pass
+                        pending_stderr = None  # closed above; finally stops pending_proc
+                        item["status"] = "spawn-failed"
+                        blockers.append(f"failed to spawn session {session_id}: {exc}")
+                        # Hard-abort: the finally below reaps every earlier child
+                        # (stop/join/close on still-running ones) and releases all
+                        # their slots, plus this child's not-yet-registered slot via
+                        # pending_release — so a spawn OSError can neither leave prior
+                        # children running nor permanently lower the process ceiling.
+                        return
+                    item["status"] = "running"
+                    item["pid"] = getattr(proc, "pid", None)
+                    reader_thread = _spawn_codex_reader_thread(
+                        proc,
+                        session_id,
+                        stdout_path,
+                        max_command_executions=max_commands_per_session,
+                        item=item,
+                    )
+                    spawn_start_at = time.monotonic()
+                    _emit_progress(
+                        f"[spawn] session={session_id} role={role} pid={item['pid']}"
+                    )
+                    batch_spawned.append((item, proc, reader_thread, stderr_file, spawn_start_at, release))
+                    # The child is now owned by the batch_spawned tuple; clear the
+                    # not-yet-registered markers so the finally does not double-handle it.
+                    pending_release = None
+                    pending_proc = None
+                    pending_stderr = None
+                    spawned.append((item, proc))
+                for item, proc, reader_thread, stderr_file, spawn_start_at, release in batch_spawned:
+                    if blockers:
+                        _stop_codex_process(proc)
+                        release()  # ADR 0094 PR-C: blocker-break exit path
+                        break
+                    wait = getattr(proc, "wait", None)
+                    try:
+                        if callable(wait):
+                            rc = wait(timeout=timeout_seconds or None)
+                        else:
+                            rc = getattr(proc, "returncode", 0)
+                    except subprocess.TimeoutExpired:
+                        item["status"] = "timeout"
+                        item["returncode"] = None
+                        blockers.append(f"session {item['session_id']} timed out after {timeout_seconds} seconds")
+                        _stop_codex_process(proc)
+                        if reader_thread is not None:
+                            reader_thread.join(timeout=10.0)
+                        if stderr_file is not None:
+                            try:
+                                stderr_file.close()
+                            except Exception:  # pragma: no cover - close failures non-fatal
+                                pass
+                        release()  # ADR 0094 PR-C: timeout exit path
+                        _emit_progress(f"[done] session={item['session_id']} timeout")
+                        continue
                     if reader_thread is not None:
                         reader_thread.join(timeout=10.0)
                     if stderr_file is not None:
@@ -14792,46 +14935,47 @@ def write_active_codex_runner(
                             stderr_file.close()
                         except Exception:  # pragma: no cover - close failures non-fatal
                             pass
-                    _emit_progress(f"[done] session={item['session_id']} timeout")
-                    continue
-                if reader_thread is not None:
-                    reader_thread.join(timeout=10.0)
-                if stderr_file is not None:
-                    try:
-                        stderr_file.close()
-                    except Exception:  # pragma: no cover - close failures non-fatal
-                        pass
-                item["returncode"] = rc
-                elapsed = time.monotonic() - spawn_start_at
-                # Persist per-lane wall-clock for the opt-in lane-autotune controller
-                # (ADR 0092). codex elapsed is the pure subprocess wait (no artifact
-                # overhead) so it is only ever compared against other codex lanes.
-                # Gated so the runner state file stays byte-identical when autotune is OFF.
-                if lane_autotune_on:
-                    item["elapsed_s"] = round(elapsed, 3)
-                if item.get("budget_exceeded"):
-                    item["status"] = "budget-exceeded"
-                    _emit_progress(
-                        f"[done] session={item['session_id']} budget-exceeded "
-                        f"commands={item.get('command_execution_count')} elapsed={elapsed:.1f}s"
-                    )
-                    blockers.append(
-                        f"session {item['session_id']} exceeded command cap "
-                        f"{max_commands_per_session}"
-                    )
-                elif rc == 0:
-                    item["status"] = "completed"
-                    _emit_progress(
-                        f"[done] session={item['session_id']} rc=0 elapsed={elapsed:.1f}s"
-                    )
-                else:
-                    item["status"] = "failed"
-                    _emit_progress(
-                        f"[done] session={item['session_id']} rc={rc} elapsed={elapsed:.1f}s"
-                    )
-                    blockers.append(f"session {item['session_id']} exited with code {rc}")
-            if blockers:
-                for item, proc, reader_thread, stderr_file, _spawn_start_at in batch_spawned:
+                    item["returncode"] = rc
+                    elapsed = time.monotonic() - spawn_start_at
+                    # Persist per-lane wall-clock for the opt-in lane-autotune controller
+                    # (ADR 0092). codex elapsed is the pure subprocess wait (no artifact
+                    # overhead) so it is only ever compared against other codex lanes.
+                    # Gated so the runner state file stays byte-identical when autotune is OFF.
+                    if lane_autotune_on:
+                        item["elapsed_s"] = round(elapsed, 3)
+                    if item.get("budget_exceeded"):
+                        item["status"] = "budget-exceeded"
+                        _emit_progress(
+                            f"[done] session={item['session_id']} budget-exceeded "
+                            f"commands={item.get('command_execution_count')} elapsed={elapsed:.1f}s"
+                        )
+                        blockers.append(
+                            f"session {item['session_id']} exceeded command cap "
+                            f"{max_commands_per_session}"
+                        )
+                    elif rc == 0:
+                        item["status"] = "completed"
+                        _emit_progress(
+                            f"[done] session={item['session_id']} rc=0 elapsed={elapsed:.1f}s"
+                        )
+                    else:
+                        item["status"] = "failed"
+                        _emit_progress(
+                            f"[done] session={item['session_id']} rc={rc} elapsed={elapsed:.1f}s"
+                        )
+                        blockers.append(f"session {item['session_id']} exited with code {rc}")
+                    release()  # ADR 0094 PR-C: normal exit path (proc waited + reaped)
+            finally:
+                # ADR 0094 PR-C BLOCKER fix: this MUST run on every exit — normal
+                # completion, the spawn-OSError `return`, AND any unhandled exception
+                # propagating out of Phase 1/2 (e.g. Thread.start() RuntimeError, a
+                # non-TimeoutExpired wait() failure). It is the load-bearing invariant
+                # that no acquired slot is ever leaked; without it M such leaks deadlock
+                # the limiter. A propagating exception runs this then re-raises (not
+                # swallowed). All release()/_stop/_join/_close calls are one-shot or
+                # idempotent (and stop is guarded on status == "running"), so on the
+                # normal X=1 path they are inert and the runner state stays byte-identical.
+                for item, proc, reader_thread, stderr_file, _spawn_start_at, release in batch_spawned:
                     if item.get("status") == "running":
                         _stop_codex_process(proc)
                         item["status"] = "terminated"
@@ -14843,6 +14987,25 @@ def write_active_codex_runner(
                             stderr_file.close()
                         except Exception:  # pragma: no cover - close failures non-fatal
                             pass
+                    # Releases any child the wait loop skipped (blocker-break stragglers
+                    # / propagating-exception remainder); one-shot so children already
+                    # released on a normal/timeout path are not double-released
+                    # (BoundedSemaphore would raise on an over-release).
+                    release()
+                # Reclaim AND clean up a child acquired in Phase 1 but never stashed in
+                # batch_spawned (the Thread.start()/stdin-I/O escape): stop the orphan
+                # proc and close its stderr so it cannot keep running untracked, then
+                # release its permit. None-guarded / one-shot, so all three are inert
+                # when the child already reached batch_spawned (markers were cleared).
+                if pending_proc is not None:
+                    _stop_codex_process(pending_proc)
+                if pending_stderr is not None:
+                    try:
+                        pending_stderr.close()
+                    except Exception:  # pragma: no cover - close failures non-fatal
+                        pass
+                if pending_release is not None:
+                    pending_release()
 
         final_gate_sessions = [item for item in planned if item.get("session_id") == "eval-claim-privacy-auditor"]
         first_gate_sessions = [item for item in planned if item.get("session_id") != "eval-claim-privacy-auditor"]
@@ -15301,33 +15464,37 @@ def _write_active_codex_patch(
                         )
                         command_display = _sanitize_command_text(shlex.join(_active_claude_display_command(command)))
                         run_claude = claude_runner or subprocess.run
-                        try:
-                            stream_input = _active_claude_stream_json_input(prompt)
-                            kwargs = {
-                                "cwd": created_path,
-                                "input": stream_input,
-                                "capture_output": True,
-                                "text": True,
-                                "check": False,
-                                "timeout": claude_timeout,
-                            }
-                            if claude_runner is None:
-                                env = strip_ship_secret_env(dict(os.environ))
-                                env.pop("ANTHROPIC_API_KEY", None)
-                                kwargs["env"] = env
-                            proc = run_claude(command, **kwargs)
-                            stdout_path.write_text(str(getattr(proc, "stdout", "") or ""), encoding="utf-8")
-                            stderr_path.write_text(str(getattr(proc, "stderr", "") or ""), encoding="utf-8")
-                            rc = int(getattr(proc, "returncode", 1) or 0)
-                            last_message_path.write_text(
-                                _sanitize_dynamic_text(_claude_stream_result_text(str(getattr(proc, "stdout", "") or ""))).rstrip()
-                                + "\n",
-                                encoding="utf-8",
-                            )
-                        except subprocess.TimeoutExpired:
-                            blockers.append(f"claude patch session {session_id} timed out after {claude_timeout} seconds")
-                        except OSError as exc:
-                            blockers.append(f"failed to run claude patch session {session_id}: {exc}")
+                        # ADR 0094 PR-C: hold the ONE process-wide CLI-spawn slot across
+                        # the claude write spawn->wait so X*Y*Z fan-out cannot multiply
+                        # into hundreds of children. Uncontended at X=1/M=8 (byte-identical).
+                        with global_concurrency_limiter().slot():
+                            try:
+                                stream_input = _active_claude_stream_json_input(prompt)
+                                kwargs = {
+                                    "cwd": created_path,
+                                    "input": stream_input,
+                                    "capture_output": True,
+                                    "text": True,
+                                    "check": False,
+                                    "timeout": claude_timeout,
+                                }
+                                if claude_runner is None:
+                                    env = strip_ship_secret_env(dict(os.environ))
+                                    env.pop("ANTHROPIC_API_KEY", None)
+                                    kwargs["env"] = env
+                                proc = run_claude(command, **kwargs)
+                                stdout_path.write_text(str(getattr(proc, "stdout", "") or ""), encoding="utf-8")
+                                stderr_path.write_text(str(getattr(proc, "stderr", "") or ""), encoding="utf-8")
+                                rc = int(getattr(proc, "returncode", 1) or 0)
+                                last_message_path.write_text(
+                                    _sanitize_dynamic_text(_claude_stream_result_text(str(getattr(proc, "stdout", "") or ""))).rstrip()
+                                    + "\n",
+                                    encoding="utf-8",
+                                )
+                            except subprocess.TimeoutExpired:
+                                blockers.append(f"claude patch session {session_id} timed out after {claude_timeout} seconds")
+                            except OSError as exc:
+                                blockers.append(f"failed to run claude patch session {session_id}: {exc}")
                     else:
                         command = _active_codex_exec_command(
                             codex_executable=str(resolved_executable),
@@ -15342,32 +15509,36 @@ def _write_active_codex_patch(
                         )
                         factory = popen_factory if popen_factory is not None else subprocess.Popen
                         proc = None
-                        try:
-                            with stdout_path.open("w", encoding="utf-8") as so, stderr_path.open("w", encoding="utf-8") as se:
-                                proc = _popen_codex_process(
-                                    factory,
-                                    command,
-                                    cwd=repo_root,
-                                    stdin=subprocess.PIPE,
-                                    stdout=so,
-                                    stderr=se,
-                                    text=True,
-                                    env=strip_ship_secret_env(dict(os.environ)),
-                                )
-                                stdin = getattr(proc, "stdin", None)
-                                if stdin is not None:
-                                    stdin.write(prompt)
-                                    stdin.close()
-                        except OSError as exc:
-                            blockers.append(f"failed to spawn codex patch session {session_id}: {exc}")
-                        if proc is not None and not blockers:
-                            wait = getattr(proc, "wait", None)
+                        # ADR 0094 PR-C: hold the ONE process-wide CLI-spawn slot across
+                        # the codex patch spawn->wait (child lifetime). Uncontended at
+                        # X=1/M=8 so on-disk artifacts stay byte-identical (ADR 0001).
+                        with global_concurrency_limiter().slot():
                             try:
-                                rc = wait(timeout=timeout_seconds or None) if callable(wait) else getattr(proc, "returncode", 0)
-                            except subprocess.TimeoutExpired:
-                                rc = None
-                                blockers.append(f"codex patch session {session_id} timed out after {timeout_seconds} seconds")
-                                _stop_codex_process(proc)
+                                with stdout_path.open("w", encoding="utf-8") as so, stderr_path.open("w", encoding="utf-8") as se:
+                                    proc = _popen_codex_process(
+                                        factory,
+                                        command,
+                                        cwd=repo_root,
+                                        stdin=subprocess.PIPE,
+                                        stdout=so,
+                                        stderr=se,
+                                        text=True,
+                                        env=strip_ship_secret_env(dict(os.environ)),
+                                    )
+                                    stdin = getattr(proc, "stdin", None)
+                                    if stdin is not None:
+                                        stdin.write(prompt)
+                                        stdin.close()
+                            except OSError as exc:
+                                blockers.append(f"failed to spawn codex patch session {session_id}: {exc}")
+                            if proc is not None and not blockers:
+                                wait = getattr(proc, "wait", None)
+                                try:
+                                    rc = wait(timeout=timeout_seconds or None) if callable(wait) else getattr(proc, "returncode", 0)
+                                except subprocess.TimeoutExpired:
+                                    rc = None
+                                    blockers.append(f"codex patch session {session_id} timed out after {timeout_seconds} seconds")
+                                    _stop_codex_process(proc)
                     if rc == 0 and not blockers:
                         run = git_runner or _git_worktree_runner
                         # Stage everything first: agents often CREATE files, and plain

--- a/tests/test_global_concurrency_limiter_regression.py
+++ b/tests/test_global_concurrency_limiter_regression.py
@@ -1,0 +1,531 @@
+"""GlobalConcurrencyLimiter global CLI-spawn ceiling regression (issue #1794, ADR 0094 PR-C).
+
+``agent_loop.GlobalConcurrencyLimiter`` is the substrate brick that puts ONE
+process-wide ``threading.BoundedSemaphore(M)`` in front of every agent-loop CLI
+subprocess spawn (claude write / codex patch / read-review) so a future X*Y*Z
+fan-out cannot multiply into hundreds of concurrent children. The senior
+contract this guards:
+
+* **M resolution + fail-closed** — ``M = BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY``
+  (operator front-door ``ACTIVE_GLOBAL_CONCURRENCY``), default 8. Unset / blank /
+  non-int falls back to 8; a parsed value ``<= 0`` clamps to 1 so a misconfig can
+  never produce a 0/unbounded ceiling.
+* **Max-occupancy <= M** — no more than M threads ever hold a slot at once, AND
+  the ceiling is actually reachable (max_seen == M under contention), so the
+  semaphore both bounds and saturates.
+* **Byte-identity (ADR 0001 gate)** — with the env unset the limiter resolves to
+  the default 8; at X=1/M=8 the loop spawns one child at a time so the semaphore
+  is uncontended and every on-disk artifact + task selection is byte-identical.
+  Ships DARK until PR-D/E enable X>1.
+* **Exactly-once / no-leak release** — ``slot()`` releases on the exception path
+  (no deadlock), and ``BoundedSemaphore`` raises ``ValueError`` on an over-release
+  instead of silently raising the ceiling.
+
+The integration byte-identity net for the wired spawn sites lives in
+``tests/test_agent_loop.py`` (the runner-execute tests
+``...spawns_agentic_processes...`` and ``...patch_mode_execute...``); those must
+stay green UNCHANGED — this file pins only the limiter primitive in isolation.
+
+Pinned values are deterministic and need no external model / network.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts import agent_loop
+
+# The Phase-1/Phase-2 spawn-loop escape-path regressions below drive the real
+# two-phase codex-read runner (write_active_codex_runner -> spawn_and_wait), so
+# they reuse the expanded-eight read-path fixtures already defined in the agent
+# loop integration suite rather than re-deriving the registry/lease scaffolding.
+from test_agent_loop import (  # type: ignore[import-not-found]
+    _chatgpt_auth_runner,
+    _write_expanded_active_runner_fixture,
+    _write_repo,
+)
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT_DIR / "Makefile"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the memoized process-wide limiter so each test resolves M fresh.
+
+    ``global_concurrency_limiter()`` builds + caches ONE limiter; tests set env
+    then trigger a build, so the cache must be cleared between tests.
+    """
+    monkeypatch.setattr(agent_loop, "_GLOBAL_CONCURRENCY_LIMITER", None)
+
+
+# ---------------------------------------------------------------------------
+# (a) M resolution + fail-closed + env + Makefile parity
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_global_concurrency_defaults_and_fail_closed() -> None:
+    """Explicit ``raw`` arg covers default / parse / fail-closed branches.
+
+    Default (8) on None/blank/non-int; pass-through on valid ints; fail-closed
+    clamp to 1 for ``<= 0`` so the ceiling is never 0/unbounded by misconfig.
+    """
+    assert agent_loop._resolve_global_concurrency(None) == 8
+    assert agent_loop._resolve_global_concurrency("4") == 4
+    assert agent_loop._resolve_global_concurrency("16") == 16
+    assert agent_loop._resolve_global_concurrency("0") == 1  # fail-closed
+    assert agent_loop._resolve_global_concurrency("-3") == 1  # fail-closed
+    assert agent_loop._resolve_global_concurrency("") == 8  # blank -> default
+    assert agent_loop._resolve_global_concurrency("abc") == 8  # non-int -> default
+
+
+def test_resolve_global_concurrency_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_resolve_global_concurrency()`` (raw=None) reads the env var.
+
+    ``BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY`` overrides the default, and the
+    ``<= 0`` fail-closed clamp applies to the env path too.
+    """
+    monkeypatch.setenv(agent_loop.GLOBAL_CONCURRENCY_ENV, "2")
+    assert agent_loop._resolve_global_concurrency() == 2
+    monkeypatch.setenv(agent_loop.GLOBAL_CONCURRENCY_ENV, "0")
+    assert agent_loop._resolve_global_concurrency() == 1  # fail-closed via env
+
+
+def test_makefile_declares_active_global_concurrency() -> None:
+    """The operator front-door var + export + runtime bridge are in the Makefile.
+
+    Parity with the code's default 8 (ADR 0094 PR-C). The bridge wires the
+    operator knob ACTIVE_GLOBAL_CONCURRENCY to the env name the code reads
+    (BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY), so `make ... ACTIVE_GLOBAL_CONCURRENCY=N`
+    is not inert.
+    """
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    assert "ACTIVE_GLOBAL_CONCURRENCY ?= 8" in makefile
+    assert "export ACTIVE_GLOBAL_CONCURRENCY" in makefile
+    # Bridge: the operator front-door knob must reach the runtime env var the
+    # code actually reads (os.getenv BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY), else
+    # `make ... ACTIVE_GLOBAL_CONCURRENCY=N` is inert (ADR 0094 item 4 override).
+    assert "BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY ?= $(ACTIVE_GLOBAL_CONCURRENCY)" in makefile
+    assert "export BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY" in makefile
+
+
+# ---------------------------------------------------------------------------
+# (b) max-occupancy <= M (and reaches the ceiling)
+# ---------------------------------------------------------------------------
+
+
+def test_max_occupancy_never_exceeds_limit_and_reaches_it() -> None:
+    """16 threads behind one limiter never exceed M=3 concurrent slots.
+
+    Each thread takes a slot, bumps a shared occupancy counter under a lock,
+    records the running max, sleeps briefly to force overlap, then releases.
+    ``max_seen <= 3`` proves the bound; ``max_seen == 3`` proves the ceiling is
+    actually reached (not merely never approached).
+    """
+    limiter = agent_loop.GlobalConcurrencyLimiter(3)
+    lock = threading.Lock()
+    occupancy = 0
+    max_seen = 0
+    barrier = threading.Barrier(16)
+
+    def worker() -> None:
+        nonlocal occupancy, max_seen
+        barrier.wait()  # release all 16 at once to maximize contention
+        with limiter.slot():
+            with lock:
+                occupancy += 1
+                max_seen = max(max_seen, occupancy)
+            time.sleep(0.005)
+            with lock:
+                occupancy -= 1
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [pool.submit(worker) for _ in range(16)]
+        for future in futures:
+            future.result(timeout=30)
+
+    assert max_seen <= 3
+    assert max_seen == 3
+
+
+# ---------------------------------------------------------------------------
+# (c) byte-identity default
+# ---------------------------------------------------------------------------
+
+
+def test_global_limiter_default_is_eight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the env unset the memoized limiter resolves to M=8 (ADR 0001 gate).
+
+    At X=1/M=8 the loop spawns one child at a time, so the semaphore is
+    uncontended and on-disk artifacts stay byte-identical. The integration
+    byte-identity net (``tests/test_agent_loop.py`` runner-execute tests
+    ``...spawns_agentic...`` and ``...patch_mode_execute...``) must stay green
+    UNCHANGED alongside this primitive check.
+    """
+    monkeypatch.delenv(agent_loop.GLOBAL_CONCURRENCY_ENV, raising=False)
+    assert agent_loop.global_concurrency_limiter().limit == 8
+
+
+def test_global_limiter_is_memoized_singleton() -> None:
+    """``global_concurrency_limiter()`` hands back the SAME instance each call."""
+    first = agent_loop.global_concurrency_limiter()
+    second = agent_loop.global_concurrency_limiter()
+    assert first is second
+
+
+# ---------------------------------------------------------------------------
+# (d) release-on-exception + over-release guard (BoundedSemaphore)
+# ---------------------------------------------------------------------------
+
+
+def test_slot_releases_on_exception_no_deadlock() -> None:
+    """An exception inside ``slot()`` still releases — no permanent slot leak."""
+    limiter = agent_loop.GlobalConcurrencyLimiter(1)
+    with pytest.raises(RuntimeError):
+        with limiter.slot():
+            raise RuntimeError("x")
+    # The single slot must be reacquirable (no deadlock from a leaked permit).
+    assert limiter._sem.acquire(timeout=1.0) is True
+    limiter._sem.release()
+
+
+def test_over_release_raises_value_error_bounded_semaphore() -> None:
+    """A spurious extra release raises ValueError (proves BoundedSemaphore).
+
+    BoundedSemaphore (not plain Semaphore) so an over-release fails loudly
+    instead of silently raising the ceiling above M.
+    """
+    limiter = agent_loop.GlobalConcurrencyLimiter(1)
+    with limiter.slot():
+        pass  # acquire + release one full cycle, leaving the count at its ceiling
+    with pytest.raises(ValueError):
+        limiter._sem.release()  # over-release past the initial bound
+
+
+# ---------------------------------------------------------------------------
+# (e) Phase-1 / Phase-2 spawn-loop escape paths never leak a permit
+#
+# ``spawn_and_wait`` (nested in ``write_active_codex_runner``) acquires the ONE
+# process-wide slot MANUALLY per codex-read child and relies on a try/finally to
+# return EVERY permit on EVERY exit. These tests pin the three escape paths an
+# adversarial review found could leak before the finally existed:
+#   1. ``_spawn_codex_reader_thread`` (Thread.start) raises AFTER the slot is
+#      acquired but BEFORE the child reaches ``batch_spawned`` (pending_release).
+#   2. Phase-2 ``wait()`` raises a NON-``TimeoutExpired`` exception (only
+#      ``TimeoutExpired`` was caught) — without a finally the remaining permits
+#      leaked and the exception escaped.
+#   3. A mid-batch spawn ``OSError`` with >= 1 earlier live child — the earlier
+#      children must be stopped/reaped AND all permits returned (DEFECT 2).
+# After M such leaks the BoundedSemaphore would deadlock. "Permits restored" is
+# measured by reading ``limiter._sem._value`` (== M means every permit returned)
+# AND proving the limiter can still be acquired M times.
+# ---------------------------------------------------------------------------
+
+
+class _ReadProc:
+    """Minimal codex-read subprocess double: usable stdin, no readable stdout.
+
+    No ``stdout`` attribute -> ``_spawn_codex_reader_thread`` returns ``None``
+    (no real tail thread), keeping the Phase-2 path deterministic. ``wait``
+    returns 0 by default; subclasses / instances override to raise.
+    """
+
+    def __init__(self, pid: int = 9000) -> None:
+        self.pid = pid
+        self.returncode = 0
+        self.stdin = self
+
+    def write(self, _text: str) -> None:  # stdin.write
+        pass
+
+    def close(self) -> None:  # stdin.close
+        pass
+
+    def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+        return 0
+
+
+def _assert_all_permits_restored(limiter: agent_loop.GlobalConcurrencyLimiter, m: int = 8) -> None:
+    """Every permit is back: count == M AND the ceiling is re-acquirable M times."""
+    assert limiter._sem._value == m  # type: ignore[attr-defined]
+    acquired = [limiter._sem.acquire(timeout=1.0) for _ in range(m)]
+    try:
+        assert all(acquired), "limiter could not be re-acquired M times -> a permit leaked"
+        # The ceiling is exhausted now; a further non-blocking acquire must fail.
+        assert limiter._sem.acquire(blocking=False) is False
+    finally:
+        for ok in acquired:
+            if ok:
+                limiter._sem.release()
+
+
+def test_reader_thread_start_failure_mid_batch_restores_all_permits(tmp_path: Path) -> None:
+    """``_spawn_codex_reader_thread`` raising mid-batch leaks NO permit.
+
+    The slot for the failing child is acquired but the child never reaches
+    ``batch_spawned`` (the Thread.start() / pre-append escape), and two earlier
+    children are already registered holding slots. The ``finally`` must reclaim
+    all three (the registered pair via the batch drain, the failing one via
+    ``pending_release``), stop/reap the earlier live children, and let the
+    exception propagate (not swallow it).
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    spawned_pids: list[int] = []
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        proc = _ReadProc(pid=9000 + len(spawned_pids))
+        spawned_pids.append(proc.pid)
+        return proc
+
+    # Raise on the 3rd reader-thread spawn so two earlier children are already
+    # registered in batch_spawned (exercises BOTH the drain and pending_release).
+    calls = {"n": 0}
+    real_helper = agent_loop._spawn_codex_reader_thread
+
+    def flaky_reader_thread(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("can't start new thread")
+        return real_helper(*args, **kwargs)
+
+    stopped: list[object] = []
+
+    def record_stop(proc, *a, **k):  # type: ignore[no-untyped-def]
+        stopped.append(proc)
+
+    import test_agent_loop as _tal  # noqa: F401 - ensure helper module imported
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(agent_loop, "_spawn_codex_reader_thread", flaky_reader_thread), \
+            _mock.patch.object(agent_loop, "_stop_codex_process", record_stop):
+        with pytest.raises(RuntimeError, match="can't start new thread"):
+            agent_loop.write_active_codex_runner(
+                execute=True,
+                repo_root=repo,
+                popen_factory=fake_popen,
+                which_func=lambda exe: "/opt/codex/bin/codex",
+                auth_runner=_chatgpt_auth_runner,
+            )
+
+    limiter = agent_loop.global_concurrency_limiter()
+    _assert_all_permits_restored(limiter)
+    # The two earlier live children were reaped by the finally (DEFECT-1 reaping
+    # on propagation), not left running.
+    assert len(stopped) >= 2
+
+
+def test_reader_thread_start_failure_first_child_restores_permit(tmp_path: Path) -> None:
+    """Reader-thread failure on the FIRST child reclaims the lone unregistered slot.
+
+    With zero earlier children, only ``pending_release`` can return the permit
+    acquired just before the failing ``_spawn_codex_reader_thread`` — the
+    batch_spawned drain is empty. Proves the pre-append escape is covered in
+    isolation.
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return _ReadProc()
+
+    def boom(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("thread start failed on first child")
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(agent_loop, "_spawn_codex_reader_thread", boom):
+        with pytest.raises(RuntimeError, match="first child"):
+            agent_loop.write_active_codex_runner(
+                execute=True,
+                repo_root=repo,
+                popen_factory=fake_popen,
+                which_func=lambda exe: "/opt/codex/bin/codex",
+                auth_runner=_chatgpt_auth_runner,
+            )
+
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_phase2_wait_non_timeout_exception_restores_all_permits(tmp_path: Path) -> None:
+    """A non-``TimeoutExpired`` ``wait()`` failure in Phase 2 leaks NO permit.
+
+    Phase 2 only catches ``subprocess.TimeoutExpired``; any other ``wait()``
+    exception propagates. Before the finally, every still-held permit (the
+    failing child plus every not-yet-waited child) leaked. The finally must
+    return them all and re-raise.
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    class _BadWaitProc(_ReadProc):
+        def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+            raise RuntimeError("wait() blew up (not a timeout)")
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return _BadWaitProc()
+
+    import unittest.mock as _mock
+
+    stopped: list[object] = []
+    with _mock.patch.object(agent_loop, "_stop_codex_process", lambda p, *a, **k: stopped.append(p)):
+        with pytest.raises(RuntimeError, match="wait\\(\\) blew up"):
+            agent_loop.write_active_codex_runner(
+                execute=True,
+                repo_root=repo,
+                popen_factory=fake_popen,
+                which_func=lambda exe: "/opt/codex/bin/codex",
+                auth_runner=_chatgpt_auth_runner,
+            )
+
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_spawn_oserror_mid_batch_reaps_earlier_child_and_restores_permits(tmp_path: Path) -> None:
+    """DEFECT 2: a mid-batch spawn ``OSError`` stops earlier children + frees all permits.
+
+    The first child spawns and starts running; the second child's ``Popen``
+    raises ``OSError``. The handler records a blocker and returns (OSError is
+    caught, not propagated, so the run ends BLOCKED). The finally must (a) stop /
+    reap the earlier live child — not leave it running with a freed permit — and
+    (b) return every acquired permit so the ceiling is fully restored.
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    spawn_calls = {"n": 0}
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        spawn_calls["n"] += 1
+        if spawn_calls["n"] == 2:
+            raise OSError("simulated spawn failure")
+        return _ReadProc(pid=9000 + spawn_calls["n"])
+
+    stopped: list[object] = []
+
+    def record_stop(proc, *a, **k):  # type: ignore[no-untyped-def]
+        stopped.append(proc)
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(agent_loop, "_stop_codex_process", record_stop):
+        result = agent_loop.write_active_codex_runner(
+            execute=True,
+            repo_root=repo,
+            popen_factory=fake_popen,
+            which_func=lambda exe: "/opt/codex/bin/codex",
+            auth_runner=_chatgpt_auth_runner,
+        )
+
+    assert result.decision == "blocked"
+    assert any("failed to spawn" in b for b in result.blockers)
+    # The earlier live child was stopped/reaped by the finally (DEFECT 2: before
+    # the fix the OSError handler freed its permit but returned without reaping).
+    assert len(stopped) >= 1
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_stdin_oserror_after_popen_stops_orphan_proc_and_restores_permits(tmp_path: Path) -> None:
+    """Codex re-review HIGH: a child whose Popen SUCCEEDS but whose stdin I/O then
+    raises OSError (before ``batch_spawned.append``) must not leave an orphan.
+
+    The permit is reclaimed via ``pending_release``, but the just-spawned proc is
+    also live and not yet in ``batch_spawned`` — the finally must stop it (via
+    ``pending_proc``), else it keeps running untracked. This pins the PROC cleanup,
+    not merely the permit: before the proc/stderr tracking was added the orphan was
+    never stopped.
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    spawned: list[object] = []
+
+    class _BadStdinProc(_ReadProc):
+        def write(self, _text: str) -> None:  # stdin.write raises AFTER a good Popen
+            raise OSError("broken pipe before append")
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        proc = _BadStdinProc()
+        spawned.append(proc)
+        return proc
+
+    stopped: list[object] = []
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(agent_loop, "_stop_codex_process", lambda p, *a, **k: stopped.append(p)):
+        result = agent_loop.write_active_codex_runner(
+            execute=True,
+            repo_root=repo,
+            popen_factory=fake_popen,
+            which_func=lambda exe: "/opt/codex/bin/codex",
+            auth_runner=_chatgpt_auth_runner,
+        )
+
+    assert result.decision == "blocked"
+    assert any("failed to spawn" in b for b in result.blockers)
+    # The orphan proc (Popen succeeded, stdin failed, never appended) was stopped by
+    # the finally via pending_proc -- before the fix only its permit was reclaimed.
+    assert spawned, "fixture did not drive a codex spawn"
+    assert spawned[0] in stopped
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_blocker_break_straggler_inline_and_finally_release_no_over_release(tmp_path: Path) -> None:
+    """The blocker-break straggler is released inline AND revisited by the finally;
+    the one-shot closure must make the second release a no-op (no ``BoundedSemaphore``
+    over-release ``ValueError``).
+
+    Drive >=2 codex children where the first exits non-zero (populating
+    ``blockers``) so Phase 2 takes the ``if blockers: ... release(); break``
+    straggler path on the next child, then the finally revisits that same child. A
+    regression that swapped ``_one_shot_release`` for a plain ``_sem.release()``
+    would raise ``ValueError`` here while every other test stayed green.
+    """
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+
+    calls = {"n": 0}
+
+    class _RcProc(_ReadProc):
+        def __init__(self, pid: int, rc: int) -> None:
+            super().__init__(pid=pid)
+            self.returncode = rc
+
+        def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+            return self.returncode
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        # First codex child exits non-zero -> blockers populated -> the NEXT child
+        # hits the blocker-break straggler path in Phase 2.
+        return _RcProc(pid=9000 + calls["n"], rc=1 if calls["n"] == 1 else 0)
+
+    import unittest.mock as _mock
+
+    # Stub stop so the test isolates release accounting: the straggler is stopped
+    # twice (inline break + finally), which must also be harmless.
+    with _mock.patch.object(agent_loop, "_stop_codex_process", lambda p, *a, **k: None):
+        result = agent_loop.write_active_codex_runner(
+            execute=True,
+            repo_root=repo,
+            popen_factory=fake_popen,
+            which_func=lambda exe: "/opt/codex/bin/codex",
+            auth_runner=_chatgpt_auth_runner,
+        )
+
+    assert result.decision == "blocked"
+    # Guard against a vacuous run: >=2 codex children must have spawned, else the
+    # blocker-break straggler path (Phase 2 child #2 after child #1 populated
+    # blockers) is never exercised and the test would pass trivially.
+    assert calls["n"] >= 2, "fixture spawned <2 codex children -> blocker-break path not exercised"
+    # No ValueError was raised (pytest would have failed); every permit is back
+    # despite the straggler being release()'d inline and revisited by the finally.
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0094 substrate brick 4/7. 모든 agent-loop CLI subprocess spawn(claude read/write, codex read-review/patch) 앞에 단일 process-wide `BoundedSemaphore(M=8)`(`GlobalConcurrencyLimiter`)를 둬, 향후 X*Y*Z fan-out 이 수백 개 동시 child 로 곱해지는 것을 막는다. X=1/M=8 에서 **DARK + byte-identical**(루프가 한 번에 child 하나만 spawn → semaphore uncontended). 실제 fan-out(X>1)은 후속 brick PR-D/E.

Closes #1794

## 2. 영향 파일

- `scripts/agent_loop.py` — `GlobalConcurrencyLimiter` + 4 wired spawn site. **off `LOAD_BEARING_PATHS`** (`scripts/_governance.py`, ADR 0080/0085/0087)
- `Makefile` — `ACTIVE_GLOBAL_CONCURRENCY` operator knob + `BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY` env bridge
- `tests/test_global_concurrency_limiter_regression.py` (new) — 14 regression

## 3. 리스크

가장 가능성 높은 깨짐 경로는 codex-read 의 manual acquire 에서 permit leak / orphan proc / over-release / byte-identity 훼손. 5개 종료 경로(normal / Thread.start escape / phase-2 non-timeout / spawn-OSError / blocker-break)를 `try/finally` + one-shot release closure + `pending_proc/stderr/release` marker 로 닫았다. 독립 3-round 리뷰(code-reviewer opus + Codex adversarial xhigh): 2 BLOCK round 가 permit-leak → orphan-proc 경로를 잡았고 모두 closed, 최종 dual SHIP. orphan 테스트는 anti-tautology 검증(finally 의 proc-stop 무력화 시 fail 확인 후 복원).

## 4. 테스트

`tests/test_global_concurrency_limiter_regression.py` 14개: M resolution + fail-closed + Makefile bridge parity, occupancy `max==M` ceiling, release-on-exception, over-release `ValueError`, 그리고 5개 permit-leak/orphan escape path. 기존 `tests/test_agent_loop.py` 332개 green 유지. Behavior change(semaphore 도입)는 신규 회귀로 검증(변경 전 fail / 후 pass).

## 5. Eval 영향

All `·` — agent-loop 자동화 오케스트레이터 변경으로 RAG 파이프라인 / eval surface 외. `scripts/agent_loop.py` 는 `LOAD_BEARING_PATHS` 에서 제외(ADR 0080/0085/0087). real-data eval delta 없음(동작은 X=1/M=8 byte-identical).

## 6. 하위 호환

없음. DARK + byte-identical at X=1/M=8. 새 env(`BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY`) / Makefile knob(`ACTIVE_GLOBAL_CONCURRENCY`)은 additive opt-in 이며 기본값 8 에서 기존 동작과 동일. answer-contract(ADR 0003) 무관.

## 7. 범위 외

- X>1 fan-out + first-writer-wins write-rejection enforcement (PR-D/E)
- `LedgerState` unlocked read-alias 의 snapshot-for-read (X>1 시)
- non-POSIX(`fcntl` 부재) fail-closed (PR-B carry-forward, X>1 시)

<!-- 🤖 Generated with Claude Code -->
