### PR TITLE
feat(agent-loop): omc multi-worker default-on with per-worker diff capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,15 @@ ACTIVE_GLOBAL_CONCURRENCY ?= 8
 export ACTIVE_GLOBAL_CONCURRENCY
 BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY ?= $(ACTIVE_GLOBAL_CONCURRENCY)
 export BIDMATE_AGENT_LOOP_GLOBAL_CONCURRENCY
+# ADR 0095 PR-D: best-effort cap on the worker count the omc runner requests of `omc team`
+# (Y default-on, omc path only). Default 3; fail-closed cap<=0 -> 1. The runtime read path is
+# os.getenv("OMC_MAX_WORKERS") directly (no bridge var needed — the code reads this exact name),
+# but a direct OMC_MAX_WORKERS already in the env still wins (via ?=). The effective worker
+# total is min(OMC_MAX_WORKERS, --max-parallel); omc is out-of-process so this is best-effort
+# (the global semaphore charges the single omc launch one permit, not each omc worker). Affects
+# the omc runner path ONLY — the default codex runner is byte-identical (ADR 0001).
+OMC_MAX_WORKERS ?= 3
+export OMC_MAX_WORKERS
 # ADR 0085: 0 == unlimited. The per-session command cap is dropped on the operator front
 # door so the autonomous loop is bounded by timeout + attempt/queue + safety guards, not an
 # arbitrary command count. Set a positive value to re-impose a cap.

--- a/docs/adr/0087-opt-in-omc-team-parallel-runner.md
+++ b/docs/adr/0087-opt-in-omc-team-parallel-runner.md
@@ -312,9 +312,18 @@ OMC의 `omc team`은 **진짜 동시** tmux worker를 per-worker git-worktree �
 
 ## Deferred / follow-up
 
