### PR TITLE
docs(eval-policy): align mutable docs to real100_v2 surface + ADR 0084 §5b repeal

### DIFF
--- a/docs/agent-utilization.md
+++ b/docs/agent-utilization.md
@@ -16,7 +16,7 @@
 |---|---|---|---|
 | **규칙(Rules)** | 자동 강제 invariant | 훅·CI 차단 | PreToolUse load-bearing edit, 브랜치 명명, ADR 0005 경계 |
 | **스킬(Skills)** | workflow 묶음 + 승인 게이트 | 사람·Claude 수동 호출 | `ship-pr`, `self-review-quarterly`, `adr-portfolio-signals` |
-| **커맨드(Commands)** | 수동 트리거 (평가·shipping·검증) | Make 타깃 / 스크립트 | `make smoke`, `make real-eval`, `make ship-arm`, `make governance-check` |
+| **커맨드(Commands)** | 수동 트리거 (평가·shipping·검증) | Make 타깃 / 스크립트 | `make smoke`, `make real-eval-v2-check`, `make ship-arm`, `make governance-check` |
 | **서브에이전트(Subagents)** | 컨텍스트 격리 (읽기 전용 탐색·설계 외주) | 메인 대화에서 위임 | Explore, Plan, general-purpose |
 
 원칙: **규칙은 자동, 나머지 셋은 트리거 만족 시만 호출.** 트리거가 모호하면 도구는 사장.
@@ -59,8 +59,8 @@
 
 | 컴포넌트 | 종류 | 5축 cover | 트리거 | 위치 |
 |---|---|---|---|---|
-| `eval-anomaly-investigator` | agent | #3 (closed error loop) + #4 (anomaly→audit) | `make real-eval` 후 dominant/이상 failure category · variance 의심 · 사용자 명시 | [`.claude/agents/eval-anomaly-investigator.md`](../.claude/agents/eval-anomaly-investigator.md) |
-| `eval-to-adr-bridge` | agent | #3 (부분) + #4 (trigger→proposed lag) | `/retrieval-eval` Phase STOP / `/eval-framework-progressive-audit` phase / `make real-eval` 후 | [`.claude/agents/eval-to-adr-bridge.md`](../.claude/agents/eval-to-adr-bridge.md) |
+| `eval-anomaly-investigator` | agent | #3 (closed error loop) + #4 (anomaly→audit) | private real-eval(maintainer 전용, ADR 0005) 후 dominant/이상 failure category · variance 의심 · 사용자 명시 | [`.claude/agents/eval-anomaly-investigator.md`](../.claude/agents/eval-anomaly-investigator.md) |
+| `eval-to-adr-bridge` | agent | #3 (부분) + #4 (trigger→proposed lag) | `/retrieval-eval` Phase STOP / `/eval-framework-progressive-audit` phase / private real-eval(maintainer 전용) 후 | [`.claude/agents/eval-to-adr-bridge.md`](../.claude/agents/eval-to-adr-bridge.md) |
 | `memory-curator` | agent | #5 (incremental gate) | 메모리 저장 직전 / `MEMORY.md` ≥180줄 / 사용자 명시 | [`.claude/agents/memory-curator.md`](../.claude/agents/memory-curator.md) |
 | `agent-delegation-gate` | hook | #2 (prompt-time delegation nudge) | UserPromptSubmit (모든 prompt, 키워드 매치 시 메시지 emit + fires.log append) | [`scripts/claude-hooks/userpromptsubmit-delegation-gate.sh`](../scripts/claude-hooks/userpromptsubmit-delegation-gate.sh) |
 
@@ -75,7 +75,7 @@
 
 ### 사용 가이드
 
-- `eval-anomaly-investigator`: `make real-eval` 후 failure category 이상치를 ADR 0005-safe slice + 가설 ranking → `docs/audits/*-inspection.md`. 산출 audit 는 `eval-to-adr-bridge` 의 입력. 실 fix / 측정 실행은 영역 외
+- `eval-anomaly-investigator`: private real-eval(maintainer 전용, ADR 0005) 후 failure category 이상치를 ADR 0005-safe slice + 가설 ranking → `docs/audits/*-inspection.md`. 산출 audit 는 `eval-to-adr-bridge` 의 입력. 실 fix / 측정 실행은 영역 외
 - `eval-to-adr-bridge`: 측정 후 ADR 작성 결정 단계에서 호출. commit / PR / Status 변경은 영역 외 (`ship-pr` skill 영역)
 - `memory-curator`: 메모리 저장 결정 게이트. batch 정리는 `consolidate-memory` skill 영역 (호출 권유만)
 - `agent-delegation-gate`: 자동 (사용자 prompt 시점). 항상 exit 0, fail-safe. 트리거 키워드 false-positive 시 description 어휘 조정

