### PR TITLE
chore(adr): resolve 0052 in-place + fix 0062 verifies-key marker drift (E follow-up)

### DIFF
--- a/docs/adr/0052-real-eval-hardcase-expansion-to-200.md
+++ b/docs/adr/0052-real-eval-hardcase-expansion-to-200.md
@@ -107,3 +107,9 @@ ADR 0044 의 incremental trajectory 대체. real-eval 케이스 cardinality 를 
 - PR #936 — `scripts/generate_real_cases.py` LLM-assisted generator (PR-A)
 - PR #939 — `random` backend + `single_chunk` preset (PR-5a)
 - Issue #942 — 본 ADR 구현 추적
+
+## Resolution
+
+**2026-06-02 — resolved in place.** 본 ADR 의 n=21→221 hardcase 확장 결정은 `scripts/generate_real_cases.py` (PR #936) 로 구현됐고 200 hardcase 가 생성·승인됐다 (실측 200/200 auto-pass). 다만 본 ADR 이 baseline 으로 삼은 **real100 n=221 aggregate 측정표면** (`reports/real100/baseline.aggregate.json`, `data/index/real100`, `make real-eval*`) 은 이후 CLAUDE.md 의 real100→real100_v2 정책으로 **archive-only** 가 되었다 (ADR 0005 / ban-list). 후속 변별력 측정은 `real100_v2` 표면 (`reports/real100_v2`, `data/index/real100_v2`, `make real-eval-v2-*`) 에서 수행한다.
+
+단일 대체 ADR 이 없어 (`real100_v2` 는 단일 ADR 이 아닌 CLAUDE.md 정책 텍스트로 도입) `Superseded by NNNN` 대신 resolve-in-place 로 처리한다. 본문의 real100 경로·n=221 분포·generator 절차는 결정 시점 기록으로 보존하며, distinguishing-power 측정 의도 자체는 real100_v2 가 계승한다. Status 는 historical 기록 보존을 위해 `Proposed` 로 둔다 — governance collector 가 본 `## Resolution` H2 로 SLA 해소(resolved_in_place)를 인식한다.

--- a/docs/adr/0062-failure-rate-regression-contract.md
+++ b/docs/adr/0062-failure-rate-regression-contract.md
@@ -113,7 +113,7 @@ production code path 변경 없음 (`rag_*.py`, `api/`, `eval/config.yaml`
 
 <!-- verifies-key: tests/test_failure_rate_regression.py:CEILING_RATE_BY_CATEGORY -->
 <!-- verifies-key: tests/test_failure_rate_regression.py:def test_gated_category_rates_under_ceiling -->
-<!-- verifies-key: tests/test_failure_rate_regression.py:def test_adr_0059_first_match_contract -->
+<!-- verifies-key: tests/test_failure_rate_regression.py:def test_adr_0075_first_match_contract -->
 <!-- verifies-key: docs/operations/failure-mode-harden-process.md:monotone-harden -->
 <!-- verifies-key: scripts/_governance.py:def ceiling_ratchet_violations -->
 <!-- verifies-key: scripts/check_branch_and_issue.py:def check_ceiling_ratchet_mode -->

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -5341,7 +5341,8 @@ make check-branch
   `reports/real100_v2/retrieval_diagnostics.aggregate.json` points at this task.
 
 ## Follow-up (from docs-real100v2-policy-alignment, 2026-06-02)
-- [ ] (E) proposed-ADR SLA backlog (~16 proposed, earliest 0050=2026-06-16) — adr-lifecycle-manager 영역, governance-cycle work. 본 docs-정렬 PR에서 해소 안 함.
-- [ ] ADR 0052 status 재분류 (Proposed vs historical) — adr-lifecycle-manager 영역. 0029도 여전히 proposed.
+- [x] (E) proposed-ADR SLA backlog — 2026-06-02 처리 (promote PR #1810 + lifecycle issue #1811). OVER_SLA=0 측정 후 구현완료+검증된 11 ADR promote: 0060/0063/0064/0066/0067/0069/0082/0093/0094/0096/0097 (proposed→accepted). keep-open 잔여: staging-trilogy 0088/0090/0091(e2e 전 accepted 불가) + deferred 0061/0092/0095 + 0050 + 0062(아래 lint-fix). grandfathered 5건(pre-2026-05-15) SLA 면제.
+- [x] ADR 0052 status 재분류 — 2026-06-02 resolve-in-place (issue #1811). real100_v2 정책으로 n=221 측정표면 archive-only → `## Resolution` H2 추가. Status Proposed 유지(historical 보존), collector resolved_in_place 인식, 단일 대체 ADR 부재로 `Superseded by` dangling 회피. 0029는 0044 supersession chain의 historical proposed로 keep-open.
+- [x] ADR 0062 verifies-key 마커 drift 정정 — 2026-06-02 (issue #1811). line 116 마커 `test_adr_0059_first_match_contract`→`test_adr_0075_first_match_contract`(first-match 계약 0059→0075 재명명, 실제 함수명). lint-fail 해소; 본문 historical 산문 보존.
 - [ ] Makefile `real-eval-with-judge: real-eval` (L1442) 가 비활성 stub(exit 2)에 의존 — 코드 불일치. 별 issue/PR(원하면). docs-only scope 밖.
 - [x] PR3 ADR-index integrity (verification-only): count recompute==README, 0074 own-row==1, dead-link==0 — 2026-06-02 실측. 0편집이면 빈 PR 미개설(증거 only); 깨짐 발견 시에만 fix PR3.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

proposed-ADR SLA backlog(E) 마무리. promote PR #1810(11 ADR proposed→accepted) 머지 후 잔여 lifecycle 2건 + task queue 갱신을 한 PR로 처리. 둘 다 governance 정합 작업이며 동작(코드 경로) 변경은 없다.

Closes #1811

## 2. 영향 파일

- `docs/adr/0052-real-eval-hardcase-expansion-to-200.md` *(load-bearing: docs/adr)* — `## Resolution` H2 append (pure additive, 본문 결정 산문 0 삭제)
- `docs/adr/0062-failure-rate-regression-contract.md` *(load-bearing: docs/adr)* — `verifies-key` 마커 1줄 정정
- `tasks/queue.md` — E 후속 블록 갱신

## 3. 리스크

- **가장 가능성 높은 깨짐**: (a) 0052 `## Resolution`을 collector가 인식 못해 SLA 신호 잔존, (b) 0062 마커가 또 다른 stale 함수명을 가리켜 lint 실패, (c) Status↔README 불일치.
- **배제 확인**: `--proposed-adr-age`가 `0052 ... resolved_in_place` + `OVER_SLA=0`로 출력(인식 ✓); `--lint-adr-consequences docs/adr/0062-*.md` rc=0(마커가 실존 함수 `test_adr_0075_first_match_contract`와 lockstep); `--check-adr-readme-status` rc=0(Status 두 ADR 모두 Proposed 유지 → README row 정합).

## 4. 테스트

동작 변경이 아니라 governance lint/SLA 정합 + 마커 lockstep 정정이므로 신규 테스트 없음. 대신 기존 게이트로 검증:
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0062-failure-rate-regression-contract.md` → **rc=0**
- `python3 scripts/_governance.py --proposed-adr-age` → **OVER_SLA=0, 0052 resolved_in_place 1건**
- `python3 scripts/_governance.py --check-adr-readme-status` → **rc=0**
- `pytest -q tests/test_failure_rate_regression.py` → **5 passed** (0062 마커 타깃 `test_adr_0075_first_match_contract` 포함 green)

## 5. Eval 영향

**동작 변화 없음 (real-data 영향 0).** load-bearing `docs/adr/`를 손댔으나:
- ADR 0052는 결정 산문에 `## Resolution`을 append할 뿐 측정 코드·baseline aggregate·eval config 미터치. n=221 측정표면이 real100_v2 정책으로 archive-only가 된 *사실을 기록*하는 것이지 측정 동작을 바꾸지 않음.
- ADR 0062는 `verifies-key` 마커 1줄을 실제 테스트 함수명과 일치시키는 정정 (테스트 코드·ceiling 소스 미터치).
- `rag_*`, `ingestion`, `eval/`, `api/`, `scripts/build_index.py` 전부 미변경.

→ real-eval 미실행 (코드 경로 무변경이라 델타 정의상 0).

## 6. 하위 호환

영향 없음. ADR 0003 답변 계약·`schema_version` 무관. 두 ADR Status는 `Proposed` 유지(0052는 resolve-in-place로 historical 기록 보존, governance collector가 SLA 해소 인식). 0062 본문의 historical "ADR 0059 first-match" 산문도 보존 — 기계 판독 마커만 0075로 lockstep.

## 7. 범위 외

- keep-open ADR 8건(0050/0061/0062-now-lint-clean/0088/0090/0091/0092/0095): staging-trilogy는 e2e 전 accepted 불가, deferred는 자연 SLA revisit(6/9–6/16) 대기.
- `Makefile` `real-eval-with-judge: real-eval`(L1442)가 비활성 stub에 의존하는 코드 불일치 — 별도 issue/PR 후보(queue에 [ ]로 남김), docs-only scope 밖.