-- **multi-worker diff 캡처/머지 보류.** worker 브랜치가 여럿일 때의 diff 합성 + 충돌 해소는
-  본 ADR 범위 밖이다. `_resolve_omc_worker_mix`가 총 worker=1을 강제하므로 현재 절대 다수
-  worker가 launch되지 않는다. 구현 완료 시 `_resolve_omc_worker_mix` 수정 + 이 ADR 업데이트.
+- **multi-worker diff 캡처/머지 — PR-D(#1804)에서 구현됨([ADR 0095](./0095-task-parallel-bounded-loop.md)).**
+  본 ADR 의 single-worker pin(`_resolve_omc_worker_mix`의 `total_workers=1` + `assert ... == 1`)은
+  ADR 0095 PR-D 가 **부분 supersede** 한다 — worker-count 결정만 번복되고, 본 ADR 의 거버넌스/ack
+  기계(ack fail-closed, no-auto-merge, privacy 재감사, scope 재부과, gate 라우팅)는 그대로 유지된다.
+  구현: `_resolve_omc_worker_mix`가 `read_agent="auto"`에서 agent_mix weight 를 worker 수로 매핑하고
+  `min(OMC_MAX_WORKERS, max_parallel)`로 clamp(explicit `claude`/`codex` override 는 single lane 유지).
+  per-worker diff 는 worker 별 merge-base→`add -A`→`diff --cached`로 캡처해 각
+  `omc_runs/omc-team/worker-{idx}/patch_artifact.json` namespace 에 privacy+scope 재감사 후 기록.
+  **fail-closed 집계**: 어느 worker 라도 캡처/재감사 실패 시 전체 run blocked(부분 성공 없음).
+  **정본 정책**: N==1 + 전 검사 통과는 본 ADR 의 표준 경로 proposed 기록과 byte-identical;
+  N>1 + 전 검사 통과는 표준 active-apply 경로를 "needs human selection" blocked artifact 로 라우팅
+  (per-worker proposed 는 보존, 자동 승격은 PR-D non-goal). **NO auto-merge** 불변.
 - **`_OMC_ENV_ALLOWLIST` 확장.** omc/tmux 런타임이 추가 환경 변수를 요구하면 허용리스트에
   추가 (단, 자격증명·토큰 류는 추가 금지).
 

--- a/docs/adr/0095-task-parallel-bounded-loop.md
+++ b/docs/adr/0095-task-parallel-bounded-loop.md
@@ -27,13 +27,32 @@ XYZ 병렬화를 도입하되 **X 는 default-dark(기본 X=1)**, **Y 는 defaul
 온다. `EXECUTE_SHIP=0`(ADR 0083) human-gated ship 은 불변이다.
 
 - **Y (omc multi-worker) default-on**: `_resolve_omc_worker_mix` 의 `total_workers=1` 핀 +
-  `assert ... == 1` 을 제거한다. worker 수는 agent_mix 정책에서 도출하되 `OMC_MAX_WORKERS`(기본
-  ≤3) ∧ M 으로 clamp 한다. [ADR 0087](./0087-opt-in-omc-team-parallel-runner.md) 이 미룬
+  `assert ... == 1` 을 제거한다(PR-D, #1804). worker 수는 agent_mix 정책에서 도출하되
+  `OMC_MAX_WORKERS`(기본 ≤3) ∧ M 으로 clamp 한다. **explicit `--read-agent claude`/`codex` override 는
+  single lane 유지**(`auto` 만 fan-out). [ADR 0087](./0087-opt-in-omc-team-parallel-runner.md) 이 미룬
   **multi-worker per-worker diff 캡처** 를 빌드하되 **NO auto-merge** 를 유지한다(캡처된 diff 는
   privacy 재감사 + scope 재부과 + 기존 active-apply / Conservative Gate / human-gated ship 으로만
-  라우팅 — main 미머지). 이미 ack-gated 된 `runner=omc` 경로에 **한정** 되므로 기본 `make 시작`
-  (codex runner)은 영향받지 않는다. omc 의 단일 기존 ack(`ACTIVE_OMC_RUNNER_ACK=1`)은 maintainer
-  결정에 따라 **N-fold egress 에 대한 consent** 로 수용한다.
+  라우팅 — main 미머지).
+  - **per-worker 캡처 + fail-closed 집계**: 각 worker 의 worktree 에서 merge-base→`git add -A`→
+    `git diff --cached`(ADR 0087 round-6/8/10 fix 시퀀스)로 diff 를 캡처해
+    `omc_runs/omc-team/worker-{idx}/patch_artifact.json` namespace 에 privacy+scope 재감사 후 기록한다.
+    어느 worker 라도 (a) merge-base 실패, (b) `add -A` 실패, (c) diff 실패, (d) privacy 위반,
+    (e) scope 위반 시 **전체 run blocked**(부분 성공 허용 금지; blocker 에 worker idx 기록).
+  - **정본(canonical) 정책**: **N==1 + 전 검사 통과** 는 표준 active-apply 경로
+    (`patch_runs/implementer/patch_artifact.json`)에 proposed 기록 — [ADR 0087](./0087-opt-in-omc-team-parallel-runner.md)
+    single-worker 동작과 **byte-identical**(worker-N namespace 미생성). **N>1 + 전 검사 통과** 는 표준
+    경로를 **"needs human selection" blocked artifact** 로 라우팅(active-apply 자동 소비 차단)하고
+    per-worker namespace 에 각 proposed 를 보존한다 — human 이 수동으로 하나를 표준 경로로 승격한다.
+    **자동 승격(auto-promotion)은 PR-D non-goal**(캡처 + 안전 라우팅까지만).
+  - **OMC_MAX_WORKERS ∧ M 은 best-effort cap**: `omc team` 은 단일 out-of-process subprocess 라
+    전역 semaphore(M)는 그 launch 에 **1 permit 만** 부과한다 — out-of-process omc worker 수를 in-process
+    semaphore 가 hard-enforce 하지 못한다. `OMC_MAX_WORKERS` 는 runner 가 요청하는 mix_spec worker
+    총수의 best-effort cap 이며, 잔여 N-fold egress 는 ack(`ACTIVE_OMC_RUNNER_ACK=1`)가 수용한다.
+  이미 ack-gated 된 `runner=omc` 경로에 **한정** 되므로 기본 `make 시작`(codex runner)은 영향받지 않는다.
+  omc 의 단일 기존 ack(`ACTIVE_OMC_RUNNER_ACK=1`)은 maintainer 결정에 따라 **N-fold egress 에 대한
+  consent** 로 수용한다. 전역 kill-switch `BIDMATE_AGENT_LOOP_PARALLELISM_KILL=1` 는 PR-D 에서
+  omc-scope 로 도입되어(`_resolve_omc_worker_mix`를 single worker 로 강등) 켜질 때 multi-worker 를
+  즉시 직렬 강등한다; X-task-pool 강등은 PR-E.
 - **X (task pool) DEFAULT X=1 (dark)**: 루프 body 를 `run_one_task` 로 refactor 하고
   `ThreadPoolExecutor` + locked `claim_next_task`(다음 task 선택을 atomic 하게)로 묶는다. race-free
   completed-count, convergent stop(#1719 teardown 재사용), per-task artifact namespacing(동시 task
@@ -81,6 +100,25 @@ completion(마지막 완료 이후 누적된 blocker)" 으로 재정의한다.
 - omc multi-worker 의 외부 egress 증폭은 best-effort 로 `OMC_MAX_WORKERS`(기본 ≤3) ∧ M 에 의해
   bounded 된다 — out-of-process worker 라 hard enforce 는 불가하며, 그 한계는 기존 ADR 0087 ack
   gate 와 ADR 0005/0061 데이터-경계가 보완한다(N-fold egress 는 ack consent 로 수용).
+- **per-worker 캡처 + fail-closed(PR-D, #1804)**: 각 worker diff 가 자체 worktree 에서 캡처되어
+  worker 별 privacy+scope 재감사를 통과해야만 per-worker artifact 로 이어진다. 어느 worker 라도
+  실패 시 전체 run 이 blocked 되어(부분 성공 없음) 한 worker 의 누출/범위이탈이 다른 worker 의
+  proposed 와 함께 active-apply 로 새지 않는다.
+- **정본 라우팅(PR-D)**: N==1 + 전 검사 통과는 ADR 0087 single-worker 경로와 byte-identical 하게
+  표준 active-apply 경로에 proposed 를 기록한다(worker-N namespace 미생성). N>1 + 전 검사 통과는
+  표준 경로가 "needs human selection" blocked artifact 가 되어 active-apply 자동 소비가 차단되고,
+  per-worker proposed 는 보존된다. **자동 승격은 의도적 non-goal** — human 이 정확히 하나를 표준
+  경로로 승격한다(NO auto-merge 불변).
+- **kill-switch omc-scope(PR-D)**: `BIDMATE_AGENT_LOOP_PARALLELISM_KILL=1` 가 `_resolve_omc_worker_mix`
+  를 single worker(`auto`→majority lane 1; explicit override 존중)로 강등한다 — 코드 revert 없이
+  multi-worker 를 즉시 끈다. X-task-pool 강등은 PR-E 에서 같은 env 로 확장된다.
+- **stale worker-* 증거 격리(PR-D, codex round-2/3 fix)**: stale `worker-{idx}/patch_artifact.json`
+  eviction 은 `_run_omc_team_runner` **함수 초입**(`execute=True` 가드)에서 모든 pre-launch
+  early-return 앞에 실행된다(이전에는 team-launch 직전에 위치해 no-ack / task-scope /
+  assignment / privacy pre-launch blocked early-return 이 eviction 을 우회했다). `execute=False`
+  (dry-run)는 round-9 fix #2 read-only 불변에 따라 제외. **eviction 실패는 warning-only 가 아니라
+  fail-closed**: `rmtree` 실패 시 stale artifact 를 in-place blocked 로 overwrite(blocked 는
+  apply-ineligible); overwrite 도 실패하면 run 을 blocked early-return(blocker 에 "fail-closed" 기록).
 - 가드-semantics 변경이 문서화된다 — consecutive-blocker 가 "since last completion" 으로 재정의
   되고, wall-clock 은 per-task budget 으로 재표현된다. exit-code 가드 SEMANTICS 는 보존.
 - redaction-scan per-task scoping 이 요구된다 — `_redact_active_*` glob 이 동시 task 를 교차
@@ -89,6 +127,15 @@ completion(마지막 완료 이후 누적된 blocker)" 으로 재정의한다.
   대신 invariant-based 테스트로 검증한다.
 - `EXECUTE_SHIP=0`(ADR 0083) 불변, X=1/M=8 byte-identical(ADR 0001), `agent_loop.py`
   `LOAD_BEARING_PATHS` 비승격 유지.
+- **pre-existing: `agent_loop` privacy redaction 이 `reports/real100/` 만 매치하고
+  `real100_v2*` 를 포함하지 않는다.** PR-D diff 밖(pre-existing) — 별도 follow-up issue 로 추적 권장.
+- **PR-D 한정 알려진 미결: artifact race + teardown-중 permit 조기 release(X=1 dark라 무해).**
+  `_finalize_omc_runner_result`(artifact write + heartbeat invalidation)와 teardown(shutdown)이
+  `global_concurrency_limiter().slot()` **밖**에서 실행된다. 모든 omc run 이 공유하는 단일 표준
+  경로(`patch_runs/implementer/patch_artifact.json`)가 있기 때문에 X>1 동시 omc run에서 artifact
+  last-writer-wins race 가 발생하고, teardown 진입 시점에 이미 permit 이 반환된 상태다. PR-D 는
+  X=1 dark 이므로 동시 omc run 이 없어 무해하다. PR-E 의 per-task artifact namespacing +
+  publication fence 가 slot-scope 를 확장하고 standard-path race 를 닫는다(X-enable 은 PR-F 전제).
 
 ## Verification
 

--- a/docs/plans/xyz-parallelism-stack.md
+++ b/docs/plans/xyz-parallelism-stack.md
@@ -242,6 +242,19 @@ PR-E 에서 기본 1 → PR-F 에서 2 로 flip 하므로, 회귀 시 X=1 으로
 - **Failure mode**: two-lock + semaphore deadlock(ledger lock × lease lock × semaphore).
   - Detection signal: hang. Stop condition or fallback: **strict lock ordering**(semaphore 를
     lock 바깥에서 acquire) + bounded acquire timeout.
+- **Failure mode (PR-D 해소됨): stale worker-* artifacts from prior N>1 run — false human promotion**.
+  `_run_omc_team_runner` 의 stale eviction 이 team-launch 직전에 위치하면 no-ack / task-scope /
+  pre-launch blocked early-return 이 eviction 을 우회해 prior run 의 proposed `worker-{idx}/
+  patch_artifact.json` 이 disk 에 잔존 — human 이 오래된 proposed 를 promote 할 수 있다. 해소:
+  eviction 을 **함수 초입(`execute=True` 가드)**으로 이동해 모든 early-return 앞에 실행. dry-run
+  (`execute=False`)은 round-9 fix #2 read-only 불변으로 제외.
+- **Failure mode (PR-D 한정, X=1 dark 동안 무해): artifact race + teardown-중 permit 조기 release**.
+  `_finalize_omc_runner_result`(artifact write + heartbeat invalidation)와 teardown(shutdown)이
+  `global_concurrency_limiter().slot()` 밖에서 실행된다. 모든 omc run 이 공유하는 단일 표준
+  경로(`patch_runs/implementer/patch_artifact.json`)에서 X>1 동시 omc run 시 last-writer-wins
+  race 가 발생하고, teardown 진입 전에 permit 이 이미 반환된다. PR-D 는 X=1 dark 이므로 동시
+  omc run 이 없어 **무해**하다. PR-E 의 per-task artifact namespacing + publication fence 가
+  slot-scope 를 확장하고 standard-path race 를 닫는다(X-enable 은 PR-F 전제).
 
 ## Observability
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1164,6 +1164,47 @@ def global_concurrency_limiter() -> GlobalConcurrencyLimiter:
     return limiter
 
 
+DEFAULT_OMC_MAX_WORKERS = 3
+OMC_MAX_WORKERS_ENV = "OMC_MAX_WORKERS"
+
+
+def _resolve_omc_max_workers(raw: str | None = None) -> int:
+    """Resolve the omc multi-worker cap (ADR 0095 PR-D, Y default-on). env
+    OMC_MAX_WORKERS overrides DEFAULT (3). Unset / blank / non-int -> DEFAULT (3).
+    fail-closed: a parsed value <=0 clamps to 1 (the cap must never be 0/unbounded
+    by misconfig). Byte-for-byte mirror of ``_resolve_global_concurrency``.
+
+    NOTE: this is a BEST-EFFORT cap on the worker-count the runner *requests* of
+    ``omc team``. ``omc team`` is a single out-of-process subprocess, so the in-process
+    global semaphore (M) charges its launch ONE permit and cannot hard-enforce the count
+    of the out-of-process omc workers it spawns. The cap bounds the mix_spec the runner
+    builds; the residual N-fold egress is acknowledged by the ACTIVE_OMC_RUNNER_ACK gate
+    (ADR 0087) and bounded best-effort by this knob ∧ M (ADR 0095)."""
+    source = os.getenv(OMC_MAX_WORKERS_ENV) if raw is None else raw
+    if source is None or not str(source).strip():
+        return DEFAULT_OMC_MAX_WORKERS
+    try:
+        value = int(str(source).strip())
+    except ValueError:
+        return DEFAULT_OMC_MAX_WORKERS
+    return value if value >= 1 else 1  # fail-closed: cap<=0 -> 1
+
+
+# Global parallelism kill-switch (ADR 0095). When truthy, every parallel branch is
+# forced down to a serial / single-worker path regardless of the other knobs. PR-D
+# introduces the skeleton at omc-scope (forces _resolve_omc_worker_mix to a single
+# worker); the X-task-pool demotion is wired in PR-E.
+PARALLELISM_KILL_ENV = "BIDMATE_AGENT_LOOP_PARALLELISM_KILL"
+
+
+def _parallelism_kill_enabled() -> bool:
+    """True when the operator set the global parallelism kill-switch to a truthy value.
+
+    Reuses the brick-C / ack resolver truthy判정 pattern ("1"/"true"/"yes"/"on",
+    case-insensitive) so all parallelism knobs agree on what "on" means."""
+    return os.environ.get(PARALLELISM_KILL_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _normalize_field(label: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", label.lower())
 
@@ -13359,23 +13400,37 @@ def _build_omc_env(base_env: dict[str, str]) -> dict[str, str]:
 def _resolve_omc_worker_mix(
     *,
     registry_payload: dict[str, object],
-    selected_count: int,
+    selected_count: int,  # NOTE: dead param — fan-out is task-count independent (redundant-attempt model); kept for API compat until PR-E
     max_parallel: int,
-    repo_root: Path,
+    repo_root: Path,  # NOTE: dead param — reserved for future per-host scaling; kept for API compat
     read_agent: str = "auto",
 ) -> tuple[int, int]:
     """Resolve (claude_workers, codex_workers) for the omc team from the agent_mix policy.
 
-    SINGLE-WORKER ONLY (ADR 0087 fix #2): per-worker diff capture and merge across multiple
-    worker worktrees (conflict resolution across worker branches) is deferred to a follow-up.
-    Until that path is implemented, only ONE worker is ever launched — launching more would
-    silently discard all but the leader-worker diff, multiplying the ADR 0005 exposure for
-    no captured benefit.
+    MULTI-WORKER (ADR 0095 PR-D, Y default-on — partially supersedes the ADR 0087 fix #2
+    single-worker pin). ``read_agent`` explicit overrides stay a SINGLE lane; only ``"auto"``
+    fans out to multiple workers. The total is capped at ``min(_resolve_omc_max_workers(),
+    max_parallel)`` and is always at least 1 (fail-closed). The ADR 0087 governance machinery
+    (ack fail-closed, no-auto-merge, per-worker privacy re-audit, scope re-imposition, gate
+    routing) is UNCHANGED — only the worker-count decision is reversed.
 
-    ``read_agent``: explicit agent override. ``"claude"`` → ``(1, 0)``, ``"codex"`` → ``(0, 1)``,
-    ``"auto"`` falls back to the agent_mix policy majority (higher weight wins; ties → claude).
+    ``read_agent``: explicit agent override stays single-lane. ``"claude"`` → ``(1, 0)``,
+    ``"codex"`` → ``(0, 1)``. ``"auto"`` maps the agent_mix claude/codex weights to worker
+    counts: a 0-weight lane gets 0 workers; when both are positive the cap is split
+    weight-proportionally (rounded), scaled down if the rounded sum exceeds the cap, and
+    given to the majority lane (ties → claude) if the rounded sum is 0.
+
+    NOTE — BEST-EFFORT cap: ``OMC_MAX_WORKERS`` bounds the worker count this runner *requests*
+    in the ``omc team N:claude,M:codex`` mix_spec. ``omc team`` is a single out-of-process
+    subprocess; the in-process global semaphore (M) charges its launch ONE permit and cannot
+    hard-enforce the out-of-process worker count. The residual N-fold egress is acknowledged by
+    the ACTIVE_OMC_RUNNER_ACK gate (ADR 0087) and bounded best-effort by this cap ∧ M (ADR 0095).
+
+    Kill-switch (ADR 0095): when ``BIDMATE_AGENT_LOOP_PARALLELISM_KILL`` is truthy the result is
+    forced to a single worker (explicit read_agent honored; ``"auto"`` → majority lane 1).
     """
-    # Explicit --read-agent override takes priority over agent_mix policy.
+    kill = _parallelism_kill_enabled()
+    # Explicit --read-agent override takes priority over agent_mix policy; always single-lane.
     if read_agent == "claude":
         return 1, 0  # 1:claude (explicit)
     if read_agent == "codex":
@@ -13384,10 +13439,36 @@ def _resolve_omc_worker_mix(
     target = policy.get("target") if isinstance(policy.get("target"), dict) else {}
     claude_weight = _coerce_wu(target.get("claude"))
     codex_weight = _coerce_wu(target.get("codex"))
-    # Force total_workers = 1: pick the higher-weight lane (ties → claude).
-    if claude_weight >= codex_weight:
-        return 1, 0  # 1:claude
-    return 0, 1  # 1:codex
+    # Kill-switch: force a single worker on the majority lane (ties → claude).
+    if kill:
+        return (1, 0) if claude_weight >= codex_weight else (0, 1)
+    # Cap = min(OMC_MAX_WORKERS, max_parallel), fail-closed to at least 1.
+    cap = max(1, min(_resolve_omc_max_workers(), max_parallel))
+    # A 0-weight lane gets 0 workers.
+    if claude_weight <= 0 and codex_weight <= 0:
+        # No positive weight at all — fall back to a single majority lane (ties → claude).
+        return 1, 0
+    if codex_weight <= 0:
+        return cap, 0  # claude-only
+    if claude_weight <= 0:
+        return 0, cap  # codex-only
+    # Both lanes positive: split the cap weight-proportionally (rounded), then clamp the
+    # rounded sum to the cap. round() is deterministic for the integer-weighted inputs here.
+    total_weight = claude_weight + codex_weight
+    claude_workers = round(cap * claude_weight / total_weight)
+    codex_workers = round(cap * codex_weight / total_weight)
+    over = (claude_workers + codex_workers) - cap
+    if over > 0:
+        # Rounding overshot the cap — trim from the smaller lane first (ties → trim codex so
+        # the majority/tie lane keeps its share, consistent with the ties → claude rule).
+        if claude_workers >= codex_workers:
+            codex_workers = max(0, codex_workers - over)
+        else:
+            claude_workers = max(0, claude_workers - over)
+    if claude_workers + codex_workers == 0:
+        # Rounded everything to 0 (cap=1 with near-equal weights) — give the majority lane 1.
+        return (1, 0) if claude_weight >= codex_weight else (0, 1)
+    return claude_workers, codex_workers
 
 
 def _run_omc_team_runner(
@@ -13436,9 +13517,14 @@ def _run_omc_team_runner(
       * always tears the team down (``omc team shutdown <team>``) in a finally block; and
       * never raises on omc failure (returns a blocked result with the failure recorded).
 
-    Scope: the single-worker capture path is implemented fully. Capturing + merging diffs
-    from >1 worker worktree (conflict resolution across worker branches) is a deliberate
-    follow-up — logged as a warning when the resolved team has multiple workers.
+    Scope (ADR 0095 PR-D): per-worker diff capture is implemented for N>=1 workers. Each
+    worker's diff is captured + re-audited (privacy + scope) into its own
+    ``omc_runs/omc-team/worker-{idx}/patch_artifact.json`` namespace. N==1 + all-pass keeps the
+    byte-identical single-worker canonical routing (standard path gets the proposed). N>1 +
+    all-pass routes the standard active-apply path to a ``needs-human-selection`` blocked
+    artifact (a human promotes exactly one per-worker proposal — automatic promotion is a
+    deliberate non-goal). Any worker failing capture or re-audit blocks the WHOLE run
+    (fail-closed; no partial success). NO ``--auto-merge`` is ever passed.
     """
     now = now or datetime.now(timezone.utc)
     blockers: list[str] = []
@@ -13451,6 +13537,72 @@ def _run_omc_team_runner(
     omc_runs_path = runs_path.parent / "omc_runs"
     run_dir = omc_runs_path / session_id
     artifact_path = run_dir / "patch_artifact.json"
+    # HIGH-3 (codex round-2 fix): evict stale worker-* artifacts at function entry, BEFORE any
+    # early-return, so EVERY execute=True path (no-ack, task-scope ambiguity, assignment missing,
+    # privacy/scope pre-launch blocked, AND the normal launch path) starts from a clean slate.
+    # Prior placement at the team-launch site (after run_dir.mkdir) was fail-open: pre-launch
+    # blocked early-returns bypassed it, leaving prior N>1 all-pass proposed worker-* on disk.
+    #
+    # FAIL-CLOSED (codex round-3): rmtree failure is NOT warning-only.  If rmtree fails, we
+    # neutralize the stale proposed artifact in-place by overwriting it with a blocked artifact
+    # (a blocked artifact is never apply-eligible).  If neutralize also fails, we add a
+    # fail-closed blocker so the run cannot proceed with a surviving proposed worker artifact.
+    # After the loop, a non-empty blockers list causes an early-return (see immediately below).
+    #
+    # dry-run (execute=False) is read-only (round-9 fix #2 invariant) and intentionally excluded:
+    # the worker-* present during a dry-run are a prior EXECUTED run's product (every execute run
+    # evicts here first, so the on-disk set always reflects the latest executed run); dry-run is
+    # not a promotion action, and the next executed run will evict before writing new ones.
+    if execute and run_dir.exists():
+        for _stale_wdir in sorted(run_dir.glob("worker-*")):
+            _stale_art = _stale_wdir / "patch_artifact.json"
+            try:
+                shutil.rmtree(_stale_wdir)
+            except Exception as _clean_exc:
+                # rmtree failed — neutralize the stale proposed artifact in-place so it can
+                # never be promoted (a blocked artifact is not apply-eligible).  If neutralize
+                # ALSO fails, record a fail-closed blocker so the run cannot proceed to launch
+                # with a surviving proposed worker artifact.
+                try:
+                    if _stale_art.exists():
+                        _write_blocked_omc_artifact(
+                            _stale_art, session_id=session_id, team_name=team_name, now=now
+                        )
+                    warnings.append(
+                        f"could not remove stale omc worker dir {_stale_wdir} ({_clean_exc}); "
+                        "neutralized its artifact to blocked"
+                    )
+                except Exception as _neut_exc:
+                    blockers.append(
+                        f"stale omc worker artifact at {_stale_art} could not be evicted "
+                        f"({_clean_exc}) nor neutralized ({_neut_exc}); fail-closed"
+                    )
+    if blockers:
+        return _finalize_omc_runner_result(
+            decision="blocked",
+            execute=execute,
+            session_id=session_id,
+            verdict="blocked",
+            blockers=blockers,
+            warnings=warnings,
+            team_name=team_name,
+            command_display=omc_command_display,
+            state_path=state_path,
+            out_path=out_path,
+            registry_path=registry_path,
+            assignments_path=assignments_path,
+            runs_path=omc_runs_path,
+            artifact_path=artifact_path,
+            diff_text="",
+            task_id=task_id,
+            model=model,
+            repo_root=repo_root,
+            now=now,
+            write_artifact=False,
+            invalidate_heartbeats=False,  # eviction-blocked: no omc team ran
+        )
+    # Per-worker captured diffs (ADR 0095 PR-D); populated by the capture loop on success.
+    omc_worker_diffs: list[dict[str, object]] = []
 
     # (2) Fail-closed data-boundary gate. NEVER spawn omc without the explicit ack.
     if not _omc_runner_ack_enabled():
@@ -13615,8 +13767,11 @@ def _run_omc_team_runner(
         repo_root=repo_root,
         read_agent=read_agent,
     )
-    # _resolve_omc_worker_mix enforces total_workers=1 (multi-worker diff capture deferred).
-    assert claude_workers + codex_workers == 1, "invariant: omc runner only launches 1 worker"
+    # ADR 0095 PR-D: the worker mix may now be multi-worker (Y default-on). The total is
+    # always >= 1 (fail-closed in _resolve_omc_worker_mix). The canonical-diff routing below
+    # treats N==1 (byte-compat) and N>1 (per-worker capture + needs-human-selection) distinctly.
+    total_workers = claude_workers + codex_workers
+    assert total_workers >= 1, "omc runner must launch at least 1 worker"
 
     # (3) Build the privacy-scrubbed task text from the selected session assignments. The
     # task text crosses the ADR 0005 boundary into uncontrolled omc workers (network-capable),
@@ -13759,146 +13914,157 @@ def _run_omc_team_runner(
             return None
         return max(1.0, deadline - _time.monotonic())
 
+    # (D4 semaphore) Charge the single out-of-process omc launch ONE global permit. The poll
+    # loop + per-worker diff capture stay inside the SAME slot (the launch is one logical CLI
+    # spawn; omc fans out its own workers out-of-process — the in-process M cannot charge those
+    # individually, hence the OMC_MAX_WORKERS best-effort cap). Lock-ordering: the omc path holds
+    # no flock (no LeaseManager / LedgerState lock), so acquiring the semaphore here satisfies the
+    # ADR 0094 ordering (semaphore acquired with no lock held). The ``with`` releases the permit
+    # on EVERY exit (success or exception) BEFORE the except/finally teardown runs.
     try:
-        # Launch the team. NO ``--auto-merge`` is ever in ``omc_command``.
-        launch = run(omc_command, cwd=repo_root, env=omc_env, timeout=_remaining_budget())
-        if getattr(launch, "returncode", 1) != 0:
-            blockers.append(f"omc team launch failed (rc={getattr(launch, 'returncode', 'unknown')})")
-        team_name = _parse_omc_team_name(str(getattr(launch, "stdout", "") or ""))
-        if not team_name and not blockers:
-            warnings.append("omc team launch did not report a team name; using default poll target")
-            team_name = "active"
+        with global_concurrency_limiter().slot():
+            # Launch the team. NO ``--auto-merge`` is ever in ``omc_command``.
+            launch = run(omc_command, cwd=repo_root, env=omc_env, timeout=_remaining_budget())
+            if getattr(launch, "returncode", 1) != 0:
+                blockers.append(f"omc team launch failed (rc={getattr(launch, 'returncode', 'unknown')})")
+            team_name = _parse_omc_team_name(str(getattr(launch, "stdout", "") or ""))
+            if not team_name and not blockers:
+                warnings.append("omc team launch did not report a team name; using default poll target")
+                team_name = "active"
 
-        # (poll) Wait for workers to reach a terminal state via the real omc API contract.
-        # Poll uses ``omc team api get-summary --input '{"team_name":"<team>"}' --json``
-        # (positional team name is NOT a valid form for api subcommands — requires --input JSON).
-        # Terminal success: all tasks completed, none failed, none in_progress, total > 0.
-        # Terminal fail: any task failed and none in_progress.
-        # ``timeout_seconds=0`` means unlimited (ADR 0085).
-        summary_data: dict[str, object] = {}
-        if not blockers:
-            team_success = False
-            while True:
-                get_sum = run(
-                    ["omc", "team", "api", "get-summary",
-                     "--input", json.dumps({"team_name": team_name}),
-                     "--json"],
-                    cwd=repo_root, env=omc_env, timeout=_remaining_budget(),
-                )
-                if getattr(get_sum, "returncode", 1) != 0:
-                    blockers.append(
-                        f"omc team api get-summary failed (rc={getattr(get_sum, 'returncode', 'unknown')})"
+            # (poll) Wait for workers to reach a terminal state via the real omc API contract.
+            # Poll uses ``omc team api get-summary --input '{"team_name":"<team>"}' --json``
+            # (positional team name is NOT a valid form for api subcommands — requires --input JSON).
+            # Terminal success: all tasks completed, none failed, none in_progress, total > 0.
+            # Terminal fail: any task failed and none in_progress.
+            # ``timeout_seconds=0`` means unlimited (ADR 0085).
+            summary_data: dict[str, object] = {}
+            if not blockers:
+                team_success = False
+                while True:
+                    get_sum = run(
+                        ["omc", "team", "api", "get-summary",
+                         "--input", json.dumps({"team_name": team_name}),
+                         "--json"],
+                        cwd=repo_root, env=omc_env, timeout=_remaining_budget(),
                     )
-                    break
-                try:
-                    summary_payload = json.loads(str(getattr(get_sum, "stdout", "") or ""))
-                    # API response: {"ok": true, "operation": "get-summary", "data": {"summary": {...}}}
-                    summary_data = (
-                        summary_payload.get("data", {}).get("summary", {})
-                        if isinstance(summary_payload.get("data"), dict)
-                        else {}
-                    )
-                except (ValueError, KeyError):
-                    summary_data = {}
-                tasks = summary_data.get("tasks") if isinstance(summary_data.get("tasks"), dict) else {}
-                total = int(tasks.get("total", 0))
-                in_progress = int(tasks.get("in_progress", 0))
-                completed = int(tasks.get("completed", 0))
-                failed = int(tasks.get("failed", 0))
-                if in_progress == 0 and failed == 0 and total > 0 and completed == total:
-                    team_success = True
-                    break
-                if in_progress == 0 and failed > 0:
-                    blockers.append(
-                        f"omc team reached a terminal failure state: {failed} task(s) failed"
-                        + (f" of {total}" if total > 0 else "")
-                    )
-                    break
-                if deadline is not None and _time.monotonic() >= deadline:
-                    blockers.append(
-                        f"omc team did not reach a terminal success state within {timeout_seconds}s timeout"
-                    )
-                    break
-                _time.sleep(_OMC_POLL_INTERVAL_SECONDS)
-
-        # Capture the worker diff from the single worker's git worktree.
-        # There is no ``get-diff`` API operation. The worker's committed changes live in its
-        # git worktree at ``{repo_root}/.omc/team/{team}/worktrees/{worker}`` (set by
-        # ``OMC_TEAM_WORKTREE_MODE=branch``).
-        #
-        # CRITICAL (round-6 fix #1): ``git diff HEAD`` captures ONLY uncommitted working-tree
-        # changes. OMC workers COMMIT their patch on their isolated worktree branch; the
-        # committed diff is therefore INVISIBLE to ``git diff HEAD``.  We must diff from the
-        # base the worker branched from — i.e. the merge-base of the worker HEAD and the
-        # canonical upstream (``origin/main``).  ``git diff <base>`` covers the working tree
-        # AND all commits since <base> (equivalent to: all committed + staged + untracked vs
-        # the branch point).  Resolution:
-        #   1. Resolve base via ``git -C <wt> merge-base HEAD origin/main`` (fallback: empty).
-        #   2. ``git -C <wt> diff <base>`` → captures committed worker changes + any residual
-        #      staged/unstaged work.
-        # If merge-base resolution fails (e.g. remote ref absent in a shallow clone / test
-        # worktree) we log a warning and fall back to ``git diff HEAD`` for the unstaged-only
-        # capture so the safety path degrades gracefully rather than erroring out.
-        if not blockers and team_success:
-            workers_list = summary_data.get("workers") if isinstance(summary_data.get("workers"), list) else []
-            worktree_path_raw = (
-                workers_list[0].get("worktree_path") if workers_list and isinstance(workers_list[0], dict) else None
-            )
-            if not worktree_path_raw:
-                # Fallback: derive canonical path from team name and first worker name.
-                worker_name = (
-                    str(workers_list[0].get("name", "worker-1")) if workers_list and isinstance(workers_list[0], dict) else "worker-1"
-                )
-                worktree_path_raw = str(repo_root / ".omc" / "team" / team_name / "worktrees" / worker_name)
-                warnings.append(
-                    f"omc summary did not report worktree_path; using derived path: {worktree_path_raw}"
-                )
-            worktree_path = str(worktree_path_raw)
-            git_run = git_runner if git_runner is not None else _git_worktree_runner
-            # Step 1: resolve the merge-base so committed worker commits are included.
-            # CRITICAL (round-8 fix #3): FAIL CLOSED when merge-base cannot be resolved.
-            # A fallback to ``git diff HEAD`` only captures uncommitted changes — workers commit
-            # their patch on a per-worker branch, so ``git diff HEAD`` returns an EMPTY diff for
-            # any committed work.  The run would finish ``empty``/``completed`` with ZERO privacy
-            # audit / scope check coverage of the actual worker output.  In a shallow clone or
-            # worktree without ``origin/main`` this is a safety hole, not a graceful degradation.
-            # Block fail-closed with a clear message; the operator must fix the remote ref first.
-            base_proc = git_run(["git", "-C", worktree_path, "merge-base", "HEAD", "origin/main"])
-            base_sha = str(getattr(base_proc, "stdout", "") or "").strip()
-            if getattr(base_proc, "returncode", 1) != 0 or not base_sha:
-                blockers.append(
-                    f"omc worker merge-base resolution failed (rc={getattr(base_proc, 'returncode', 'unknown')}); "
-                    "cannot safely capture committed worker output without a verified diff base — "
-                    "ensure origin/main is reachable in the worker worktree and retry; "
-                    f"worktree: {worktree_path}"
-                )
-            else:
-                # Step 2: stage everything (committed + tracked + UNTRACKED) then diff cached.
-                # CRITICAL (round-10 fix #1): plain ``git diff <base_sha>`` captures committed
-                # changes and unstaged changes to tracked files, but silently MISSES new
-                # untracked files — an OMC worker that creates a new file makes this look
-                # ``empty`` and the file bypasses privacy + scope checks entirely.
-                # The in-repo codex path uses ``git add -A`` for exactly this reason.
-                # Fix: stage everything with ``git -C <wt> add -A``, then capture the full
-                # index diff with ``git -C <wt> diff --cached <base_sha>``; this covers
-                # committed + staged + newly-created untracked files in one snapshot.
-                add_proc = git_run(["git", "-C", worktree_path, "add", "-A"])
-                if getattr(add_proc, "returncode", 0) != 0:
-                    blockers.append(
-                        f"git add -A in worker worktree failed (rc={getattr(add_proc, 'returncode', 'unknown')}); "
-                        f"cannot safely capture untracked worker files; worktree: {worktree_path}"
-                    )
-                else:
-                    diff_cmd: list[str] = ["git", "-C", worktree_path, "diff", "--cached", base_sha]
-                    diff_proc = git_run(diff_cmd)
-                    if getattr(diff_proc, "returncode", 0) == 0:
-                        diff_text = str(getattr(diff_proc, "stdout", "") or "")
-                        verdict = "proposed" if diff_text.strip() else "empty"
-                    else:
+                    if getattr(get_sum, "returncode", 1) != 0:
                         blockers.append(
-                            f"git diff --cached in worker worktree failed (rc={getattr(diff_proc, 'returncode', 'unknown')}); "
-                            f"worktree: {worktree_path}"
+                            f"omc team api get-summary failed (rc={getattr(get_sum, 'returncode', 'unknown')})"
                         )
+                        break
+                    try:
+                        summary_payload = json.loads(str(getattr(get_sum, "stdout", "") or ""))
+                        # API response: {"ok": true, "operation": "get-summary", "data": {"summary": {...}}}
+                        summary_data = (
+                            summary_payload.get("data", {}).get("summary", {})
+                            if isinstance(summary_payload.get("data"), dict)
+                            else {}
+                        )
+                    except (ValueError, KeyError):
+                        summary_data = {}
+                    tasks = summary_data.get("tasks") if isinstance(summary_data.get("tasks"), dict) else {}
+                    total = int(tasks.get("total", 0))
+                    in_progress = int(tasks.get("in_progress", 0))
+                    completed = int(tasks.get("completed", 0))
+                    failed = int(tasks.get("failed", 0))
+                    if in_progress == 0 and failed == 0 and total > 0 and completed == total:
+                        team_success = True
+                        break
+                    if in_progress == 0 and failed > 0:
+                        blockers.append(
+                            f"omc team reached a terminal failure state: {failed} task(s) failed"
+                            + (f" of {total}" if total > 0 else "")
+                        )
+                        break
+                    if deadline is not None and _time.monotonic() >= deadline:
+                        blockers.append(
+                            f"omc team did not reach a terminal success state within {timeout_seconds}s timeout"
+                        )
+                        break
+                    _time.sleep(_OMC_POLL_INTERVAL_SECONDS)
+
+            # Capture EVERY worker diff from its own git worktree (ADR 0095 PR-D multi-worker).
+            # There is no ``get-diff`` API operation. Each worker's committed changes live in its
+            # git worktree at ``{repo_root}/.omc/team/{team}/worktrees/{worker}`` (set by
+            # ``OMC_TEAM_WORKTREE_MODE=branch``). Per worker we run the same merge-base →
+            # ``git add -A`` → ``git diff --cached`` sequence (ADR 0087 round-6 / round-8 / round-10
+            # fixes) via ``_capture_omc_worker_diff``, then privacy + scope re-audit per worker.
+            #
+            # FAIL-CLOSED AGGREGATION: if ANY worker fails capture (merge-base / add -A / diff) or
+            # fails the privacy/scope re-audit, the WHOLE run is blocked (no partial success).
+            if not blockers and team_success:
+                workers_list = summary_data.get("workers") if isinstance(summary_data.get("workers"), list) else []
+                # HIGH-2 (ADR 0095 PR-D adversarial fix): if the summary reports NO workers but
+                # the runner requested N>1, the whole run is fail-closed blocked.  A missing
+                # workers list means we cannot locate ANY diff — silently falling back to a
+                # [None]-derived single worker would produce a canonical proposed for a run that
+                # was supposed to deliver N worker candidates, masking the real failure.
+                # For requested_total==1 the [None] single-worker fallback is safe (legacy behaviour).
+                if not workers_list and total_workers > 1:
+                    blockers.append(
+                        f"omc summary reported no workers but {total_workers} workers were "
+                        "requested; cannot locate worker diffs — blocked fail-closed"
+                    )
+                elif not workers_list:
+                    # Defensive: single-worker run with no workers list — derive path via fallback
+                    # helper (warns inside helper). Legacy behaviour preserved (N==1 byte-compat).
+                    workers_list = [None]
+                if not blockers:
+                    git_run = git_runner if git_runner is not None else _git_worktree_runner
+                    worker_diffs: list[dict[str, object]] = []
+                    for idx, worker_entry in enumerate(workers_list):
+                        worktree_path = _omc_worker_worktree_path(
+                            worker_entry=worker_entry,
+                            idx=idx,
+                            team_name=team_name,
+                            repo_root=repo_root,
+                            warnings=warnings,
+                        )
+                        w_diff, w_verdict, w_capture_blockers = _capture_omc_worker_diff(
+                            git_run=git_run,
+                            worktree_path=worktree_path,
+                        )
+                        if w_capture_blockers:
+                            blockers.extend(
+                                (f"worker {idx}: {b}" if total_workers > 1 else b)
+                                for b in w_capture_blockers
+                            )
+                            break  # fail-closed: stop at the first failing worker
+                        # Per-worker privacy + scope re-audit (fail-closed). The audit path is the
+                        # per-worker namespace so privacy finding messages reference the right file.
+                        worker_artifact_path = run_dir / f"worker-{idx}" / "patch_artifact.json"
+                        w_audited_verdict, w_audit_blockers = _audit_omc_diff_verdict(
+                            diff_text=w_diff,
+                            verdict=w_verdict,
+                            task_id=task_id,
+                            audit_path=worker_artifact_path,
+                            repo_root=repo_root,
+                        )
+                        if w_audited_verdict == "blocked":
+                            blockers.extend(
+                                (f"worker {idx}: {b}" if total_workers > 1 else b)
+                                for b in w_audit_blockers
+                            )
+                            break  # fail-closed: any worker privacy/scope violation blocks the run
+                        worker_diffs.append(
+                            {
+                                "idx": idx,
+                                "diff": w_diff,
+                                "verdict": w_verdict,
+                                "artifact_path": worker_artifact_path,
+                            }
+                        )
+                    # HIGH-2 (partial-capture guard): if capture succeeded for fewer workers than
+                    # requested, the result is ambiguous — block fail-closed rather than promoting
+                    # a partial result as if it were a full N-worker run.
+                    if not blockers and len(worker_diffs) != total_workers:
+                        blockers.append(
+                            f"captured {len(worker_diffs)} worker diff(s) but {total_workers} "
+                            "were requested; partial capture is not accepted — blocked fail-closed"
+                        )
+                    if not blockers:
+                        omc_worker_diffs = worker_diffs
     except subprocess.TimeoutExpired as exc:
         # Per-command timeout expired — record a deterministic blocker; attempt graceful shutdown.
         blockers.append(f"omc runner command timed out after {timeout_seconds}s: {exc}")
@@ -13984,6 +14150,60 @@ def _run_omc_team_runner(
             except Exception as exc:  # pragma: no cover - teardown best-effort
                 warnings.append(f"omc team shutdown warning: {exc}")
 
+    # (ADR 0095 PR-D) Canonical-diff routing from the per-worker captures.
+    #   * N==1 + all-pass: feed the single worker's diff into the canonical finalize so the
+    #     standard active-apply path gets the proposed artifact — byte-identical to the
+    #     pre-PR-D single-worker path (no worker-0/ namespace is written; the run-specific
+    #     artifact_path + standard path carry the proposed exactly as before).
+    #   * N>1 + all-pass: write EACH worker's proposed artifact into its worker-{idx}/ namespace
+    #     and route the standard path to a needs-human-selection blocked artifact (a human
+    #     promotes exactly one; auto-promotion is a non-goal). NO auto-merge.
+    # Capture-time / re-audit blockers (set in the loop above) take priority — they leave
+    # omc_worker_diffs empty so neither branch runs and the run finalizes blocked.
+    worker_count = len(omc_worker_diffs)
+    needs_human_selection = False
+    if not blockers and worker_count >= 1:
+        if worker_count == 1:
+            diff_text = str(omc_worker_diffs[0]["diff"])
+            verdict = str(omc_worker_diffs[0]["verdict"])
+        else:
+            # Persist each worker's proposed/empty artifact in its own namespace, then route
+            # the standard path to needs-human-selection. Per-worker artifacts already passed
+            # the in-memory privacy + scope re-audit in the capture loop; here we run the
+            # written-file backstop (mirrors the canonical path's audit_privacy_output backstop).
+            worker_artifact_paths: list[Path] = []
+            for worker in omc_worker_diffs:
+                worker_artifact_path = worker["artifact_path"]
+                assert isinstance(worker_artifact_path, Path)
+                worker_artifact_path.parent.mkdir(parents=True, exist_ok=True)
+                worker_payload = _omc_proposed_artifact_payload(
+                    diff_text=str(worker["diff"]),
+                    verdict=str(worker["verdict"]),
+                    task_id=task_id,
+                    session_id=session_id,
+                    team_name=team_name,
+                    now=now,
+                )
+                worker_artifact_path.write_text(
+                    json.dumps(_patch_artifact_json_payload(worker_payload), indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                worker_artifact_paths.append(worker_artifact_path)
+                file_findings = audit_privacy_output(worker_artifact_path, out_path=None, repo_root=repo_root)
+                if file_findings:
+                    issues = sorted({finding.issue for finding in file_findings})
+                    blockers.extend(f"worker {worker['idx']}: privacy: {issue}" for issue in issues)
+            if blockers:
+                # Fail-closed: a backstop leak in ANY worker blocks the whole run AND must not
+                # leave a proposed artifact in ANY per-worker namespace (no partial success).
+                for worker_artifact_path in worker_artifact_paths:
+                    _write_blocked_omc_artifact(
+                        worker_artifact_path, session_id=session_id, team_name=team_name, now=now
+                    )
+            else:
+                needs_human_selection = True
+                diff_text = ""  # skip the canonical proposed write; route to needs-human-selection
+
     decision = "blocked" if blockers else ("completed" if verdict in {"proposed", "empty"} else "blocked")
     return _finalize_omc_runner_result(
         decision=decision,
@@ -14007,6 +14227,8 @@ def _run_omc_team_runner(
         now=now,
         write_artifact=not blockers,
         invalidate_heartbeats=True,  # omc team was actually launched; invalidate stale heartbeats
+        needs_human_selection=needs_human_selection,
+        worker_count=worker_count,
     )
 
 
@@ -14076,6 +14298,232 @@ def _build_omc_task_text(
     return _sanitize_inline_text(_redact_private_text(text)), task_blockers
 
 
+def _capture_omc_worker_diff(
+    *,
+    git_run,
+    worktree_path: str,
+) -> tuple[str, str, list[str]]:
+    """Capture ONE omc worker's committed+staged+untracked diff from its git worktree.
+
+    Returns ``(diff_text, verdict, blockers)``. Extracted from the single-worker path so the
+    multi-worker loop (ADR 0095 PR-D) reuses the EXACT same merge-base → ``git add -A`` →
+    ``git diff --cached`` sequence (ADR 0087 round-6 / round-8 / round-10 fixes) per worker.
+
+    CRITICAL (round-8 fix #3): FAIL CLOSED when merge-base cannot be resolved — workers COMMIT
+    on a per-worker branch, so a ``git diff HEAD`` fallback would return an EMPTY diff and the
+    run would finish ``empty``/``completed`` with ZERO privacy/scope coverage of the real
+    output. CRITICAL (round-10 fix #1): stage with ``git add -A`` first so newly-created
+    untracked files are captured (plain ``git diff <base>`` silently misses them).
+    """
+    worker_blockers: list[str] = []
+    base_proc = git_run(["git", "-C", worktree_path, "merge-base", "HEAD", "origin/main"])
+    base_sha = str(getattr(base_proc, "stdout", "") or "").strip()
+    if getattr(base_proc, "returncode", 1) != 0 or not base_sha:
+        worker_blockers.append(
+            f"omc worker merge-base resolution failed (rc={getattr(base_proc, 'returncode', 'unknown')}); "
+            "cannot safely capture committed worker output without a verified diff base — "
+            "ensure origin/main is reachable in the worker worktree and retry; "
+            f"worktree: {worktree_path}"
+        )
+        return "", "error", worker_blockers
+    add_proc = git_run(["git", "-C", worktree_path, "add", "-A"])
+    if getattr(add_proc, "returncode", 0) != 0:
+        worker_blockers.append(
+            f"git add -A in worker worktree failed (rc={getattr(add_proc, 'returncode', 'unknown')}); "
+            f"cannot safely capture untracked worker files; worktree: {worktree_path}"
+        )
+        return "", "error", worker_blockers
+    diff_proc = git_run(["git", "-C", worktree_path, "diff", "--cached", base_sha])
+    if getattr(diff_proc, "returncode", 0) != 0:
+        worker_blockers.append(
+            f"git diff --cached in worker worktree failed (rc={getattr(diff_proc, 'returncode', 'unknown')}); "
+            f"worktree: {worktree_path}"
+        )
+        return "", "error", worker_blockers
+    diff_text = str(getattr(diff_proc, "stdout", "") or "")
+    return diff_text, ("proposed" if diff_text.strip() else "empty"), worker_blockers
+
+
+def _omc_worker_worktree_path(
+    *,
+    worker_entry: object,
+    idx: int,
+    team_name: str,
+    repo_root: Path,
+    warnings: list[str],
+) -> str:
+    """Resolve the git-worktree path for worker ``idx`` from a summary ``workers[idx]`` entry,
+    falling back to the canonical ``.omc/team/<team>/worktrees/<name>`` path."""
+    worktree_path_raw = (
+        worker_entry.get("worktree_path") if isinstance(worker_entry, dict) else None
+    )
+    if not worktree_path_raw:
+        worker_name = (
+            str(worker_entry.get("name", f"worker-{idx + 1}"))
+            if isinstance(worker_entry, dict)
+            else f"worker-{idx + 1}"
+        )
+        worktree_path_raw = str(repo_root / ".omc" / "team" / team_name / "worktrees" / worker_name)
+        warnings.append(
+            f"omc summary did not report worktree_path for worker {idx}; "
+            f"using derived path: {worktree_path_raw}"
+        )
+    return str(worktree_path_raw)
+
+
+def _omc_proposed_artifact_payload(
+    *,
+    diff_text: str,
+    verdict: str,
+    task_id: str | None,
+    session_id: str,
+    team_name: str,
+    now: datetime,
+) -> dict[str, object]:
+    """Build the patch_artifact.json dict for a captured omc diff (codex-patch-compatible shape).
+
+    Single source of truth shared by ``_finalize_omc_runner_result`` (canonical N==1 path) and
+    the multi-worker per-worker artifact writes (ADR 0095 PR-D), so every omc proposed artifact
+    has byte-identical structure regardless of N."""
+    return {
+        "schema_version": 1,
+        "task_id": task_id if (task_id and TASK_ID_RE.fullmatch(task_id)) else None,
+        "session_id": session_id,
+        "role": "Implementer",
+        "agent": "omc",
+        "generated_at": _isoformat(now),
+        "base": "origin/main",
+        "scratch_branch": team_name,
+        "verdict": verdict,
+        "summary": _patch_summary(verdict, diff_text, agent="omc"),
+        "files": _diff_files(diff_text),
+        "diffstat": _diffstat(diff_text),
+        "diff": diff_text,
+        "wu": 1 if verdict == "proposed" else 0,
+        "privacy_scrubbed": True,
+    }
+
+
+def _write_needs_human_selection_artifact(
+    artifact_path: Path,
+    *,
+    session_id: str,
+    team_name: str,
+    worker_count: int,
+    now: datetime,
+) -> None:
+    """Write a privacy-clean ``needs-human-selection`` blocked artifact (no raw diff).
+
+    For N>1 omc workers that ALL pass the per-worker privacy + scope re-audit (ADR 0095 PR-D),
+    the standard active-apply consumption path is intentionally NOT auto-fed any single worker's
+    proposed diff — a human must promote exactly one of the preserved per-worker
+    (``worker-{idx}/patch_artifact.json``) proposals. This blocked artifact at the standard path
+    prevents the active-apply auto-consumer from silently picking one. Automatic promotion is a
+    deliberate PR-D non-goal (capture + safe routing only)."""
+    redacted = {
+        "schema_version": 1,
+        "task_id": None,
+        "session_id": session_id,
+        "role": "Implementer",
+        "agent": "omc",
+        "generated_at": _isoformat(now),
+        "base": "origin/main",
+        "scratch_branch": _sanitize_inline_text(team_name),
+        "verdict": "blocked",
+        "summary": (
+            f"omc multi-worker run produced {worker_count} candidate proposals — needs human "
+            "selection; promote exactly one worker-N/patch_artifact.json (no auto-merge)"
+        ),
+        "files": [],
+        "diffstat": {"files_changed": 0, "insertions": 0, "deletions": 0},
+        "diff": "",
+        "wu": 0,
+        "privacy_scrubbed": False,
+        "needs_human_selection": True,
+        "worker_count": worker_count,
+    }
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(json.dumps(_sanitize_json_value(redacted), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _audit_omc_diff_verdict(
+    *,
+    diff_text: str,
+    verdict: str,
+    task_id: str | None,
+    audit_path: Path,
+    repo_root: Path,
+) -> tuple[str, list[str]]:
+    """Re-impose the omc privacy re-audit + claimed_files scope check on ONE captured diff.
+
+    Single source of truth shared by ``_finalize_omc_runner_result`` (the N==1 canonical
+    path) and the multi-worker per-worker capture loop (ADR 0095 PR-D). Returns
+    ``(verdict, extra_blockers)``: ``verdict`` is downgraded to ``"blocked"`` when any
+    privacy finding or scope violation is detected (fail-closed for the uncontrolled omc
+    path — ADR 0087 fix round-5 #2 / round-6 fix #2 / round-7 fix #1), otherwise the input
+    ``verdict`` is returned unchanged. ``audit_path`` is only used to derive a redacted
+    display path for the privacy finding messages; this helper does NOT write any artifact.
+    """
+    extra_blockers: list[str] = []
+    # (1) Privacy re-audit on the captured diff (fail-closed -> blocked).
+    privacy_findings = _privacy_findings_for_text(
+        diff_text,
+        path=_display_path(_repo_path(audit_path, repo_root), repo_root=repo_root),
+    )
+    if privacy_findings:
+        issues = sorted({finding.issue for finding in privacy_findings})
+        extra_blockers.extend(f"privacy: {issue}" for issue in issues)
+        return "blocked", extra_blockers
+
+    # (2) claimed_files scope check on the captured diff (fail-closed for omc). A missing
+    # write lease or empty claimed_files is BLOCKING when there is a proposed diff —
+    # uncontrolled workers require explicit scope enforcement; "unenforced" is unacceptable
+    # (round-5 fix #2). REQUIRE an EXACT current task_id match (round-6 fix #2 / round-7 fix
+    # #1): legacy/unscoped leases are not accepted. When task_id is None/empty (standalone
+    # call without --task), fall back to any active/recovery write lease.
+    lease_items = _load_active_leases(_active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root))
+    if task_id:
+        task_write_leases = [
+            lease for lease in lease_items
+            if isinstance(lease, dict)
+            and lease.get("lease_type") == "write"
+            and lease.get("status") in {"active", "recovery-needed"}
+            and str(lease.get("task_id") or "") == task_id
+        ]
+    else:
+        task_write_leases = [
+            lease for lease in lease_items
+            if isinstance(lease, dict)
+            and lease.get("lease_type") == "write"
+            and lease.get("status") in {"active", "recovery-needed"}
+        ]
+    if len(task_write_leases) > 1:
+        lease_ids = [str(lse.get("lease_id") or "") for lse in task_write_leases]
+        extra_blockers.append(
+            f"omc diff scope is ambiguous: {len(task_write_leases)} active write leases "
+            f"found for task_id={task_id!r} (lease_ids: {', '.join(lease_ids[:5])}); "
+            "resolve to exactly one active write lease before running the omc runner"
+        )
+        return "blocked", extra_blockers
+    write_lease = task_write_leases[0] if len(task_write_leases) == 1 else None
+    claimed_raw = write_lease.get("claimed_files") if isinstance(write_lease, dict) else None
+    claimed = {str(f) for f in claimed_raw} if isinstance(claimed_raw, list) else set()
+    if not claimed and verdict == "proposed":
+        extra_blockers.append(
+            "omc diff scope is unenforced: no active write lease or claimed_files found; "
+            "set claimed_files in the write lease before running the omc runner"
+        )
+        return "blocked", extra_blockers
+    if claimed and verdict == "proposed":
+        out_of_scope = sorted(f for f in _diff_files(diff_text) if f not in claimed)
+        if out_of_scope and not _context_only_claimed_files(claimed):
+            extra_blockers.append(
+                "omc diff touches files outside the lease claim: " + ", ".join(out_of_scope[:5])
+            )
+            return "blocked", extra_blockers
+    return verdict, extra_blockers
+
+
 def _finalize_omc_runner_result(
     *,
     decision: str,
@@ -14099,6 +14547,8 @@ def _finalize_omc_runner_result(
     now: datetime,
     write_artifact: bool,
     invalidate_heartbeats: bool,
+    needs_human_selection: bool = False,
+    worker_count: int = 1,
 ) -> ActiveCodexRunnerResult:
     """Re-impose governance on the captured omc diff, write the patch_artifact.json, and map
     the result into an ActiveCodexRunnerResult (codex-patch-compatible shape).
@@ -14108,117 +14558,78 @@ def _finalize_omc_runner_result(
     ``invalidate_heartbeats``: only True when the omc team was actually launched (execute=True
     and the team launch was attempted) — prevents dry-run / no-ack / pre-spawn-blocked paths
     from mutating gate state.
+    ``needs_human_selection`` (ADR 0095 PR-D): True for an N>1 multi-worker run whose workers
+    ALL passed per-worker re-audit. The per-worker proposed artifacts are already written to
+    their ``worker-{idx}/`` namespaces by the caller; here we route the standard active-apply
+    path (and the run-specific ``artifact_path``) to a ``needs-human-selection`` BLOCKED artifact
+    so the active-apply auto-consumer never silently picks one candidate (automatic promotion is
+    a deliberate non-goal). ``worker_count`` is recorded in that artifact.
     """
     blockers = list(blockers)
     warnings = list(warnings)
 
-    if write_artifact and diff_text:
-        artifact = {
-            "schema_version": 1,
-            "task_id": task_id if (task_id and TASK_ID_RE.fullmatch(task_id)) else None,
-            "session_id": session_id,
-            "role": "Implementer",
-            "agent": "omc",
-            "generated_at": _isoformat(now),
-            "base": "origin/main",
-            "scratch_branch": team_name,
-            "verdict": verdict,
-            "summary": _patch_summary(verdict, diff_text, agent="omc"),
-            "files": _diff_files(diff_text),
-            "diffstat": _diffstat(diff_text),
-            "diff": diff_text,
-            "wu": 1 if verdict == "proposed" else 0,
-            "privacy_scrubbed": True,
-        }
+    # (ADR 0095 PR-D) N>1 multi-worker all-pass: route the standard + run-specific paths to a
+    # needs-human-selection blocked artifact (per-worker proposals are preserved by the caller).
+    # decision is forced blocked so active-apply will not auto-consume; this takes priority over
+    # the normal proposed write (the caller passes diff_text="" here, but guard explicitly).
+    if needs_human_selection and not blockers:
+        decision = "blocked"
+        verdict = "blocked"
+        blockers.append(
+            f"omc multi-worker run produced {worker_count} candidate proposals across "
+            f"worker-0..worker-{worker_count - 1}; needs human selection — promote exactly one "
+            "worker-N/patch_artifact.json to the standard path (no auto-merge, no auto-promotion)"
+        )
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_needs_human_selection_artifact(
+            artifact_path, session_id=session_id, team_name=team_name,
+            worker_count=worker_count, now=now,
+        )
+        standard_path = _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent / "patch_runs" / "implementer" / "patch_artifact.json"
+        standard_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_needs_human_selection_artifact(
+            standard_path, session_id=session_id, team_name=team_name,
+            worker_count=worker_count, now=now,
+        )
+    elif write_artifact and diff_text:
+        artifact = _omc_proposed_artifact_payload(
+            diff_text=diff_text,
+            verdict=verdict,
+            task_id=task_id,
+            session_id=session_id,
+            team_name=team_name,
+            now=now,
+        )
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Re-impose the privacy re-audit on the captured diff (fail-closed -> blocked).
-        privacy_findings = _privacy_findings_for_text(
-            diff_text,
-            path=_display_path(_repo_path(artifact_path, repo_root), repo_root=repo_root),
+        # Re-impose the privacy re-audit + claimed_files scope check on the captured diff
+        # (fail-closed -> blocked). Shared with the multi-worker per-worker capture loop via
+        # ``_audit_omc_diff_verdict`` (ADR 0095 PR-D single source of truth).
+        audited_verdict, audit_blockers = _audit_omc_diff_verdict(
+            diff_text=diff_text,
+            verdict=verdict,
+            task_id=task_id,
+            audit_path=artifact_path,
+            repo_root=repo_root,
         )
-        if privacy_findings:
-            issues = sorted({finding.issue for finding in privacy_findings})
+        if audited_verdict == "blocked":
             verdict = "blocked"
             decision = "blocked"
-            blockers.extend(f"privacy: {issue}" for issue in issues)
+            blockers.extend(audit_blockers)
             _write_blocked_omc_artifact(artifact_path, session_id=session_id, team_name=team_name, now=now)
         else:
-            # claimed_files scope check on the captured diff (fail-closed for omc).
-            # For omc runner, a missing write lease or empty claimed_files is a BLOCKING
-            # condition when there is a proposed diff — uncontrolled workers require explicit
-            # scope enforcement; "unenforced" is not acceptable (fix round-5 #2).
-            #
-            # CRITICAL (round-6 fix #2): ``_find_active_write_lease(lease_id=None)`` returns
-            # the FIRST active write lease regardless of which task it belongs to.  When
-            # ``active-start`` appends a new lease without removing the previous one, a stale
-            # lease from ANOTHER task_id may be returned — validating an OMC diff against the
-            # WRONG task's claimed_files.  Fix: filter by the current task_id FIRST; if no
-            # exactly-one matching lease is found, block fail-closed.  This ensures the scope
-            # check is always against the correct task's boundary.
-            lease_items = _load_active_leases(_active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root))
-            # CRITICAL (round-7 fix #1): for the omc runner, REQUIRE an EXACT task_id match.
-            # Legacy leases without a task_id field are NOT accepted — an unscoped lease could
-            # belong to any task (stale/leaked), and accepting it silently validates the wrong
-            # scope. Fail-closed: if task_id is set, only leases whose task_id field
-            # EXPLICITLY equals the current task_id are eligible. When task_id is None/empty
-            # (standalone call without --task), fall back to any active/recovery write lease.
-            if task_id:
-                task_write_leases = [
-                    lease for lease in lease_items
-                    if isinstance(lease, dict)
-                    and lease.get("lease_type") == "write"
-                    and lease.get("status") in {"active", "recovery-needed"}
-                    and str(lease.get("task_id") or "") == task_id
-                ]
-            else:
-                task_write_leases = [
-                    lease for lease in lease_items
-                    if isinstance(lease, dict)
-                    and lease.get("lease_type") == "write"
-                    and lease.get("status") in {"active", "recovery-needed"}
-                ]
-            if len(task_write_leases) > 1:
-                # Multiple active write leases for the same task — ambiguous scope.
-                lease_ids = [str(lse.get("lease_id") or "") for lse in task_write_leases]
+            artifact_path.write_text(
+                json.dumps(_patch_artifact_json_payload(artifact), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            # Re-audit the written artifact file as the fail-closed backstop.
+            file_findings = audit_privacy_output(artifact_path, out_path=None, repo_root=repo_root)
+            if file_findings:
+                issues = sorted({finding.issue for finding in file_findings})
                 verdict = "blocked"
                 decision = "blocked"
-                blockers.append(
-                    f"omc diff scope is ambiguous: {len(task_write_leases)} active write leases "
-                    f"found for task_id={task_id!r} (lease_ids: {', '.join(lease_ids[:5])}); "
-                    "resolve to exactly one active write lease before running the omc runner"
-                )
-            write_lease = task_write_leases[0] if len(task_write_leases) == 1 else None
-            claimed_raw = write_lease.get("claimed_files") if isinstance(write_lease, dict) else None
-            claimed = {str(f) for f in claimed_raw} if isinstance(claimed_raw, list) else set()
-            if not claimed and verdict == "proposed":
-                verdict = "blocked"
-                decision = "blocked"
-                blockers.append(
-                    "omc diff scope is unenforced: no active write lease or claimed_files found; "
-                    "set claimed_files in the write lease before running the omc runner"
-                )
-            elif claimed and verdict == "proposed":
-                out_of_scope = sorted(f for f in _diff_files(diff_text) if f not in claimed)
-                if out_of_scope and not _context_only_claimed_files(claimed):
-                    verdict = "blocked"
-                    decision = "blocked"
-                    blockers.append("omc diff touches files outside the lease claim: " + ", ".join(out_of_scope[:5]))
-            if verdict == "blocked":
+                blockers.extend(f"privacy: {issue}" for issue in issues)
                 _write_blocked_omc_artifact(artifact_path, session_id=session_id, team_name=team_name, now=now)
-            else:
-                artifact_path.write_text(
-                    json.dumps(_patch_artifact_json_payload(artifact), indent=2, sort_keys=True) + "\n",
-                    encoding="utf-8",
-                )
-                # Re-audit the written artifact file as the fail-closed backstop.
-                file_findings = audit_privacy_output(artifact_path, out_path=None, repo_root=repo_root)
-                if file_findings:
-                    issues = sorted({finding.issue for finding in file_findings})
-                    verdict = "blocked"
-                    decision = "blocked"
-                    blockers.extend(f"privacy: {issue}" for issue in issues)
-                    _write_blocked_omc_artifact(artifact_path, session_id=session_id, team_name=team_name, now=now)
 
         # Mirror the artifact into the standard active-apply consumption path so the existing
         # integration-branch / Conservative-Gate path consumes it UNCHANGED (no auto-merge).
@@ -14274,11 +14685,39 @@ def _finalize_omc_runner_result(
         )
         if invalidation_error:
             decision = "blocked"
+            verdict = "blocked"
             blockers.append(
                 f"omc gate-heartbeat invalidation failed — cannot verify blocking-role "
                 f"statuses were reset; Conservative Gate may be stale-open: "
                 f"{invalidation_error}"
             )
+            # HIGH-1 (ADR 0095 PR-D adversarial fix): late blocker — the standard_path may
+            # already carry a proposed artifact written earlier in this function (before
+            # invalidation runs). Overwrite it (and artifact_path) with a blocked artifact so
+            # active-apply cannot consume a proposed diff that was produced in the same run
+            # whose heartbeat invalidation then failed.  Also overwrite any per-worker
+            # worker-{idx} artifacts written by a prior N>1 all-pass run in the same run_dir.
+            _late_blocker_standard_path = (
+                _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent
+                / "patch_runs" / "implementer" / "patch_artifact.json"
+            )
+            _late_blocker_standard_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_blocked_omc_artifact(
+                _late_blocker_standard_path, session_id=session_id, team_name=team_name, now=now
+            )
+            artifact_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_blocked_omc_artifact(
+                artifact_path, session_id=session_id, team_name=team_name, now=now
+            )
+            # Overwrite per-worker artifacts (N>1 run may have written proposed per-worker
+            # artifacts before heartbeat invalidation was attempted).
+            _late_run_dir = artifact_path.parent  # omc_runs/omc-team/
+            for _wdir in sorted(_late_run_dir.glob("worker-*")):
+                _wart = _wdir / "patch_artifact.json"
+                if _wart.exists():
+                    _write_blocked_omc_artifact(
+                        _wart, session_id=session_id, team_name=team_name, now=now
+                    )
     if invalidated_roles:
         warnings.append(
             "OMC runner invalidated prior blocking-role gate heartbeats for "

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 
 import pytest
@@ -7290,6 +7291,12 @@ def _fake_omc_runner(
     summary_task_counts_seq: list[dict[str, int]] | None = None,
     summary_worktree_path: str = "/tmp/fake-worktree",
     summary_worker_name: str = "worker-1",
+    # ADR 0095 PR-D multi-worker support: an explicit list of worker entries to return in the
+    # get-summary ``workers`` array. Each entry is a dict with at least ``worktree_path`` (and
+    # optionally ``name``). When None (default) a SINGLE worker entry is synthesized from
+    # ``summary_worktree_path`` / ``summary_worker_name`` so the existing 47 single-worker tests
+    # are unaffected. Use to drive the per-worker diff-capture loop with N>1 workers.
+    summary_workers: list[dict[str, object]] | None = None,
     # Simulate shutdown failures (round-7 fix #2 tests).
     # shutdown_rc: nonzero means the first shutdown attempt returns this rc.
     # shutdown_force_rc: rc returned by the --force fallback (default 0 = success).
@@ -7307,12 +7314,21 @@ def _fake_omc_runner(
     poll loop terminates with a terminal-success state immediately.
     ``summary_task_counts_seq``: list of task-count dicts for successive get-summary calls;
     overrides ``summary_task_counts`` per call, falls back to it when exhausted.
-    ``summary_worktree_path`` / ``summary_worker_name``: the worker entry in the summary
+    ``summary_worktree_path`` / ``summary_worker_name``: the single worker entry in the summary
     response (used for diff-capture path resolution from ``workers[0].worktree_path``).
+    ``summary_workers``: explicit multi-worker list (ADR 0095 PR-D); overrides the single-worker
+    synthesis when provided.
     """
     terminal_counts: dict[str, int] = summary_task_counts or {
         "total": 1, "completed": 1, "failed": 0, "in_progress": 0, "pending": 0
     }
+    workers_payload: list[dict[str, object]] = summary_workers if summary_workers is not None else [
+        {
+            "name": summary_worker_name,
+            "worktree_path": summary_worktree_path,
+            "worktree_branch": "omc-team/active/worker-1",
+        }
+    ]
     seq_iter = iter(summary_task_counts_seq or [])
     calls: list[dict[str, object]] = []
 
@@ -7355,15 +7371,9 @@ def _fake_omc_runner(
                     "data": {
                         "summary": {
                             "teamName": "active",
-                            "workerCount": 1,
+                            "workerCount": len(workers_payload),
                             "tasks": counts,
-                            "workers": [
-                                {
-                                    "name": summary_worker_name,
-                                    "worktree_path": summary_worktree_path,
-                                    "worktree_branch": "omc-team/active/worker-1",
-                                }
-                            ],
+                            "workers": workers_payload,
                         }
                     },
                 }
@@ -7833,22 +7843,31 @@ def test_active_codex_runner_omc_env_does_not_forward_secrets(monkeypatch, tmp_p
     assert launch_env.get("OMC_TEAM_WORKTREE_MODE") == agent_loop.OMC_TEAM_WORKTREE_MODE
 
 
-# --- PR-L round-2 fix #2: single-worker-only regression ---
+# --- PR-D (ADR 0095, #1804): Y default-on omc multi-worker ---
 
 
-def test_active_codex_runner_omc_always_launches_exactly_one_worker(
+def _mix_spec_total(mix_spec: str) -> int:
+    """Total worker count parsed from an ``omc team`` mix_spec ("2:claude,1:codex" → 3)."""
+    return sum(
+        int(part.split(":")[0])
+        for part in mix_spec.split(",")
+        if ":" in part and part.split(":")[0].isdigit()
+    )
+
+
+def test_active_codex_runner_omc_auto_launches_multi_worker_within_cap(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """Regression: even with a high-multiplicity agent_mix (claude=5, codex=5) and large
-    max_parallel, the omc team command must request exactly 1 worker total.
-    Multi-worker diff capture is deferred; launching >1 workers would silently discard all
-    but the leader diff while multiplying ADR 0005 exposure."""
+    """ADR 0095 PR-D (supersedes the ADR 0087 single-worker pin): with read_agent=auto and a
+    high-multiplicity agent_mix (claude=5, codex=5), the omc team launch fans out to MULTIPLE
+    workers, bounded by min(OMC_MAX_WORKERS=3 default, max_parallel)."""
     monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.delenv(agent_loop.OMC_MAX_WORKERS_ENV, raising=False)
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
     monkeypatch.setattr("time.sleep", lambda _: None)
     repo = _write_repo(tmp_path)
     active = _write_expanded_active_runner_fixture(repo)
 
-    # Override the registry's agent_mix to a high-multiplicity mix.
     registry_path = active / "session_registry.json"
     registry = json.loads(registry_path.read_text(encoding="utf-8"))
     registry["agent_mix"] = {"target": {"claude": 5, "codex": 5}, "rolling": {}}
@@ -7863,20 +7882,750 @@ def test_active_codex_runner_omc_always_launches_exactly_one_worker(
         repo_root=repo,
         omc_runner=omc,
         git_runner=_fake_git_runner(diff_stdout=diff),
+        read_agent="auto",
         max_parallel=8,
     )
 
-    # Find the launch invocation (contains --no-decompose).
     launch = next((c for c in omc.calls if "--no-decompose" in c["cmd"]), None)
     assert launch is not None, "omc team launch never called"
-    mix_spec = launch["cmd"][2]  # e.g. "1:claude" or "1:codex"
-    # Parse total workers from the mix spec (e.g. "1:claude" → 1, "1:claude,0:codex" → 1).
-    total = sum(
-        int(part.split(":")[0])
-        for part in mix_spec.split(",")
-        if ":" in part and part.split(":")[0].isdigit()
+    mix_spec = launch["cmd"][2]
+    total = _mix_spec_total(mix_spec)
+    assert total > 1, f"expected multi-worker fan-out, got mix_spec={mix_spec!r} (total={total})"
+    assert total <= 3, f"must be capped at OMC_MAX_WORKERS=3, got total={total} (mix_spec={mix_spec!r})"
+
+
+def test_resolve_omc_max_workers_defaults_and_fail_closed() -> None:
+    """Explicit ``raw`` arg covers default / parse / fail-closed branches (mirrors the brick-C
+    _resolve_global_concurrency contract): default 3 on None/blank/non-int; pass-through on
+    valid ints; fail-closed clamp to 1 for <= 0."""
+    assert agent_loop._resolve_omc_max_workers(None) == 3
+    assert agent_loop._resolve_omc_max_workers("2") == 2
+    assert agent_loop._resolve_omc_max_workers("9") == 9
+    assert agent_loop._resolve_omc_max_workers("0") == 1  # fail-closed
+    assert agent_loop._resolve_omc_max_workers("-4") == 1  # fail-closed
+    assert agent_loop._resolve_omc_max_workers("") == 3  # blank -> default
+    assert agent_loop._resolve_omc_max_workers("abc") == 3  # non-int -> default
+
+
+def test_resolve_omc_max_workers_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_resolve_omc_max_workers()`` (raw=None) reads OMC_MAX_WORKERS; the <=0 fail-closed clamp
+    applies to the env path too."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "2")
+    assert agent_loop._resolve_omc_max_workers() == 2
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "0")
+    assert agent_loop._resolve_omc_max_workers() == 1  # fail-closed via env
+
+
+def _agent_mix_registry(claude: int, codex: int) -> dict[str, object]:
+    return {"agent_mix": {"target": {"claude": claude, "codex": codex}, "rolling": {}}}
+
+
+def test_omc_worker_mix_clamps_to_omc_max_workers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """auto fan-out total never exceeds OMC_MAX_WORKERS (here 2) even with a large mix + max_parallel."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "2")
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
+    claude_w, codex_w = agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 5),
+        selected_count=8,
+        max_parallel=8,
+        repo_root=tmp_path,
+        read_agent="auto",
     )
-    assert total == 1, f"expected exactly 1 worker, got mix_spec={mix_spec!r} (total={total})"
+    assert claude_w + codex_w == 2, f"expected total clamped to 2, got ({claude_w}, {codex_w})"
+    assert claude_w >= 1 and codex_w >= 1, "balanced 5:5 should split 1:1 at cap=2"
+
+
+def test_omc_worker_mix_clamps_to_max_parallel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When max_parallel < OMC_MAX_WORKERS the total is clamped to max_parallel."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "8")
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
+    claude_w, codex_w = agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 5),
+        selected_count=8,
+        max_parallel=2,
+        repo_root=tmp_path,
+        read_agent="auto",
+    )
+    assert claude_w + codex_w == 2, f"expected total clamped to max_parallel=2, got ({claude_w}, {codex_w})"
+
+
+def test_omc_worker_mix_fail_closed_min_one(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """OMC_MAX_WORKERS=0 fails closed to a cap of 1 → exactly one worker total."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "0")
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
+    claude_w, codex_w = agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 5),
+        selected_count=8,
+        max_parallel=8,
+        repo_root=tmp_path,
+        read_agent="auto",
+    )
+    assert claude_w + codex_w == 1, f"fail-closed cap=1 must yield 1 worker, got ({claude_w}, {codex_w})"
+
+
+def test_omc_read_agent_override_stays_single_lane(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Explicit --read-agent override is always a SINGLE lane (never fans out), regardless of
+    OMC_MAX_WORKERS or a high-multiplicity mix."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "8")
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
+    assert agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 5),
+        selected_count=8, max_parallel=8, repo_root=tmp_path, read_agent="claude",
+    ) == (1, 0)
+    assert agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 5),
+        selected_count=8, max_parallel=8, repo_root=tmp_path, read_agent="codex",
+    ) == (0, 1)
+
+
+def test_omc_worker_mix_zero_weight_lane_gets_zero_workers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A 0-weight lane gets 0 workers; the positive lane takes the whole cap (codex-only here)."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "3")
+    monkeypatch.delenv(agent_loop.PARALLELISM_KILL_ENV, raising=False)
+    claude_w, codex_w = agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(0, 5),
+        selected_count=8, max_parallel=8, repo_root=tmp_path, read_agent="auto",
+    )
+    assert (claude_w, codex_w) == (0, 3), f"codex-only mix should be (0, 3), got ({claude_w}, {codex_w})"
+
+
+def test_omc_parallelism_kill_forces_single_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """ADR 0095 D5: the global parallelism kill-switch forces auto to a single majority-lane worker."""
+    monkeypatch.setenv(agent_loop.OMC_MAX_WORKERS_ENV, "8")
+    monkeypatch.setenv(agent_loop.PARALLELISM_KILL_ENV, "1")
+    claude_w, codex_w = agent_loop._resolve_omc_worker_mix(
+        registry_payload=_agent_mix_registry(5, 3),
+        selected_count=8, max_parallel=8, repo_root=tmp_path, read_agent="auto",
+    )
+    assert (claude_w, codex_w) == (1, 0), (
+        f"kill-switch must force single majority lane (claude>codex), got ({claude_w}, {codex_w})"
+    )
+
+
+def test_makefile_declares_omc_max_workers() -> None:
+    """ADR 0095 PR-D: the operator front-door knob OMC_MAX_WORKERS is declared + exported.
+
+    The code reads os.getenv("OMC_MAX_WORKERS") directly (no bridge var), so the Makefile
+    needs only the knob + export for `make ... OMC_MAX_WORKERS=N` to reach the runtime."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "OMC_MAX_WORKERS ?= 3" in makefile
+    assert "export OMC_MAX_WORKERS" in makefile
+
+
+# --- PR-D: per-worker diff capture (fake omc + git) ---
+
+
+def _multi_worker_git_runner(
+    diff_by_worktree: dict[str, str],
+    *,
+    merge_base_sha: str = "deadbeef00000000",
+    add_fail_worktrees: frozenset[str] = frozenset(),
+    merge_base_fail_worktrees: frozenset[str] = frozenset(),
+):
+    """Injectable git runner keyed by worktree path so each omc worker returns its OWN diff.
+
+    ``diff_by_worktree``: {worktree_path: diff_stdout}. ``add_fail_worktrees`` /
+    ``merge_base_fail_worktrees``: worktree paths whose ``git add -A`` / ``merge-base`` should
+    return a nonzero rc (to drive the fail-closed aggregation)."""
+    calls: list[list[str]] = []
+
+    def _wt(cmd: list[str]) -> str:
+        # cmd is ["git", "-C", <worktree>, <subcommand>, ...]
+        return cmd[2] if len(cmd) >= 3 and cmd[1] == "-C" else ""
+
+    def run(cmd):
+        calls.append(cmd)
+        wt = _wt(cmd)
+        if "merge-base" in cmd:
+            if wt in merge_base_fail_worktrees:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="fatal: no merge base")
+            return subprocess.CompletedProcess(cmd, 0, stdout=merge_base_sha + "\n", stderr="")
+        if "add" in cmd:
+            rc = 1 if wt in add_fail_worktrees else 0
+            return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="" if rc == 0 else "add failed")
+        if "diff" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=diff_by_worktree.get(wt, ""), stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+def _two_worker_summary(wt0: str = "/tmp/wt-0", wt1: str = "/tmp/wt-1") -> list[dict[str, object]]:
+    return [
+        {"name": "worker-1", "worktree_path": wt0, "worktree_branch": "omc-team/active/worker-1"},
+        {"name": "worker-2", "worktree_path": wt1, "worktree_branch": "omc-team/active/worker-2"},
+    ]
+
+
+def test_omc_multi_worker_captures_per_worker_diffs(monkeypatch, tmp_path: Path) -> None:
+    """Two workers, both passing → each worker's proposed diff is captured into its own
+    worker-{idx}/patch_artifact.json namespace (ADR 0095 PR-D)."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    diff0 = "diff --git a/foo.py b/foo.py\n+a\n"
+    diff1 = "diff --git a/bar.py b/bar.py\n+b\n"
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    git = _multi_worker_git_runner({"/tmp/wt-0": diff0, "/tmp/wt-1": diff1})
+
+    agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    base = repo / "reports" / "agent_loop" / "active" / "omc_runs" / "omc-team"
+    w0 = json.loads((base / "worker-0" / "patch_artifact.json").read_text(encoding="utf-8"))
+    w1 = json.loads((base / "worker-1" / "patch_artifact.json").read_text(encoding="utf-8"))
+    assert w0["verdict"] == "proposed" and w0["diff"] == diff0
+    assert w1["verdict"] == "proposed" and w1["diff"] == diff1
+    assert w0["files"] == ["foo.py"] and w1["files"] == ["bar.py"]
+
+
+def test_omc_multi_worker_n_gt_1_standard_path_needs_human_selection(monkeypatch, tmp_path: Path) -> None:
+    """N>1 all-pass → the STANDARD active-apply path is a needs-human-selection BLOCKED artifact
+    (no auto-consume), while each per-worker proposed is preserved (ADR 0095 PR-D non-goal:
+    automatic promotion)."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    git = _multi_worker_git_runner({
+        "/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n",
+        "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+b\n",
+    })
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked"
+    assert any("needs human selection" in b.lower() for b in result.blockers), result.blockers
+    standard = repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    std = json.loads(standard.read_text(encoding="utf-8"))
+    assert std["verdict"] == "blocked"
+    assert std.get("needs_human_selection") is True
+    assert std["diff"] == ""  # no candidate auto-fed to the standard path
+    # Per-worker proposals are still on disk for a human to promote.
+    base = repo / "reports" / "agent_loop" / "active" / "omc_runs" / "omc-team"
+    assert json.loads((base / "worker-0" / "patch_artifact.json").read_text())["verdict"] == "proposed"
+    assert json.loads((base / "worker-1" / "patch_artifact.json").read_text())["verdict"] == "proposed"
+
+
+def test_omc_multi_worker_blocks_when_one_worker_merge_base_fails(monkeypatch, tmp_path: Path) -> None:
+    """If ANY worker's merge-base fails, the WHOLE run is blocked fail-closed (no partial success)."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    # worker-1 (/tmp/wt-1) merge-base fails.
+    git = _multi_worker_git_runner(
+        {"/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n", "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+b\n"},
+        merge_base_fail_worktrees=frozenset({"/tmp/wt-1"}),
+    )
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked"
+    assert any("merge-base" in b.lower() for b in result.blockers), result.blockers
+    # The standard path is NOT a proposed artifact (fail-closed, no partial success).
+    standard = repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    assert json.loads(standard.read_text(encoding="utf-8"))["verdict"] == "blocked"
+
+
+def test_omc_multi_worker_reaudits_privacy_per_worker(monkeypatch, tmp_path: Path) -> None:
+    """A private real100 path in ONE worker's diff fails the per-worker privacy re-audit and
+    blocks the whole run (uncontrolled-worker fail-closed)."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    # worker-1 leaks a private real100 artifact path.
+    git = _multi_worker_git_runner({
+        "/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n",
+        "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+# see reports/real100/baseline.aggregate.json\n",
+    })
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked"
+    assert any("privacy:" in b for b in result.blockers), result.blockers
+    standard = repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    standard_text = standard.read_text(encoding="utf-8")
+    assert "reports/real100" not in standard_text
+    assert "baseline.aggregate.json" not in standard_text
+
+
+def test_omc_multi_worker_never_passes_auto_merge(monkeypatch, tmp_path: Path) -> None:
+    """No omc invocation in a multi-worker run ever carries --auto-merge."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    git = _multi_worker_git_runner({
+        "/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n",
+        "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+b\n",
+    })
+
+    agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert all("--auto-merge" not in c["cmd"] for c in omc.calls), (
+        "omc multi-worker must NEVER pass --auto-merge"
+    )
+
+
+# --- PR-D: byte-identical preservation (codex default + omc N==1) ---
+
+
+def test_codex_runner_default_never_enters_omc_path(monkeypatch, tmp_path: Path) -> None:
+    """runner="codex" (default) must NEVER touch the omc path, even if an omc_runner is injected.
+
+    The injected stub records every call; zero calls proves the codex fork is byte-identical."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")  # ack on to rule out the ack-gate masking it
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    omc = _fake_omc_runner()
+
+    agent_loop.write_active_codex_runner(
+        execute=False,  # dry-run: no real codex spawn either
+        runner="codex",
+        repo_root=repo,
+        omc_runner=omc,
+    )
+
+    assert omc.calls == [], "codex runner must never invoke the omc runner"
+
+
+def test_omc_single_worker_standard_path_byte_compat(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-D byte-compat: omc N==1 (read_agent default → single codex lane) writes the
+    SAME proposed standard-path artifact as the pre-PR-D single-worker path, and does NOT create
+    any worker-N/ namespace."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    diff = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1,2 @@\n line\n+new line\n"
+    omc = _fake_omc_runner()  # default single-worker summary
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+        git_runner=_fake_git_runner(diff_stdout=diff), task_id="T-2026-1804",
+    )
+
+    assert result.decision == "completed"
+    standard = repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    artifact = json.loads(standard.read_text(encoding="utf-8"))
+    assert artifact["verdict"] == "proposed"
+    assert artifact["agent"] == "omc"
+    assert artifact["files"] == ["foo.py"]
+    assert artifact["diff"] == diff
+    # N==1 must NOT create a worker-0/ namespace (byte-identical with the canonical path).
+    base = repo / "reports" / "agent_loop" / "active" / "omc_runs" / "omc-team"
+    assert not (base / "worker-0").exists(), "N==1 must not write a per-worker namespace"
+    # The run-specific artifact_path carries the proposed exactly as before.
+    run_artifact = json.loads((base / "patch_artifact.json").read_text(encoding="utf-8"))
+    assert run_artifact["verdict"] == "proposed" and run_artifact["diff"] == diff
+
+
+# --- PR-D adversarial fixes (HIGH-1/2/3 + LOW-1) ---
+
+
+def test_omc_heartbeat_invalidation_failure_overwrites_standard_proposed(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-1: when heartbeat invalidation fails AFTER a proposed artifact was already written
+    to the standard path, the standard path AND run-specific artifact path must be overwritten
+    to blocked.  active-apply must not be able to consume the proposed diff from a run whose
+    heartbeat invalidation then failed."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    diff = "diff --git a/foo.py b/foo.py\n+x\n"
+    omc = _fake_omc_runner(summary_worktree_path=str(tmp_path / "fake-wt"))
+    # Simulate heartbeat invalidation failure AFTER capture succeeds.
+    monkeypatch.setattr(
+        agent_loop,
+        "_invalidate_omc_blocking_gate_heartbeats",
+        lambda **kwargs: ([], "registry write failed: [Errno 13] Permission denied"),
+    )
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+        git_runner=_fake_git_runner(diff_stdout=diff), task_id="T-2026-1804",
+    )
+
+    assert result.decision == "blocked", f"expected blocked; got {result.decision!r}"
+    active = repo / "reports" / "agent_loop" / "active"
+    standard = active / "patch_runs" / "implementer" / "patch_artifact.json"
+    run_artifact = active / "omc_runs" / "omc-team" / "patch_artifact.json"
+    # Both paths must be BLOCKED — not proposed (HIGH-1 fix).
+    std = json.loads(standard.read_text(encoding="utf-8"))
+    assert std["verdict"] == "blocked", (
+        f"standard path must be blocked after invalidation failure; got {std['verdict']!r}"
+    )
+    assert "proposed" not in standard.read_text(encoding="utf-8"), (
+        "standard path must not contain a proposed artifact after invalidation failure"
+    )
+    run_art = json.loads(run_artifact.read_text(encoding="utf-8"))
+    assert run_art["verdict"] == "blocked", (
+        f"run-specific artifact must be blocked after invalidation failure; got {run_art['verdict']!r}"
+    )
+
+
+def test_omc_heartbeat_invalidation_failure_overwrites_per_worker_proposed(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-1 (N>1 variant): when a N>1 all-pass run writes per-worker proposed artifacts and
+    THEN heartbeat invalidation fails, ALL per-worker artifacts must be overwritten to blocked."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    git = _multi_worker_git_runner({
+        "/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n",
+        "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+b\n",
+    })
+    monkeypatch.setattr(
+        agent_loop,
+        "_invalidate_omc_blocking_gate_heartbeats",
+        lambda **kwargs: ([], "registry write failed"),
+    )
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked"
+    base = repo / "reports" / "agent_loop" / "active" / "omc_runs" / "omc-team"
+    # Per-worker artifacts must be BLOCKED (not proposed) after late invalidation failure.
+    for widx in (0, 1):
+        wart_path = base / f"worker-{widx}" / "patch_artifact.json"
+        assert wart_path.exists(), f"worker-{widx} artifact should exist"
+        wart = json.loads(wart_path.read_text(encoding="utf-8"))
+        assert wart["verdict"] == "blocked", (
+            f"worker-{widx} artifact must be blocked after invalidation failure; "
+            f"got {wart['verdict']!r}"
+        )
+
+
+def test_omc_requested_multi_worker_but_summary_missing_blocks_fail_closed(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-2: when N>1 workers are requested but the omc summary reports no workers list,
+    the run must be blocked fail-closed — NOT a single-worker proposed falldown."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    # Summary with NO workers list but terminal-success task counts.
+    omc = _fake_omc_runner(summary_workers=[])  # empty list → no workers reported
+    git = _multi_worker_git_runner({})
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked", (
+        f"expected blocked when N>1 requested but no workers reported; got {result.decision!r}"
+    )
+    assert any("no workers" in b.lower() or "requested" in b.lower() for b in result.blockers), (
+        f"expected a blocker about missing workers; blockers={result.blockers}"
+    )
+    standard = repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    assert json.loads(standard.read_text(encoding="utf-8"))["verdict"] == "blocked", (
+        "standard path must be blocked (not a single-worker proposed falldown)"
+    )
+
+
+def test_omc_partial_worker_capture_blocks(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-2 (partial-capture guard): N=2 requested, summary reports 1 worker — partial
+    capture must be blocked fail-closed rather than promoting a partial result."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    # Summary reports only 1 worker (partial), but the mix resolves to 2.
+    one_worker = [{"name": "worker-1", "worktree_path": "/tmp/wt-0", "worktree_branch": "b"}]
+    omc = _fake_omc_runner(summary_workers=one_worker)
+    git = _multi_worker_git_runner({"/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n"})
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    assert result.decision == "blocked", (
+        f"partial capture must be blocked; got {result.decision!r}"
+    )
+    assert any("partial" in b.lower() or "captured" in b.lower() for b in result.blockers), (
+        f"expected a blocker about partial capture; blockers={result.blockers}"
+    )
+
+
+def test_omc_stale_worker_artifacts_cleared_on_new_run_start(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-3: stale worker-* artifacts from a PRIOR run in the same run_dir must be evicted
+    before each new run so a false human-promotion of an old proposed is impossible."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+
+    # Pre-seed a stale proposed artifact at worker-0 (simulates a prior N>1 all-pass run).
+    active = repo / "reports" / "agent_loop" / "active"
+    stale_wdir = active / "omc_runs" / "omc-team" / "worker-0"
+    stale_wdir.mkdir(parents=True, exist_ok=True)
+    stale_artifact = stale_wdir / "patch_artifact.json"
+    stale_artifact.write_text(
+        json.dumps({"verdict": "proposed", "diff": "stale proposed from prior run", "agent": "omc"}),
+        encoding="utf-8",
+    )
+
+    # New N==1 run (default single-worker, no new worker-0 written).
+    diff = "diff --git a/foo.py b/foo.py\n+x\n"
+    omc = _fake_omc_runner()  # single-worker summary
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+        git_runner=_fake_git_runner(diff_stdout=diff), task_id="T-2026-1804",
+    )
+
+    assert result.decision == "completed"
+    # Stale worker-0 directory must be gone (evicted before the new run launched).
+    assert not stale_wdir.exists(), (
+        "stale worker-0 directory from a prior run must be evicted before the new run"
+    )
+
+
+def test_omc_stale_worker_artifacts_cleared_on_pre_launch_blocked_execute_run(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-3 codex round-2 fix: cleanup must run BEFORE any early-return, not only at the
+    team-launch site.  Prior N>1 all-pass run's proposed worker-* are evicted even when the
+    NEXT run is blocked by an early-return (e.g. no-ack).  execute=True is required for eviction
+    (dry-run is read-only per round-9 fix #2)."""
+    # Seed a stale proposed artifact at worker-0 (simulates a prior N>1 all-pass run).
+    active = tmp_path / "reports" / "agent_loop" / "active"
+    stale_wdir = active / "omc_runs" / "omc-team" / "worker-0"
+    stale_wdir.mkdir(parents=True, exist_ok=True)
+    stale_artifact = stale_wdir / "patch_artifact.json"
+    stale_artifact.write_text(
+        json.dumps({"verdict": "proposed", "diff": "stale proposed from prior run", "agent": "omc"}),
+        encoding="utf-8",
+    )
+
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    omc = _fake_omc_runner()
+
+    # execute=True + no-ack → early-return BEFORE the team-launch site.
+    # With the old cleanup position (at team-launch) this path bypassed eviction entirely.
+    monkeypatch.delenv(agent_loop.OMC_RUNNER_ACK_ENV, raising=False)
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+    )
+
+    assert result.decision == "blocked"
+    assert agent_loop.OMC_RUNNER_REQUIRES_ACK_MESSAGE in result.blockers
+    # Stale worker-0 MUST be gone — evicted at function entry even though the run was
+    # blocked before reaching the team-launch site (codex round-2 HIGH-3 fix).
+    assert not stale_wdir.exists(), (
+        "stale worker-0 from a prior run must be evicted even when the new run is "
+        "pre-launch blocked (execute=True); old cleanup position missed this path"
+    )
+
+
+def test_omc_dry_run_preserves_stale_worker_artifacts_read_only(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-3 dry-run invariant: execute=False (dry-run) is read-only (round-9 fix #2) and
+    must NOT evict stale worker-* artifacts.  The worker-* set during a dry-run reflects the
+    latest executed run; dry-run is not a promotion action, and the next executed run evicts."""
+    # Seed a stale proposed artifact at worker-0.
+    active = tmp_path / "reports" / "agent_loop" / "active"
+    stale_wdir = active / "omc_runs" / "omc-team" / "worker-0"
+    stale_wdir.mkdir(parents=True, exist_ok=True)
+    stale_artifact = stale_wdir / "patch_artifact.json"
+    stale_content = json.dumps({"verdict": "proposed", "diff": "stale from prior run"})
+    stale_artifact.write_text(stale_content, encoding="utf-8")
+
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    omc = _fake_omc_runner()
+
+    # execute=False (dry-run) — must be read-only, no artifact eviction.
+    result = agent_loop.write_active_codex_runner(
+        execute=False, runner="omc", repo_root=repo, omc_runner=omc,
+    )
+
+    assert result.decision in {"planned", "blocked"}, (
+        f"dry-run should be planned or blocked; got {result.decision!r}"
+    )
+    # Stale worker-0 must STILL EXIST — dry-run is read-only.
+    assert stale_wdir.exists(), "dry-run must not evict stale worker-* (read-only invariant)"
+    assert stale_artifact.read_text(encoding="utf-8") == stale_content, (
+        "dry-run must not modify stale worker artifact content"
+    )
+
+
+def test_omc_worker_eviction_rmtree_failure_neutralizes_stale_to_blocked(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HIGH-3 codex round-3: when shutil.rmtree fails during stale eviction, the artifact is
+    neutralized in-place by overwriting it with a blocked artifact so it can never be promoted.
+    The run must still proceed to launch (neutralize success → no blocker added).
+    A warning containing 'neutralized' must be emitted."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+
+    # Seed a stale PROPOSED artifact at worker-0.
+    active = repo / "reports" / "agent_loop" / "active"
+    stale_wdir = active / "omc_runs" / "omc-team" / "worker-0"
+    stale_wdir.mkdir(parents=True, exist_ok=True)
+    stale_artifact = stale_wdir / "patch_artifact.json"
+    stale_artifact.write_text(
+        json.dumps({"verdict": "proposed", "diff": "stale diff from prior run", "agent": "omc"}),
+        encoding="utf-8",
+    )
+
+    # Patch shutil.rmtree to raise — simulates permission / file-lock failure.
+    original_rmtree = shutil.rmtree
+
+    def _fail_rmtree(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "worker-" in str(path):
+            raise OSError(f"[Errno 13] Permission denied: '{path}'")
+        return original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", _fail_rmtree)
+
+    diff = "diff --git a/foo.py b/foo.py\n+x\n"
+    omc = _fake_omc_runner()
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+        git_runner=_fake_git_runner(diff_stdout=diff), task_id="T-2026-1804",
+    )
+
+    # Run must proceed (neutralize succeeded → no blocker from eviction).
+    assert result.decision == "completed", (
+        f"run must complete when rmtree fails but neutralize succeeds; got {result.decision!r}"
+    )
+    # (a) stale artifact must be overwritten to blocked (not proposed).
+    assert stale_artifact.exists(), "stale artifact path should still exist (rmtree failed)"
+    neutralized = json.loads(stale_artifact.read_text(encoding="utf-8"))
+    assert neutralized["verdict"] == "blocked", (
+        f"stale artifact must be neutralized to blocked; got verdict={neutralized['verdict']!r}"
+    )
+    assert neutralized.get("diff", "") == "", "neutralized artifact must have empty diff"
+    # (b) a warning mentioning 'neutralized' must be emitted.
+    assert any("neutralized" in w.lower() for w in result.warnings), (
+        f"expected a 'neutralized' warning; warnings={result.warnings}"
+    )
+    # (c) no eviction-related blocker (neutralize succeeded).
+    assert not any("fail-closed" in b.lower() for b in result.blockers), (
+        f"no fail-closed blocker expected when neutralize succeeds; blockers={result.blockers}"
+    )
+
+
+def test_omc_worker_eviction_total_failure_blocks(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-3 codex round-3 (double-failure): when BOTH rmtree AND neutralize fail, the run
+    must be blocked fail-closed with a blocker mentioning 'fail-closed'."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+
+    # Seed a stale proposed artifact at worker-0.
+    active = repo / "reports" / "agent_loop" / "active"
+    stale_wdir = active / "omc_runs" / "omc-team" / "worker-0"
+    stale_wdir.mkdir(parents=True, exist_ok=True)
+    stale_artifact = stale_wdir / "patch_artifact.json"
+    stale_artifact.write_text(
+        json.dumps({"verdict": "proposed", "diff": "stale diff"}),
+        encoding="utf-8",
+    )
+
+    # Patch rmtree to fail.
+    original_rmtree = shutil.rmtree
+
+    def _fail_rmtree(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "worker-" in str(path):
+            raise OSError(f"[Errno 13] Permission denied: '{path}'")
+        return original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", _fail_rmtree)
+
+    # Patch _write_blocked_omc_artifact to fail ONLY for the stale worker artifact path,
+    # so _finalize_omc_runner_result (called later on the normal artifact_path) still works.
+    real_write_blocked = agent_loop._write_blocked_omc_artifact
+
+    def _fail_neutralize(artifact_path, **kwargs):  # type: ignore[no-untyped-def]
+        if "worker-" in str(artifact_path):
+            raise OSError("write denied — simulated neutralize failure")
+        return real_write_blocked(artifact_path, **kwargs)
+
+    monkeypatch.setattr(agent_loop, "_write_blocked_omc_artifact", _fail_neutralize)
+
+    omc = _fake_omc_runner()
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+    )
+
+    assert result.decision == "blocked", (
+        f"double-failure must block the run fail-closed; got {result.decision!r}"
+    )
+    assert any("fail-closed" in b.lower() for b in result.blockers), (
+        f"expected a 'fail-closed' blocker; blockers={result.blockers}"
+    )
+
+
+def test_omc_single_worker_capture_blocker_has_no_worker_prefix(monkeypatch, tmp_path: Path) -> None:
+    """LOW-1 byte parity: N==1 run with a capture blocker (merge-base fail) must NOT prefix
+    the blocker message with 'worker 0:' — the pre-PR-D single-worker blocker format is
+    preserved for byte-identical compatibility."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    omc = _fake_omc_runner()  # single worker
+    git = _fake_git_runner(merge_base_sha="")  # empty sha → merge-base fail
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc,
+        git_runner=git, task_id="T-2026-1804",
+    )
+
+    assert result.decision == "blocked"
+    # LOW-1: single-worker blockers must NOT have the "worker 0:" prefix.
+    assert all(not b.startswith("worker 0:") for b in result.blockers), (
+        f"N==1 blockers must not have 'worker 0:' prefix; blockers={result.blockers}"
+    )
+    # Sanity: there IS a merge-base related blocker.
+    assert any("merge" in b.lower() or "base" in b.lower() or "diff" in b.lower() for b in result.blockers), (
+        f"expected a capture blocker; blockers={result.blockers}"
+    )
 
 
 # --- PR-L round-2 fix #3: task_id propagation to patch artifact regression ---

--- a/tests/test_global_concurrency_limiter_regression.py
+++ b/tests/test_global_concurrency_limiter_regression.py
@@ -46,6 +46,10 @@ from scripts import agent_loop
 # loop integration suite rather than re-deriving the registry/lease scaffolding.
 from test_agent_loop import (  # type: ignore[import-not-found]
     _chatgpt_auth_runner,
+    _fake_git_runner,
+    _fake_omc_runner,
+    _multi_worker_git_runner,
+    _two_worker_summary,
     _write_expanded_active_runner_fixture,
     _write_repo,
 )
@@ -528,4 +532,120 @@ def test_blocker_break_straggler_inline_and_finally_release_no_over_release(tmp_
     assert calls["n"] >= 2, "fixture spawned <2 codex children -> blocker-break path not exercised"
     # No ValueError was raised (pytest would have failed); every permit is back
     # despite the straggler being release()'d inline and revisited by the finally.
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+# ---------------------------------------------------------------------------
+# (f) omc runner launch acquires EXACTLY one global slot (ADR 0095 PR-D)
+#
+# ``omc team`` is a SINGLE out-of-process subprocess (it fans out its own tmux
+# workers out-of-process), so the in-process semaphore charges the launch ONE
+# permit — not one per omc worker. These tests pin that the omc path (a) acquires
+# exactly one slot for the launch+poll+capture span and (b) returns it on EVERY
+# exit (success or blocked), with no BoundedSemaphore over-release.
+# ---------------------------------------------------------------------------
+
+
+def _count_slot_acquisitions(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Wrap ``GlobalConcurrencyLimiter.slot`` to count enter/exit; returns the live counter."""
+    counter = {"acquired": 0, "max_held": 0, "held": 0}
+    real_slot = agent_loop.GlobalConcurrencyLimiter.slot
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def counting_slot(self):  # type: ignore[no-untyped-def]
+        with real_slot(self):
+            counter["acquired"] += 1
+            counter["held"] += 1
+            counter["max_held"] = max(counter["max_held"], counter["held"])
+            try:
+                yield
+            finally:
+                counter["held"] -= 1
+
+    monkeypatch.setattr(agent_loop.GlobalConcurrencyLimiter, "slot", counting_slot)
+    return counter
+
+
+def test_omc_launch_acquires_exactly_one_global_slot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A successful omc run takes exactly ONE global slot for its launch+poll+capture span."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    counter = _count_slot_acquisitions(monkeypatch)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    omc = _fake_omc_runner()
+    git = _fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n")
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        task_id="T-2026-1804",
+    )
+
+    assert result.decision == "completed"
+    assert counter["acquired"] == 1, f"omc launch must acquire exactly one slot, got {counter['acquired']}"
+    assert counter["max_held"] == 1, f"never more than one slot held, got {counter['max_held']}"
+    # The single permit was returned: the default-8 limiter is fully restored.
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_omc_launch_releases_slot_on_blocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A blocked omc run (merge-base failure) still releases its one slot exactly once — no
+    leak, no BoundedSemaphore over-release ValueError."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    counter = _count_slot_acquisitions(monkeypatch)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
+    omc = _fake_omc_runner()
+    # merge_base_sha="" → merge-base fails → BLOCKED inside the slot span.
+    git = _fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n", merge_base_sha="")
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        task_id="T-2026-1804",
+    )
+
+    assert result.decision == "blocked"
+    assert counter["acquired"] == 1, f"blocked omc run still acquires its one slot, got {counter['acquired']}"
+    assert counter["held"] == 0, "the slot must be released on the blocked path (no leak)"
+    # No ValueError (pytest would fail); the single permit is fully restored.
+    _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
+
+
+def test_omc_multi_worker_launch_acquires_exactly_one_global_slot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """LOW-2 (ADR 0095 PR-D N>1 semaphore variant): a multi-worker (read_agent='auto') omc run
+    also charges the in-process semaphore EXACTLY ONE permit for the entire launch+poll+capture
+    span (omc fans out its own workers out-of-process, so in-process M = 1 permit).
+    max_held must remain 1 — never 2+ regardless of the number of omc workers captured."""
+    monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    counter = _count_slot_acquisitions(monkeypatch)
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804", claimed_files=["foo.py", "bar.py"])
+    omc = _fake_omc_runner(summary_workers=_two_worker_summary())
+    git = _multi_worker_git_runner({
+        "/tmp/wt-0": "diff --git a/foo.py b/foo.py\n+a\n",
+        "/tmp/wt-1": "diff --git a/bar.py b/bar.py\n+b\n",
+    })
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True, runner="omc", repo_root=repo, omc_runner=omc, git_runner=git,
+        read_agent="auto", task_id="T-2026-1804", max_parallel=2,
+    )
+
+    # N>1 all-pass → needs-human-selection blocked (the result decision).
+    assert result.decision == "blocked"
+    assert any("needs human selection" in b.lower() for b in result.blockers), result.blockers
+    # Semaphore: exactly one slot acquired for the entire multi-worker span.
+    assert counter["acquired"] == 1, (
+        f"omc multi-worker launch must acquire exactly one global slot, got {counter['acquired']}"
+    )
+    assert counter["max_held"] == 1, (
+        f"never more than one slot held simultaneously, got {counter['max_held']}"
+    )
+    assert counter["held"] == 0, "the single slot must be released after the multi-worker run"
     _assert_all_permits_restored(agent_loop.global_concurrency_limiter())


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1804

ADR 0095 brick 5/7 (PR-D). omc runner 의 worker-pin (`total_workers=1` + assert) 을 제거해 omc 가 agent_mix 가중치 기반으로 worker 수를 도출하도록 한다 (`min(OMC_MAX_WORKERS, max_parallel)` clamp, fail-closed `>=1`). ADR 0087 이 보류했던 per-worker diff capture 를 구현 — 각 worker diff 를 privacy + scope 재감사 후 자기 `worker-{idx}` namespace 에 격리. **DARK ship**: X task-pool 은 X=1 유지 (PR-E/F 까지), 이 PR 은 Y(per-task omc multi-worker) 만 default-on.

## 2. 영향 파일

- `scripts/agent_loop.py` — **NOT load-bearing** (`scripts/_governance.py` `LOAD_BEARING_PATHS` 제외; 자율 루프 오케스트레이션, RAG/eval surface 아님)
- `Makefile` — `OMC_MAX_WORKERS ?= 3` knob
- `docs/adr/0095-task-parallel-bounded-loop.md` (**load-bearing** docs/adr/) — Decision/Consequences 보강, **Status: proposed 유지** (X-enable PR-F 에서 accepted)
- `docs/adr/0087-opt-in-omc-team-parallel-runner.md` (**load-bearing** docs/adr/) — Deferred 섹션 "보류"→"PR-D 구현됨"
- `docs/plans/xyz-parallelism-stack.md` — PR-D 상태 + HIGH-4 defer 기록
- `tests/test_agent_loop.py`, `tests/test_global_concurrency_limiter_regression.py` — +18 tests

## 3. 리스크

가장 가능성 높은 깨짐: stale/late `proposed` per-worker artifact 가 human-promotion / active-apply 경로로 새는 fail-open. **4 라운드 codex adversarial review** 로 배제 — late heartbeat-invalidation, N>1 summary-missing falldown, fixed-namespace stale, eviction-failure 를 전부 fail-closed 로 닫음 (codex round-4 clean SHIP, must-fix none). byte-identical 불변(N==1 + codex path)을 회귀 테스트로 고정.

## 4. 테스트

+18 tests (375 passed). byte-identical parity (변경 전후 동일 `proposed` standard artifact), worker-mix 도출, per-worker diff capture/re-audit, semaphore wiring, fail-closed 회귀 (eviction rmtree 실패 → neutralize→blocked / total-failure→blocked early-return, heartbeat-invalidation→blocked overwrite, partial-capture→blocked, N>1 summary-missing→blocked).

## 5. Eval 영향

**real-data 영향 없음.** `scripts/agent_loop.py` 는 NOT load-bearing (RAG/retrieval/eval surface 아님 — `시작omc` 자율 루프 오케스트레이션). runner=omc only 이며 codex path + omc N==1 은 byte-identical (ADR 0001 baseline 불변). `docs/adr/` 수정은 결정 기록(0095 proposed 유지, 0087 Deferred 갱신)이지 eval 계약/측정 표면 변경 아님. CI eval delta: All `·` (RAG 외 변경).

## 6. 하위 호환

Breaking 없음. 기존 codex runner path 와 omc N==1 path 는 byte-identical 보존. Answer-contract (ADR 0003) 무관 — `schema_version` bump 불필요. 신규 동작(N>1 worker derivation)은 runner=omc + ack-gated 에서만 활성, X=1 DARK.

## 7. 범위 외

- X task-pool enable (X=2 flip + ADR 0094/0095 Proposed→Accepted) → **PR-F**
- X>1 publication race (canonical routing + `_finalize` artifact-write 가 global slot 밖 + standard path 공유) → **PR-E** per-task artifact namespacing + publication fence (codex HIGH-4 documented-defer; PR-D 는 X=1 dark 라 무해)
- `agent_loop` privacy redaction 이 `reports/real100/` 만 매치하고 `real100_v2*` 미포함 — pre-existing, PR-D diff 밖 (codex HIGH-5) → 별도 follow-up
- pre-existing Pyright type-looseness (CI 는 pytest-only gate)