--- a/docs/investigations/152-splade-colbert-feasibility.md
+++ b/docs/investigations/152-splade-colbert-feasibility.md
@@ -59,14 +59,7 @@ C3 가 두 knob 을 동시에 켜는 유일한 cell 이다. k=30 을 single pick
 
 private 100-doc / 21-case real-data 에서만 실행. raw 결과는 `artifacts/benchmarks/private100_*/` 에 로컬로만 둔다.
 
-```bash
-# Each cell — pipeline 이름만 바꿔서 4번 실행
-make real-eval PIPELINE=full                       # C1 baseline
-make real-eval PIPELINE=hybrid_bm25                # C2
-make real-eval PIPELINE=hybrid_bm25_k30_extra      # C3 (NEW row)
-make real-eval PIPELINE=hybrid_bm25_k30            # C4 (best-of 후보)
-make real-eval-delta BASE=full HEAD=hybrid_bm25_k30_extra
-```
+> **이 측정은 private real-eval(maintainer 전용)** 이다 — 절차·산출물 경계는 [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md) / CLAUDE.md ban-list 관할. 레거시 `real-eval` make 타깃은 비활성(exit-2 stub)이며, maintainer 는 `real100_v2` 인벤토리/체크(`make real-eval-v2-inventory` / `make real-eval-v2-check`) 와 `make real-eval-delta` 로 cell 별 aggregate Δ 를 측정한다. 4-cell(C1–C4) 파이프라인 sweep 은 C1=full, C2=hybrid_bm25, C3=hybrid_bm25_k30_extra, C4=hybrid_bm25_k30 네 cell 로 구성되며, §3.3 결과는 측정 후 채운다.
 
 본 노트 §3.3 표에는 **aggregate Δ 만** 옮겨 적는다. per-case predictions / chunk IDs / 원문은 절대 commit 하지 않는다 ([docs/real-data/private-100-doc-experiments.md](../real-data/private-100-doc-experiments.md) 의 commit boundary).
 

--- a/docs/local-gold-authoring.md
+++ b/docs/local-gold-authoring.md
@@ -16,7 +16,7 @@
 
 - `eval/*.local.yaml`은 [`.gitignore`](../.gitignore)에 등록되어 있다. 절대 git에 커밋하지 않는다.
 - 파일 내용에는 발주기관명, 사업명, 공고 번호, 문서 원문 일부 등 민감정보가 포함될 수 있다. PR 본문, 이슈 코멘트, 스크린샷, 외부 채널에 그대로 붙여 넣지 않는다.
-- 평가 결과(`reports/real100/eval_summary.json`)도 같은 이유로 git 추적 대상이 아니다. 공유가 필요하면 sanitized 요약(`docs/real-data/real-data-failure-taxonomy.md`처럼 카테고리별 빈도 + sanitized 증상)으로 옮긴다.
+- 평가 결과(`reports/real100_v2/eval_summary.json`)도 같은 이유로 git 추적 대상이 아니다. 공유가 필요하면 sanitized 요약(`docs/real-data/real-data-failure-taxonomy.md`처럼 카테고리별 빈도 + sanitized 증상)으로 옮긴다.
 - 공개 README의 성능 표는 실데이터 평가 결과로 갱신하지 않는다([이슈 #47 out-of-scope](real-data/real-data-failure-taxonomy.md)).
 
 ## 어디서 시작하나
@@ -35,7 +35,7 @@ cp eval/real_config.example.yaml eval/real_config.local.yaml
 |---|---|---|
 | `mode` | 평가 모드. 항상 `rag`. | 다른 값은 지원하지 않는다. |
 | `description` | 사람이 읽는 한 줄 설명. | 자유롭게. |
-| `index_dir` | 사용할 인덱스 경로. | 보통 `data/index/real100`. |
+| `index_dir` | 사용할 인덱스 경로. | 보통 private real100_v2 인덱스 경로(`data/index/real100_v2`). private real-eval 은 maintainer 전용 — ADR 0005 / CLAUDE.md ban-list 참조. |
 | `answer_policy` | 답변 가능/불가 케이스에 어떤 status를 기대하는지. | example과 동일하게 둔다. |
 | `ablation_runs` | 실행할 파이프라인 목록. 최소 1개. | 보통 `full` 하나로 충분. |
 | `cases` | 실제 케이스 목록. **이 부분이 핵심.** |  |
@@ -68,7 +68,7 @@ cp eval/real_config.example.yaml eval/real_config.local.yaml
 
 ## doc_id를 어떻게 알아내나
 
-[`scripts/build_index.py`](../scripts/build_index.py) 실행 후 `data/index/real100/ingestion_report.json`에 모든 row의 `doc_id`가 기록된다. 보통 `<공고 번호>-<공고 차수>` 형태이며, 공고 번호가 비어 있을 때만 파일명 stem이 사용된다(자세한 규칙은 [PDF/HWP ingestion](./real-data/real-data-ingestion.md#canonical-doc_id-rule)).
+[`scripts/build_index.py`](../scripts/build_index.py) 실행 후 `data/index/real100_v2/ingestion_report.json`에 모든 row의 `doc_id`가 기록된다. 보통 `<공고 번호>-<공고 차수>` 형태이며, 공고 번호가 비어 있을 때만 파일명 stem이 사용된다(자세한 규칙은 [PDF/HWP ingestion](./real-data/real-data-ingestion.md#canonical-doc_id-rule)).
 
 이 파일은 비공개이므로 평가 케이스 작성 외 용도로 외부에 공유하지 않는다.
 
@@ -146,7 +146,7 @@ PDF/HWP 인덱스의 한 사업에 대해 사업기간과 사업예산을 묻는
    python3 scripts/build_index.py \
      --metadata_csv data/data_list.csv \
      --files_dir data/files \
-     --output_dir data/index/real100 \
+     --output_dir data/index/real100_v2 \
      --embedding_backend hashing
    ```
 2. CSV 자체에 column / null / duplicate 문제가 없는지 먼저 본다.
@@ -154,17 +154,20 @@ PDF/HWP 인덱스의 한 사업에 대해 사업기간과 사업예산을 묻는
    python3 scripts/validate_data_list.py \
      --metadata_csv data/data_list.csv \
      --files_dir data/files \
-     --output_path reports/real100/data_list_validation.json
+     --output_path reports/real100_v2/data_list_validation.json
    ```
    exit code가 0이 아니면 인덱스 빌드 전에 fix한다(이슈 [#51](https://github.com/hskim-solv/BidMate-DocAgent/issues/51)).
 3. gold를 적용해 평가한다.
-   ```bash
+
+   > private real-eval 의 full-run 은 maintainer 전용이다(ADR 0005 / CLAUDE.md ban-list). 일반 기여자는 `make real-eval-v2-check` / `make real-eval-v2-inventory` 로 경로·산출물만 검증한다. maintainer 의 canonical full-run 은 `make real-eval-v2-chroma`(`-chroma-llm`); 아래는 그 내부 호출의 *설명용 비실행 스니펫*이다.
+
+   ```text
    python3 eval/run_eval.py \
      --config eval/real_config.local.yaml \
-     --index_dir data/index/real100 \
-     --output_dir reports/real100
+     --index_dir data/index/real100_v2 \
+     --output_dir reports/real100_v2
    ```
-4. `reports/real100/eval_summary.json`의 `by_query_type`과 `case_results`를 확인한다. 슬라이스별 빈도와 실패 패턴은 [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md)와 동일한 분류 체계로 정리하면 트래킹이 쉽다.
+4. `reports/real100_v2/eval_summary.json`의 `by_query_type`과 `case_results`를 확인한다. 슬라이스별 빈도와 실패 패턴은 [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md)와 동일한 분류 체계로 정리하면 트래킹이 쉽다.
 
 ## 자주 막히는 지점
 

--- a/docs/multi-agent-ownership.md
+++ b/docs/multi-agent-ownership.md
@@ -87,7 +87,7 @@ RAG 파이프라인은 단계별 (ingestion → 검색 → 계획 → 검증 →
 
 ## 검증
 
-매 PR 전: `make smoke` + `bash scripts/test.sh`. load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`) 변경 시 `make real-eval` + `make real-eval-delta` + PR 템플릿 5b 채움.
+매 PR 전: `make smoke` + `bash scripts/test.sh`. load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`) 변경 시 real-data 영향을 검토한다 — private real-eval 은 maintainer 전용(ADR 0005 / CLAUDE.md ban-list 참조)이며, 동작 변경 PR 은 `make real-eval-delta` 로 델타를 측정해 PR §5 에 근거를 남기는 것을 **권장**한다(§5b 강제 게이트는 [ADR 0084](adr/0084-deprecate-5b-real-data-delta-gate.md) 로 폐지).
 
 CI gate: [`pr-eval.yml`](../.github/workflows/pr-eval.yml), [`branch-and-issue-check.yml`](../.github/workflows/branch-and-issue-check.yml). 답변 계약 PR 은 추가로 `schema_version` 증가 + ADR 0003 갱신 확인.
 

--- a/docs/private-real-eval-inventory.md
+++ b/docs/private-real-eval-inventory.md
@@ -3,7 +3,7 @@
 이 문서는 private real-eval 이 실제 코드에서 참조하는 local/private 경로를
 required input, optional input, regenerable cache, output artifact,
 deprecated/dead reference 로 분리한다. 조사 기준은 repo-wide `rg` 로
-`real_config|REAL_EVAL|data_list|files_kordoc|data/files|eval_summary|reports/real100|cache|cached|artifacts|runs|index|indices|embedding|embeddings|faiss|chroma|vector|bm25|retrieval|ocr|parsed|layout|page_images|thumbnails|jsonl|parquet|sqlite|\.db`
+`real_config|REAL_EVAL|data_list|files_kordoc|data/files|eval_summary|reports/real100_v2|cache|cached|artifacts|runs|index|indices|embedding|embeddings|faiss|chroma|vector|bm25|retrieval|ocr|parsed|layout|page_images|thumbnails|jsonl|parquet|sqlite|\.db`
 패턴을 검색하고, `find data eval reports scripts tests -maxdepth 4` 로
 실제 tree 를 대조한 결과다.
 
@@ -16,16 +16,16 @@ deprecated/dead reference 로 분리한다. 조사 기준은 repo-wide `rg` 로
 | `data/files/` | required input | `scripts/build_index.py --files_dir`, `scripts/validate_data_list.py --files_dir`, kordoc source hashing | yes | no | `REAL_EVAL_DATA_DIR`, `real_eval.document_dirs.default` |
 | `data/files_kordoc/` | regenerable cache | `ingestion._resolve_kordoc_cache_dir`, `scripts/build_kordoc_manifest.py`, `BIDMATE_KORDOC_CACHE_DIR` | no | yes | `REAL_EVAL_KORDOC_DATA_DIR`, `real_eval.document_dirs.kordoc` |
 | `.cache/real_eval/` | regenerable cache | resolver-owned root for OCR/parsed/layout/embedding cache placement | no | yes | `REAL_EVAL_CACHE_DIR`, `real_eval.cache.root` |
-| `data/index/real100/` | regenerable cache | `app.py --input_dir`, `eval/run_eval.py --index_dir`, `scripts/smoke_real.sh`, `make real-eval` | no | yes | `REAL_EVAL_INDEX_DIR`, `real_eval.index.root`; hashing/offline surface |
-| `data/index/real100_minilm/` | regenerable cache | `make real-eval-minilm` | no | yes | `REAL_EVAL_INDEX_DIR`; MiniLM sentence-transformers baseline |
-| `data/index/real100_m3/` | regenerable cache | `make real-eval-semantic`, `scripts/phase35_m3_ablation.py --index_dir_m3` | no | yes | `REAL_EVAL_INDEX_DIR`; BGE-M3 semantic comparison |
-| `data/index/real100_kordoc/` | regenerable cache | Phase 4 metadata retrieval reports and docs | no | yes | `REAL_EVAL_INDEX_DIR` for kordoc-only runs |
-| `outputs/real100/` | output artifact | `scripts/smoke_real.sh`, `app.py --output_dir` | no | yes | `OUTPUT_DIR` |
-| `reports/real100/` | output artifact | `eval/run_eval.py --output_dir`, `scripts/run_real_eval_delta.py` | no | yes | `REAL_EVAL_REPORT_DIR`, `real_eval.reports.output_dir` |
-| `reports/real100/eval_summary.json` | output artifact | `make real-eval`, `scripts/run_real_eval_delta.py --head`, ship PR body cache check | no | yes | derived from `REAL_EVAL_REPORT_DIR` |
-| `reports/real100/baseline.aggregate.json` | optional input | `scripts/run_real_eval_delta.py --base`, baseline provenance checks | no | no | `REAL_EVAL_BASELINE_SUMMARY`, `real_eval.reports.baseline_summary` |
-| `reports/real100/judge.local.json` | output artifact | `scripts/llm_judge.py`, `scripts/run_real_eval_delta.py` optional fold-in | no | yes | `REAL_EVAL_REPORT_DIR` |
-| `reports/real100/traces/` | output artifact | trace/rationality judge workflows | no | yes | `REAL_EVAL_REPORT_DIR` |
+| `data/index/real100_v2/` | regenerable cache | `app.py --input_dir`, `eval/run_eval.py --index_dir`, `scripts/smoke_real.sh`, `make real-eval-v2-chroma` | no | yes | `REAL_EVAL_INDEX_DIR`, `real_eval.index.root`; hashing/offline surface |
+| `data/index/real100_minilm/` | deprecated / removed artifact | 폐지된 real-eval-minilm stub(archive-only) | no | yes | `REAL_EVAL_INDEX_DIR`; MiniLM sentence-transformers baseline |
+| `data/index/real100_m3/` | deprecated / removed artifact | 폐지된 real-eval-semantic stub(archive-only) | no | yes | `REAL_EVAL_INDEX_DIR`; BGE-M3 semantic comparison |
+| `data/index/real100_kordoc/` | deprecated / removed artifact | Phase 4 metadata retrieval reports(archive-only) | no | yes | `REAL_EVAL_INDEX_DIR` for kordoc-only runs |
+| `outputs/real100_v2/` | output artifact | `scripts/smoke_real.sh`, `app.py --output_dir` | no | yes | `OUTPUT_DIR` |
+| `reports/real100_v2/` | output artifact | `eval/run_eval.py --output_dir`, `scripts/run_real_eval_delta.py` | no | yes | `REAL_EVAL_REPORT_DIR`, `real_eval.reports.output_dir` |
+| `reports/real100_v2/eval_summary.json` | output artifact | `make real-eval-v2-chroma`(`-chroma-llm`), `scripts/run_real_eval_delta.py --head`, ship PR body cache check | no | yes | derived from `REAL_EVAL_REPORT_DIR` |
+| `reports/real100_v2/baseline.aggregate.json` | optional input | `scripts/run_real_eval_delta.py --base`, baseline provenance checks | no | no | `REAL_EVAL_BASELINE_SUMMARY`, `real_eval.reports.baseline_summary` |
+| `reports/real100_v2/judge.local.json` | output artifact | `scripts/llm_judge.py`, `scripts/run_real_eval_delta.py` optional fold-in | no | yes | `REAL_EVAL_REPORT_DIR` |
+| `reports/real100_v2/traces/` | output artifact | trace/rationality judge workflows | no | yes | `REAL_EVAL_REPORT_DIR` |
 | `reports/real100_v2/judge.aggregate.json` | aggregate output artifact | `make real-eval-v2-judge`, `scripts/llm_judge.py --out-aggregate` | no | yes | `REAL100_V2_REPORT_DIR` |
 | `reports/real100_v2/judge_ragas.aggregate.json` | aggregate output artifact | `make real-eval-v2-ragas-judge`, `eval/judges/llm_judge.py --out-aggregate` | no | yes | `REAL100_V2_REPORT_DIR` |
 | `reports/real100_v2/rationality.aggregate.json` | aggregate output artifact | `make real-eval-v2-rationality-judge`, `scripts/run_rationality_judge.py` | no | yes | `REAL100_V2_REPORT_DIR` |
@@ -61,7 +61,7 @@ friendly error 로 중단해야 한다.
 - Existing private real100 index 의 metadata 가 `num_documents >= 50` 이고
   `0 < num_chunks <= 1000` 이면 stale/invalid CSV fallback index 로 표시한다.
   현재 허용 기준은 kordoc 26k급 index 다.
-- `reports/real100/eval_summary.json` 은 output artifact 다. 실행 전 required
+- `reports/real100_v2/eval_summary.json` 은 output artifact 다. 실행 전 required
   input 으로 요구하면 안 된다.
 - Baseline comparison 은 `REAL_EVAL_BASELINE_SUMMARY` 또는
   `real_eval.reports.baseline_summary` 로 명시 분리한다.

--- a/docs/rag-challenges-solved.md
+++ b/docs/rag-challenges-solved.md
@@ -1,6 +1,6 @@
 # RAG 시스템 개선 회고 — 3가지 핵심 문제와 해결
 
-> 이 문서는 BidMate-DocAgent 의 주요 RAG 개선 결정을 **STAR 형식** (Situation → Task → Action → Result) 으로 재서술한 포트폴리오 자산입니다. 모든 수치는 공개 fixture smoke 평가셋 (n=100) 기준이며, raw query·문서 원문은 [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) 경계를 준수해 포함하지 않습니다.
+> 이 문서는 BidMate-DocAgent 의 주요 RAG 개선 결정을 **STAR 형식** (Situation → Task → Action → Result) 으로 재서술한 포트폴리오 자산입니다. 모든 수치는 private internal eval 집계(historical, 100-doc 계열; raw 는 ADR 0005 경계로 미포함) 기준이며, harness 동작 확인 전용 smoke(5-case)와는 별개입니다. raw query·문서 원문은 [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) 경계를 준수해 포함하지 않습니다.
 
 ---
 
@@ -43,7 +43,7 @@ ablation 보호: `naive_baseline` preset 에는 `comparison_balance` 키가 없�
 ### Result
 
 ```
-ablation 비교 (n=100, agentic_full baseline):
+ablation 비교 (historical private internal eval, n=100, agentic_full baseline):
   no_metadata_first (balance off 대리 지표): Citation 0.679 ± 0.11
   full             (balance on):              Citation 0.905 ± 0.08
   → CI 비겹침(0.571–0.786 vs 0.821–0.976): 통계적으로 유의한 +22.6pp
@@ -126,7 +126,7 @@ answerable 중 partial:        0 → 4  (신규)
 
 Trade-off 관리: intended-abstention 4건 중 2건이 `partial` 로 오분류 → ADR 0004 에 회귀 테스트 케이스로 기록, 향후 fraction tuning 시 가이드라인으로 사용.
 
-Public fixture smoke eval (n=100): Abstention Accuracy **1.000** (naive_baseline 0.222 → agentic_full 1.000, +77.8pp). Public 에서의 완벽한 기권 정밀도가 real-data 조율의 결과.
+Private internal eval (historical n=100): Abstention Accuracy **1.000** (naive_baseline 0.222 → agentic_full 1.000, +77.8pp). 공개 smoke harness 는 5-case 확인 전용이며 이 수치와 별개. 완벽한 기권 정밀도가 real-data 조율의 결과.
 
 **포트폴리오 신호**: 실데이터 vs 합성 평가 gap 관리, config knob 설계, trade-off 를 문서화한 의사결정 이력.
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -5339,3 +5339,9 @@ make check-branch
 - Spun off from T-2026-0029 page-aware re-measurement (issue #1764). The renderer's
   new `retrieval_integrity_suspect` signal in
   `reports/real100_v2/retrieval_diagnostics.aggregate.json` points at this task.
+
+## Follow-up (from docs-real100v2-policy-alignment, 2026-06-02)
+- [ ] (E) proposed-ADR SLA backlog (~16 proposed, earliest 0050=2026-06-16) — adr-lifecycle-manager 영역, governance-cycle work. 본 docs-정렬 PR에서 해소 안 함.
+- [ ] ADR 0052 status 재분류 (Proposed vs historical) — adr-lifecycle-manager 영역. 0029도 여전히 proposed.
+- [ ] Makefile `real-eval-with-judge: real-eval` (L1442) 가 비활성 stub(exit 2)에 의존 — 코드 불일치. 별 issue/PR(원하면). docs-only scope 밖.
+- [x] PR3 ADR-index integrity (verification-only): count recompute==README, 0074 own-row==1, dead-link==0 — 2026-06-02 실측. 0편집이면 빈 PR 미개설(증거 only); 깨짐 발견 시에만 fix PR3.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

가변(mutable) 운영/온보딩 문서 6개가 금지된 legacy real100 eval 표면(`make real-eval`, `reports/real100`, `data/index/real100`, minilm/semantic stub)을 살아있는 워크플로처럼 기술해 real100→real100_v2 정책(CLAUDE.md ban-list / ADR 0005)과 모순됐다. 문서 유형별 **혼합 treatment**로 정렬: **swap-v2**(살아있는 경로/명령 → v2 등가물), **policy-pointer**(full private-eval *실행* 지시 → maintainer 전용 정책 참조), **fact-fix**(`rag-challenges-solved.md`가 n=100을 "공개 fixture smoke"로 오표기 → 공개 smoke=5-case, n=100=private internal eval historical). `multi-agent-ownership.md`에 ADR 0084 §5b 폐지 역전파. docs-only.

Closes #1805

## 2. 영향 파일

- `docs/multi-agent-ownership.md` — §5b 폐지 반영 (`make real-eval` + "5b 채움" 의무 제거, `make real-eval-delta` 권장 유지, ADR 0084 링크)
- `docs/agent-utilization.md` — L19 swap-v2(`make real-eval-v2-check`), eval-agent trigger/가이드 3곳 policy-pointer
- `docs/private-real-eval-inventory.md` — 경로행 _v2 swap + provenance regex, minilm/m3/kordoc → deprecated/removed 재라벨
- `docs/local-gold-authoring.md` — 인덱스/리포트 경로 5곳 _v2, run_eval 절차 블록 비실행화(```text) + maintainer-only canonical `make real-eval-v2-chroma` 포인터
- `docs/rag-challenges-solved.md` — n=100 라벨 fact-fix (공개 smoke→private internal eval, 한/영 양쪽)
- `docs/investigations/152-splade-colbert-feasibility.md` — 4× `make real-eval` 코드펜스 → policy-pointer (C1–C4 cell 설계 prose 보존)
- `tasks/queue.md` — deferred follow-up 3건 + PR3 verification 증거 기록

load-bearing(`scripts/_governance.py` SSoT): **없음** — `docs/adr/` 미변경, 그 외 load-bearing 경로(rag_*, ingestion, eval/, api/, build_index.py) 무관.

## 3. 리스크

가장 가능성 높은 깨짐: (a) 정책-민감 문서에서 금지 표면 잔존, (b) 새 정책-포인터 문장이 살아있는 v2 워크플로를 maintainer-only로 과차단, (c) 신규 doc dead-link. 확인: **V-1(a/b/c) grep = 0** (non-v2 `make real-eval` / banned path / "공개 smoke+n=100" 결합 전무); v2-swap 타깃은 `make real-eval-v2-check`/`-chroma`로 실제 살아있는 타깃 지정; 신규 링크(ADR 0084/0005, private-100-doc) 실파일 존재 확인.

## 4. 테스트

docs-only — 동작 변경 없음, 새 테스트 미추가. 대신 plan 검증 게이트로 보장: V-1(누출 0), V-2(policy-pointer/swap positive), V-5(코드/yaml/test 변경 0 = `git diff --name-only`가 md만). 코드 무변경이므로 기존 `bash scripts/test.sh` 회귀 없음.

## 5. Eval 영향

**All `·` (동작 변화 없음).** load-bearing path 미변경 — 문서 텍스트만 정렬. eval delta 없음, README metric sync 불필요(성능 표 미변경). private real-eval 미실행 (docs-only, 측정 대상 코드 무변경).

## 6. 하위 호환

깨짐 없음. 답변 계약/스키마/CLI flag 무관. doc link: 신규 추가 링크(ADR 0084/0005, private-100-doc-experiments) 전부 실존 확인; 기존 링크 미변경. 금지 표면→정책-포인터 전환은 문서 내용 정렬이며 외부 계약 아님.

## 7. 범위 외

- **PR2**(후속): 불변 ADR 0029/0044/0056 Status 블록에 archive/superseded 노트 (본문 immutable)
- **PR3**(조건부): ADR-index integrity 검증 — count==README / 0074 own-row==1 / dead-link==0. 0편집이면 빈 PR 미개설(`tasks/queue.md` 증거만)
- E(proposed-ADR SLA backlog), ADR 0052 status 재분류, Makefile `real-eval-with-judge` stub-dep — adr-lifecycle-manager / 별 issue 영역, `tasks/queue.md` 기록
- 금지 토큰 재발방지 CI guard 신설 — deep-interview Round 3에서 명시 제외(원하면 별 ADR)
