### PR TITLE
feat(agent-loop): per-task path substrate + redaction scoping (XYZ brick 6a)

### DIFF
--- a/docs/adr/0095-task-parallel-bounded-loop.md
+++ b/docs/adr/0095-task-parallel-bounded-loop.md
@@ -122,7 +122,18 @@ completion(마지막 완료 이후 누적된 blocker)" 으로 재정의한다.
 - 가드-semantics 변경이 문서화된다 — consecutive-blocker 가 "since last completion" 으로 재정의
   되고, wall-clock 은 per-task budget 으로 재표현된다. exit-code 가드 SEMANTICS 는 보존.
 - redaction-scan per-task scoping 이 요구된다 — `_redact_active_*` glob 이 동시 task 를 교차
-  스캔하지 않도록 PR-E 전에 trace + scoping 필요(미해결 시 PR-E 보류).
+  스캔하지 않도록 PR-E 전에 trace + scoping 필요(미해결 시 PR-E 보류). **PR-E1(#1817)에서
+  착륙**: `_redact_active_codex_runs`/`_redact_active_patch_runs` 에 `task_slug` 인자를 추가해
+  scan 을 `<active>/codex_runs|patch_runs/<slug>` subtree 로 좁히고, `expected` 가드를 "표준 경로
+  OR 그 직계 task-scoped 자식" 으로 확장한다(pre-E1 의 bare `runs != expected` 동치 검사는
+  task-scoped 경로를 *조용히 스킵* → private 데이터 누출의 가장 미묘한 함정이었다). `task_slug`
+  은 영숫자+`-_` 만 허용한다(`_sanitize_task_slug`) — `.`·`/` 를 포함한 그 외 문자는 모두
+  **제거**되므로 `.`/`..`/traversal 토큰이 애초에 살아남을 수 없고(charset 자체가 방어),
+  남는 글자가 없으면 `None` 을 반환한다. 미지정(`task_slug=None`) 시 표준 경로로 fallback
+  하되, **task-scoped intent(`task_slug is not None`)인데 sanitize 결과가 `None`(unsafe)이면
+  표준 경로를 스캔하지 않고 `0` 을 반환(fail-closed)** — task-scoped 모드에서 표준 스캔으로
+  fallback 하면 실제 per-task subtree 를 건너뛰어 누출이 되기 때문(E1 기본 = byte-identical,
+  E2 가 slug 주입해 활성).
 - guard trip 하에서 completed-set 이 비결정적(nondeterministic)일 수 있다 → count 기반 정확 일치
   대신 invariant-based 테스트로 검증한다.
 - `EXECUTE_SHIP=0`(ADR 0083) 불변, X=1/M=8 byte-identical(ADR 0001), `agent_loop.py`
@@ -134,8 +145,27 @@ completion(마지막 완료 이후 누적된 blocker)" 으로 재정의한다.
   `global_concurrency_limiter().slot()` **밖**에서 실행된다. 모든 omc run 이 공유하는 단일 표준
   경로(`patch_runs/implementer/patch_artifact.json`)가 있기 때문에 X>1 동시 omc run에서 artifact
   last-writer-wins race 가 발생하고, teardown 진입 시점에 이미 permit 이 반환된 상태다. PR-D 는
-  X=1 dark 이므로 동시 omc run 이 없어 무해하다. PR-E 의 per-task artifact namespacing +
-  publication fence 가 slot-scope 를 확장하고 standard-path race 를 닫는다(X-enable 은 PR-F 전제).
+  X=1 dark 이므로 동시 omc run 이 없어 무해하다. **이 race 는 slot/fence 가 아니라 PR-E2 의
+  per-task disjoint `standard_path` 로 닫힌다** — semaphore 는 capacity throttle 이지 publication
+  mutex 가 아니다(아래 PR-E1 항목). PR-E1 은 그 `standard_path` 파라미터화 substrate 만 깐다.
+- **PR-E1(#1817)에서 `standard_path` substrate 착륙 — HIGH-4 는 slot/fence 로 닫지 않는다**:
+  PR-E 가 2-PR 로 분할된다(E1=path/privacy substrate, E2=#1816 X task pool). E1 은 **오직**
+  표준 active-apply 경로를 `_finalize_omc_runner_result` 의 `standard_path` 인자로
+  parametrize 하고(4개의 하드코딩 재계산 제거 — late-blocker overwrite 포함), per-task
+  run-root helper(`_omc_task_run_root`)와 task-scoped redaction scoping(`task_slug`)을 도입한다.
+  **HIGH-4 의 X>1 publication race 를 slot/semaphore fence 로 닫지 않는다**:
+  `global_concurrency_limiter()` 는 `BoundedSemaphore(M)` **capacity throttle** 일 뿐
+  **publication mutex 가 아니다** — M=1 이어도 teardown gap 이 launch/capture 순서와 publication
+  순서를 분리하고, M>1 이면 두 sibling run 이 둘 다 permit 을 쥔 채 같은 `standard_path` 를
+  last-writer-wins clobber 한다(slot 은 exclusion 을 제공하지 못한다). legacy 공유 경로에 flock 을
+  거는 것도 같은 이유로 last-writer-wins data loss 를 못 막고 partial-write tearing 만 막으며,
+  E2 가 path 를 disjoint 로 만들면 redundant 가 된다. 따라서 E1 의 finalize 는 **어떤 slot 으로도
+  감싸지 않는다**(launch slot 은 ADR 0094 의 정당한 spawn throttle 로 유지). **E1 기본값
+  (standard_path 미지정, task_slug=None)은 기존 경로 계산식과 textually identical → X=1
+  byte-identical(ADR 0001); X=1 은 dark 라 동시 publication 자체가 없다**. HIGH-4 의 실제 fix 는
+  **PR-E2** 가 E1 substrate 의 task_slug 를 per-task **disjoint `standard_path`** 로 wiring +
+  **M>1 동시 publication 회귀 테스트**(서로 다른 path 로 publish → 충돌 없음 증명)로 닫는다
+  (X-enable 은 PR-F 전제).
 
 ## Verification
 

--- a/docs/plans/xyz-parallelism-stack.md
+++ b/docs/plans/xyz-parallelism-stack.md
@@ -167,6 +167,20 @@ autonomy core).
    를 "since-last-completion(마지막 완료 이후 blocker)" 로 재정의, per-task wall-clock budget,
    convergent stop(#1719 teardown 재사용), per-task artifact namespacing(redaction-scan scoping
    포함). 기본 X=1 으로 dark 착륙.
+   - **2-PR 분할 — E1(#1817 path/privacy substrate) / E2(#1816 X task pool)**: privacy(누출
+     방지)와 throughput(동시 task) concern 을 분리하고 **gating-first**(누출 가드를 X 도입
+     *전에* 착륙)로 진행한다. **E1**(이 단계) = redaction-scan per-task scoping + expected-가드
+     확장 + `_finalize_omc_runner_result` `standard_path` 인자화 + per-task run-root helper +
+     slug sanitize 계약(alnum+`-`+`_`, task-scoped fail-closed) — 모두 X=1 byte-identical
+     인프라(ADR 0001), X>1 은 미도입. **E1 은 HIGH-4 를 slot/fence 로 닫지 않는다**:
+     `global_concurrency_limiter()` 는 BoundedSemaphore(M) capacity throttle 일 뿐 publication
+     mutex 가 아니므로(두 sibling run 이 둘 다 permit 을 쥔 채 같은 `standard_path` 를
+     last-writer-wins) fence 로 쓰면 안 된다 — E1 은 오직 `standard_path` 파라미터화 substrate 만
+     깐다(X=1 은 dark 라 동시 publication 자체가 없음). **E2** = `run_one_task` +
+     `ThreadPoolExecutor` + locked `claim_next_task` 가 E1 substrate 의 task_slug 를 per-task
+     **disjoint `standard_path`** 로 wiring + **M>1 동시 publication 회귀 테스트**(서로 다른 path
+     로 publish 하므로 충돌 없음을 증명) → 이것이 HIGH-4 의 실제 fix. E1 이 redaction cross-scan
+     위험(아래 Stop condition)을 닫으므로 E2 는 그 가드 위에서 안전하게 task pool 을 올린다.
 7. **PR-F — flip-on(X=2) + ADR Accepted + runbook**: X 기본을 2 로 올리고 ADR 0094/0095 를
    proposed → accepted 로 전환, [`docs/operations/active-agent-loop.md`](../operations/active-agent-loop.md)
    에 운영 runbook 추가.
@@ -248,13 +262,21 @@ PR-E 에서 기본 1 → PR-F 에서 2 로 flip 하므로, 회귀 시 X=1 으로
   patch_artifact.json` 이 disk 에 잔존 — human 이 오래된 proposed 를 promote 할 수 있다. 해소:
   eviction 을 **함수 초입(`execute=True` 가드)**으로 이동해 모든 early-return 앞에 실행. dry-run
   (`execute=False`)은 round-9 fix #2 read-only 불변으로 제외.
-- **Failure mode (PR-D 한정, X=1 dark 동안 무해): artifact race + teardown-중 permit 조기 release**.
+- **HIGH-4 (X>1-only artifact publication race; X=1 dark 동안 무해) — PR-D / E1 / E2 분할**.
   `_finalize_omc_runner_result`(artifact write + heartbeat invalidation)와 teardown(shutdown)이
   `global_concurrency_limiter().slot()` 밖에서 실행된다. 모든 omc run 이 공유하는 단일 표준
   경로(`patch_runs/implementer/patch_artifact.json`)에서 X>1 동시 omc run 시 last-writer-wins
-  race 가 발생하고, teardown 진입 전에 permit 이 이미 반환된다. PR-D 는 X=1 dark 이므로 동시
-  omc run 이 없어 **무해**하다. PR-E 의 per-task artifact namespacing + publication fence 가
-  slot-scope 를 확장하고 standard-path race 를 닫는다(X-enable 은 PR-F 전제).
+  race 가 발생한다.
+  - **PR-D**: 이 race 를 만들지만 X=1 dark(동시 omc run 0개)라 **무해**.
+  - **PR-E1**(이 단계): `standard_path` **파라미터화 substrate** 만 깐다 — slot/fence 가
+    **아니다**. semaphore 는 capacity throttle 이지 publication mutex 가 아니므로(M=1 이어도
+    teardown gap 이 launch/capture 순서와 publication 순서를 분리, M>1 이면 두 run 이 동시에
+    permit 을 쥔 채 같은 path 를 clobber) fence 로 쓰면 last-writer-wins data loss 를 못 막고
+    partial-write tearing 만 막는다. legacy 공유 경로에 flock 을 거는 것도 같은 이유로 오답이며,
+    E2 가 path 를 disjoint 로 만들면 redundant 가 된다. X=1 byte-identical(ADR 0001).
+  - **PR-E2**: E1 substrate 의 task_slug 를 per-task **disjoint `standard_path`** 로 wiring →
+    동시 task 가 서로 겹치지 않는 path 로 publish 하므로 race 자체가 사라진다 + **M>1 동시
+    publication 회귀 테스트**로 증명. 이것이 HIGH-4 의 실제 fix(X-enable 은 PR-F 전제).
 
 ## Observability
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -11876,6 +11876,40 @@ def _active_path(path: Path, *, repo_root: Path) -> Path:
 _ACTIVE_CODEX_RUN_REDACT_SUFFIXES = {".md", ".txt", ".json", ".jsonl", ".yaml", ".yml", ".log"}
 
 
+def _sanitize_task_slug(task_id: str | None) -> str | None:
+    """Sanitize a task id into a path-safe run-root slug (ADR 0095 PR-E1 substrate).
+
+    Returns ``None`` for a missing/blank/unsafe id so the caller keeps the legacy
+    (un-scoped) run-root — the X==1 byte-identical path. Only alnum + ``-`` + ``_`` survive
+    (``[A-Za-z0-9_-]``); every other character — crucially ``.`` and ``/`` — is dropped, so
+    the result can never be ``.`` / ``..`` nor contain a parent-dir component, and a
+    hostile/garbage task id can never escape the ``active/codex_runs/`` subtree via path
+    traversal. (Defense-in-depth: ``.`` is excluded from the charset precisely so no
+    traversal token can survive in the first place.) Mirrors ``_validate_session_id`` but
+    returns ``None`` instead of raising so the legacy path is the safe default.
+    """
+    if not isinstance(task_id, str):
+        return None
+    safe = re.sub(r"[^A-Za-z0-9_-]", "", _sanitize_inline_text(task_id))
+    if not safe:
+        return None
+    return safe
+
+
+def _omc_task_run_root(active_dir: Path, *, task_slug: str | None) -> Path:
+    """Resolve the omc/codex run-root for a task (ADR 0095 PR-E1 substrate).
+
+    ``task_slug is None`` -> legacy ``<active>/codex_runs`` (byte-identical with the pre-PR-E
+    single-task path; the X==1 default). A non-None slug -> ``<active>/codex_runs/<slug>`` so
+    concurrent X>1 tasks write into disjoint run-roots instead of colliding on one directory.
+    E1 callers pass ``task_slug=None`` (legacy); E2 wires the slug to activate per-task scoping.
+    """
+    base = active_dir / "codex_runs"
+    if task_slug is None:
+        return base
+    return base / task_slug
+
+
 def _redact_text_file_in_place(path: Path) -> bool:
     try:
         text = _read_text(path)
@@ -11888,10 +11922,57 @@ def _redact_text_file_in_place(path: Path) -> bool:
     return True
 
 
-def _redact_active_codex_runs(active_dir: Path, *, repo_root: Path) -> int:
+def _is_standard_or_task_scoped_run_root(runs: Path, expected: Path, *, repo_root: Path) -> bool:
+    """Privacy-critical guard (ADR 0095 PR-E1): accept ``runs`` iff it is the standard run-root
+    OR a *direct* task-scoped child subtree of it (``expected/<task_slug>``).
+
+    Pre-PR-E the guard was a bare ``runs != expected`` equality check, which would *silently
+    skip* every per-task path (``active/codex_runs/<slug>``) E2 introduces — leaving private
+    data un-redacted before it crosses the privacy gate. This widens the guard to the standard
+    path AND its direct children while keeping traversal defense: both paths are first run
+    through ``_safe_output_path`` (enforces the ``reports/agent_loop/`` containment + resolves
+    ``..``), and we additionally require the resolved ``runs`` to sit under ``repo_root`` and to
+    have ``expected`` as its resolved parent (direct child only — no deeper / sibling escape).
+    """
+    runs_resolved = runs.resolve()
+    expected_resolved = expected.resolve()
+    repo_resolved = repo_root.resolve()
+    # Containment: the redaction target must stay under the repo root (defense-in-depth on top
+    # of the _safe_output_path reports/agent_loop/ fence already applied by the caller).
+    try:
+        runs_resolved.relative_to(repo_resolved)
+    except ValueError:
+        return False
+    if runs_resolved == expected_resolved:
+        return True
+    # Direct task-scoped child only: active/codex_runs/<task_slug> (one level under expected).
+    return runs_resolved.parent == expected_resolved
+
+
+def _redact_active_codex_runs(active_dir: Path, *, repo_root: Path, task_slug: str | None = None) -> int:
+    """Redact the active codex-run artifacts before the privacy gate.
+
+    ``task_slug`` (ADR 0095 PR-E1 substrate): when ``None`` (the E1 default) this scans the
+    standard ``<active>/codex_runs`` directory — byte-identical with the pre-PR-E behaviour. When
+    a non-None slug is supplied (E2 wiring) it scopes the scan to that task's run-root
+    (``<active>/codex_runs/<slug>``) so a per-task redaction never cross-scans a concurrent task's
+    subtree. The slug is re-sanitized here (defense-in-depth). FAIL-CLOSED: in task-scoped mode
+    (``task_slug is not None``) an unsafe slug that sanitizes to ``None`` returns 0 WITHOUT
+    scanning — it must NOT silently fall back to the standard scan, which in task-scoped mode
+    would skip the real per-task data subtree (``<slug>``) and leave it un-redacted before the
+    privacy gate (leak). The legacy ``task_slug is None`` standard scan is unchanged (byte-identical).
+    """
+    if task_slug is not None:
+        safe_slug = _sanitize_task_slug(task_slug)
+        if safe_slug is None:
+            return 0  # fail-closed: task-scoped intent + unsafe slug -> never scan the standard path
+    else:
+        safe_slug = None
     runs = _safe_output_path(active_dir / "codex_runs", repo_root=repo_root)
+    if safe_slug is not None:
+        runs = _safe_output_path(runs / safe_slug, repo_root=repo_root)
     expected = _safe_output_path(repo_root / "reports" / "agent_loop" / "active" / "codex_runs", repo_root=repo_root)
-    if runs != expected or not runs.exists():
+    if not _is_standard_or_task_scoped_run_root(runs, expected, repo_root=repo_root) or not runs.exists():
         return 0
     paths = sorted(runs.rglob("*")) if runs.is_dir() else [runs]
     changed = 0
@@ -11903,10 +11984,27 @@ def _redact_active_codex_runs(active_dir: Path, *, repo_root: Path) -> int:
     return changed
 
 
-def _redact_active_patch_runs(active_dir: Path, *, repo_root: Path) -> int:
+def _redact_active_patch_runs(active_dir: Path, *, repo_root: Path, task_slug: str | None = None) -> int:
+    """Redact the active patch-run artifacts before the privacy gate.
+
+    ``task_slug`` (ADR 0095 PR-E1 substrate): mirrors ``_redact_active_codex_runs`` — ``None``
+    scans the standard ``<active>/patch_runs`` (byte-identical default), a non-None slug scopes
+    the scan to ``<active>/patch_runs/<slug>`` so concurrent X>1 tasks do not cross-scan.
+    FAIL-CLOSED: in task-scoped mode (``task_slug is not None``) an unsafe slug that sanitizes to
+    ``None`` returns 0 WITHOUT scanning — falling back to the standard scan would skip the real
+    per-task subtree and leak it past the privacy gate. ``task_slug is None`` is unchanged.
+    """
+    if task_slug is not None:
+        safe_slug = _sanitize_task_slug(task_slug)
+        if safe_slug is None:
+            return 0  # fail-closed: task-scoped intent + unsafe slug -> never scan the standard path
+    else:
+        safe_slug = None
     runs = _safe_output_path(active_dir / "patch_runs", repo_root=repo_root)
+    if safe_slug is not None:
+        runs = _safe_output_path(runs / safe_slug, repo_root=repo_root)
     expected = _safe_output_path(repo_root / "reports" / "agent_loop" / "active" / "patch_runs", repo_root=repo_root)
-    if runs != expected or not runs.exists():
+    if not _is_standard_or_task_scoped_run_root(runs, expected, repo_root=repo_root) or not runs.exists():
         return 0
     paths = sorted(runs.rglob("*")) if runs.is_dir() else [runs]
     changed = 0
@@ -13537,6 +13635,14 @@ def _run_omc_team_runner(
     omc_runs_path = runs_path.parent / "omc_runs"
     run_dir = omc_runs_path / session_id
     artifact_path = run_dir / "patch_artifact.json"
+    # (ADR 0095 PR-E1) standard active-apply consumption path, computed once and threaded into
+    # every ``_finalize_omc_runner_result`` call. E1 injects the LEGACY path (textually identical
+    # to finalize's default) so X==1 is byte-identical; E2 swaps this for a per-task path so
+    # concurrent X>1 runs publish into disjoint standard paths instead of racing one file.
+    standard_path = (
+        _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent
+        / "patch_runs" / "implementer" / "patch_artifact.json"
+    )
     # HIGH-3 (codex round-2 fix): evict stale worker-* artifacts at function entry, BEFORE any
     # early-return, so EVERY execute=True path (no-ack, task-scope ambiguity, assignment missing,
     # privacy/scope pre-launch blocked, AND the normal launch path) starts from a clean slate.
@@ -13592,6 +13698,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13620,6 +13727,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13680,6 +13788,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13722,6 +13831,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13750,6 +13860,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=None,
@@ -13801,6 +13912,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13827,6 +13939,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13868,6 +13981,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -13893,6 +14007,7 @@ def _run_omc_team_runner(
             registry_path=registry_path,
             assignments_path=assignments_path,
             runs_path=omc_runs_path,
+            standard_path=standard_path,
             artifact_path=artifact_path,
             diff_text="",
             task_id=task_id,
@@ -14150,6 +14265,18 @@ def _run_omc_team_runner(
             except Exception as exc:  # pragma: no cover - teardown best-effort
                 warnings.append(f"omc team shutdown warning: {exc}")
 
+    # (ADR 0095 PR-E1) HIGH-4 scope split — NO publication fence here. PR-E1 ships ONLY the
+    # ``standard_path`` parametrization substrate; it stays X==1 byte-identical, and X==1 is dark
+    # (no second task runs concurrently) so there is no concurrent publication to fence at all.
+    # HIGH-4's X>1 publication race (two omc runs last-writer-wins the same ``standard_path``) is
+    # NOT closed by a slot/semaphore: ``global_concurrency_limiter()`` is a BoundedSemaphore(M)
+    # capacity throttle (see ~1113), NOT a publication mutex — two sibling runs can both hold a
+    # permit and still clobber the same path, and even at M==1 the teardown gap separates
+    # launch/capture order from publication order. The honest fix is PR-E2 injecting a per-task
+    # DISJOINT ``standard_path`` (the substrate this PR lays down) so concurrent tasks publish to
+    # non-overlapping paths; a flock here would be wrong (on the legacy shared path it cannot
+    # prevent last-writer-wins, only partial-write tearing, and once E2 makes paths disjoint it is
+    # redundant). So E1 does NOT wrap the finalize in a slot.
     # (ADR 0095 PR-D) Canonical-diff routing from the per-worker captures.
     #   * N==1 + all-pass: feed the single worker's diff into the canonical finalize so the
     #     standard active-apply path gets the proposed artifact — byte-identical to the
@@ -14219,6 +14346,7 @@ def _run_omc_team_runner(
         registry_path=registry_path,
         assignments_path=assignments_path,
         runs_path=omc_runs_path,
+        standard_path=standard_path,
         artifact_path=artifact_path,
         diff_text=diff_text,
         task_id=task_id,
@@ -14549,6 +14677,7 @@ def _finalize_omc_runner_result(
     invalidate_heartbeats: bool,
     needs_human_selection: bool = False,
     worker_count: int = 1,
+    standard_path: Path | None = None,
 ) -> ActiveCodexRunnerResult:
     """Re-impose governance on the captured omc diff, write the patch_artifact.json, and map
     the result into an ActiveCodexRunnerResult (codex-patch-compatible shape).
@@ -14568,6 +14697,15 @@ def _finalize_omc_runner_result(
     blockers = list(blockers)
     warnings = list(warnings)
 
+    # (ADR 0095 PR-E1) standard active-apply consumption path. Parametrized so X>1 callers can
+    # supply a per-task path; the DEFAULT computes the legacy path EXACTLY as the four prior
+    # hardcoded recomputations did -> byte-identical when ``standard_path`` is unset (X==1).
+    if standard_path is None:
+        standard_path = (
+            _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent
+            / "patch_runs" / "implementer" / "patch_artifact.json"
+        )
+
     # (ADR 0095 PR-D) N>1 multi-worker all-pass: route the standard + run-specific paths to a
     # needs-human-selection blocked artifact (per-worker proposals are preserved by the caller).
     # decision is forced blocked so active-apply will not auto-consume; this takes priority over
@@ -14585,7 +14723,6 @@ def _finalize_omc_runner_result(
             artifact_path, session_id=session_id, team_name=team_name,
             worker_count=worker_count, now=now,
         )
-        standard_path = _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent / "patch_runs" / "implementer" / "patch_artifact.json"
         standard_path.parent.mkdir(parents=True, exist_ok=True)
         _write_needs_human_selection_artifact(
             standard_path, session_id=session_id, team_name=team_name,
@@ -14633,7 +14770,6 @@ def _finalize_omc_runner_result(
 
         # Mirror the artifact into the standard active-apply consumption path so the existing
         # integration-branch / Conservative-Gate path consumes it UNCHANGED (no auto-merge).
-        standard_path = _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent / "patch_runs" / "implementer" / "patch_artifact.json"
         standard_path.parent.mkdir(parents=True, exist_ok=True)
         if decision != "blocked":
             standard_path.write_text(artifact_path.read_text(encoding="utf-8"), encoding="utf-8")
@@ -14660,7 +14796,6 @@ def _finalize_omc_runner_result(
     elif execute:
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
         _write_blocked_omc_artifact(artifact_path, session_id=session_id, team_name=team_name, now=now)
-        standard_path = _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent / "patch_runs" / "implementer" / "patch_artifact.json"
         standard_path.parent.mkdir(parents=True, exist_ok=True)
         _write_blocked_omc_artifact(standard_path, session_id=session_id, team_name=team_name, now=now)
 
@@ -14697,13 +14832,11 @@ def _finalize_omc_runner_result(
             # active-apply cannot consume a proposed diff that was produced in the same run
             # whose heartbeat invalidation then failed.  Also overwrite any per-worker
             # worker-{idx} artifacts written by a prior N>1 all-pass run in the same run_dir.
-            _late_blocker_standard_path = (
-                _active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root).parent
-                / "patch_runs" / "implementer" / "patch_artifact.json"
-            )
-            _late_blocker_standard_path.parent.mkdir(parents=True, exist_ok=True)
+            # (PR-E1) reuse the parametrized ``standard_path`` so a per-task run overwrites ITS
+            # own standard path (not the legacy one) — byte-identical at X==1 (default path).
+            standard_path.parent.mkdir(parents=True, exist_ok=True)
             _write_blocked_omc_artifact(
-                _late_blocker_standard_path, session_id=session_id, team_name=team_name, now=now
+                standard_path, session_id=session_id, team_name=team_name, now=now
             )
             artifact_path.parent.mkdir(parents=True, exist_ok=True)
             _write_blocked_omc_artifact(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8242,6 +8242,209 @@ def test_omc_single_worker_standard_path_byte_compat(monkeypatch, tmp_path: Path
     assert run_artifact["verdict"] == "proposed" and run_artifact["diff"] == diff
 
 
+# --- ADR 0095 PR-E1: path/privacy substrate (redaction scoping + standard_path arg + run-root) ---
+
+
+def _active_dir(repo: Path) -> Path:
+    return repo / "reports" / "agent_loop" / "active"
+
+
+def _write_run_file(run_root: Path, name: str, text: str) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
+    target = run_root / name
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def test_redaction_scope_per_task_no_cross_scan(tmp_path: Path) -> None:
+    """ADR 0095 PR-E1: a task-scoped redaction (task_slug='task-a') must redact ONLY task-a's
+    run-root and leave a concurrent task-b run-root byte-for-byte untouched (no cross-scan)."""
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    private = "doc_id-123 leaked to active codex run\n"
+    a_file = _write_run_file(active / "codex_runs" / "task-a", "out.md", private)
+    b_file = _write_run_file(active / "codex_runs" / "task-b", "out.md", private)
+
+    changed = agent_loop._redact_active_codex_runs(active, repo_root=repo, task_slug="task-a")
+
+    assert changed == 1, "exactly task-a's one file should be redacted"
+    assert "[redacted-private-token]" in a_file.read_text(encoding="utf-8")
+    # task-b must be untouched — byte-identical to what was written (no cross-scan).
+    assert b_file.read_text(encoding="utf-8") == private
+
+
+def test_redaction_expected_guard_accepts_task_scoped_path(tmp_path: Path) -> None:
+    """Privacy-leak regression: a task-scoped run-root must NOT be silently skipped by the
+    expected-path guard — the private token must actually be redacted (the pre-PR-E bare equality
+    guard would have skipped it, leaking private data past the privacy gate)."""
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    leak = _write_run_file(
+        active / "codex_runs" / "T-2026-1817", "evidence.json", '{"question": "PRIVATE RAW QUERY"}\n'
+    )
+    # Patch-runs subtree too (mirror function).
+    patch_leak = _write_run_file(
+        active / "patch_runs" / "T-2026-1817", "patch.md", "reports/real100/case-7.json\n"
+    )
+
+    codex_changed = agent_loop._redact_active_codex_runs(active, repo_root=repo, task_slug="T-2026-1817")
+    patch_changed = agent_loop._redact_active_patch_runs(active, repo_root=repo, task_slug="T-2026-1817")
+
+    assert codex_changed == 1 and patch_changed == 1, "task-scoped paths must not be skipped"
+    assert "PRIVATE RAW QUERY" not in leak.read_text(encoding="utf-8")
+    assert "[redacted-private-value]" in leak.read_text(encoding="utf-8")
+    assert "reports/real100/[redacted-private-artifact]" in patch_leak.read_text(encoding="utf-8")
+
+
+def test_sanitize_task_slug_strips_dot_and_separators(tmp_path: Path) -> None:
+    """The slug charset is alnum + ``-`` + ``_`` only — ``.`` and ``/`` are STRIPPED so no
+    parent-dir / separator token can survive (the contract the docstring states). A slug whose
+    only chars are unsafe sanitizes to ``None`` (the fail-closed signal); a slug with some safe
+    chars survives as a within-subtree token that can never traverse."""
+    # ``.`` is dropped (code matches the "alnum + - _ only" docstring): no traversal token remains.
+    assert agent_loop._sanitize_task_slug("T.test") == "Ttest"
+    assert "." not in (agent_loop._sanitize_task_slug("T.test") or "")
+    assert agent_loop._sanitize_task_slug("foo.bar/baz") == "foobarbaz"
+    # Traversal / separator forms collapse to a safe within-subtree token (NOT None) — they cannot
+    # escape because the escaping chars themselves are gone.
+    assert agent_loop._sanitize_task_slug("../../secret_outside") == "secret_outside"
+    assert agent_loop._sanitize_task_slug("a/../b") == "ab"
+    # All-unsafe inputs sanitize to None (the fail-closed signal the redactors key off).
+    assert agent_loop._sanitize_task_slug("..") is None
+    assert agent_loop._sanitize_task_slug(".") is None
+    assert agent_loop._sanitize_task_slug("...") is None
+    assert agent_loop._sanitize_task_slug("") is None
+    assert agent_loop._sanitize_task_slug("!!!") is None
+    # A safe slug survives sanitization unchanged.
+    assert agent_loop._sanitize_task_slug("T-2026-1817") == "T-2026-1817"
+
+
+def test_redaction_traversal_slug_stays_within_subtree(tmp_path: Path) -> None:
+    """A traversal task_slug ('../../secret_outside') must NOT escape the codex_runs subtree: it
+    sanitizes to the within-subtree token 'secret_outside', so the scan targets
+    codex_runs/secret_outside (not present here) and a file planted OUTSIDE the subtree is left
+    byte-identical (no traversal escape)."""
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    # An out-of-subtree file a traversal slug would target if it escaped.
+    outside = repo / "reports" / "agent_loop" / "secret_outside.md"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    outside.write_text("doc_id-999 must never be redacted via traversal\n", encoding="utf-8")
+    # The traversal slug is stripped to 'secret_outside' (a child of codex_runs), which does not
+    # exist here, so nothing is redacted; the out-of-subtree file is left byte-identical.
+    changed = agent_loop._redact_active_codex_runs(active, repo_root=repo, task_slug="../../secret_outside")
+    assert changed == 0
+    assert outside.read_text(encoding="utf-8") == "doc_id-999 must never be redacted via traversal\n"
+
+
+def test_redaction_task_scoped_unsafe_slug_fails_closed_no_standard_scan(tmp_path: Path) -> None:
+    """Privacy fail-closed (ADR 0095 PR-E1): a task-scoped redaction whose slug is UNSAFE (e.g.
+    '..' -> sanitizes to None) must return 0 WITHOUT scanning the STANDARD run-root. Falling back
+    to the standard scan in task-scoped mode would skip the real per-task subtree AND wrongly
+    redact the shared standard path; both branches (codex + patch) must leave a planted standard
+    file byte-identical."""
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    private = "doc_id-555 leaked into the standard run-root\n"
+    # Plant a private file DIRECTLY in the standard (un-scoped) run-roots.
+    std_codex = _write_run_file(active / "codex_runs", "out.md", private)
+    std_patch = _write_run_file(active / "patch_runs", "out.md", private)
+
+    # task_slug is not None (task-scoped intent) but sanitizes to None (unsafe) -> fail-closed.
+    codex_changed = agent_loop._redact_active_codex_runs(active, repo_root=repo, task_slug="..")
+    patch_changed = agent_loop._redact_active_patch_runs(active, repo_root=repo, task_slug="..")
+
+    assert codex_changed == 0, "task-scoped unsafe slug must NOT scan the standard codex_runs path"
+    assert patch_changed == 0, "task-scoped unsafe slug must NOT scan the standard patch_runs path"
+    # The standard-path files were never scanned -> byte-identical (no redaction, no leak-skip).
+    assert std_codex.read_text(encoding="utf-8") == private
+    assert std_patch.read_text(encoding="utf-8") == private
+
+
+def test_finalize_standard_path_arg_per_task(tmp_path: Path) -> None:
+    """ADR 0095 PR-E1: when ``standard_path`` is supplied, ``_finalize_omc_runner_result`` writes
+    the mirrored artifact to THAT path (so two different tasks publish to disjoint paths), not the
+    legacy hardcoded one."""
+    import datetime as _dt
+
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    active.mkdir(parents=True, exist_ok=True)
+    run_dir = active / "omc_runs" / "omc-team"
+    artifact_path = run_dir / "patch_artifact.json"
+    per_task_standard = active / "patch_runs" / "task-zzz" / "implementer" / "patch_artifact.json"
+    legacy_standard = active / "patch_runs" / "implementer" / "patch_artifact.json"
+    diff = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1,2 @@\n line\n+new\n"
+    # An active write lease whose claimed_files cover the diff so the scope re-audit passes.
+    (active / "leases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "leases": [
+                    {
+                        "lease_id": "task-zzz-write",
+                        "status": "active",
+                        "lease_type": "write",
+                        "active_agent": "codex",
+                        "task_id": "T-2026-1817",
+                        "issue": "1817",
+                        "branch": "feat/issue-1817-path-substrate",
+                        "worktree": ".",
+                        "claimed_files": ["foo.py"],
+                        "expires_at": "2099-01-01T00:00:00Z",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = agent_loop._finalize_omc_runner_result(
+        decision="completed",
+        execute=True,
+        session_id="omc-team",
+        verdict="proposed",
+        blockers=[],
+        warnings=[],
+        team_name="omc-team",
+        command_display="omc team ...",
+        state_path=active / "codex_runner_state.json",
+        out_path=active / "codex_runner.md",
+        registry_path=active / "session_registry.json",
+        assignments_path=active / "assignments",
+        runs_path=active / "omc_runs",
+        artifact_path=artifact_path,
+        diff_text=diff,
+        task_id="T-2026-1817",
+        model=None,
+        repo_root=repo,
+        now=_dt.datetime(2026, 6, 2, tzinfo=_dt.timezone.utc),
+        write_artifact=True,
+        invalidate_heartbeats=False,
+        standard_path=per_task_standard,
+    )
+
+    assert result.decision == "completed"
+    # The proposed artifact landed at the per-task standard path, NOT the legacy one.
+    assert per_task_standard.exists(), "per-task standard_path must receive the mirrored artifact"
+    written = json.loads(per_task_standard.read_text(encoding="utf-8"))
+    assert written["verdict"] == "proposed" and written["diff"] == diff
+    assert not legacy_standard.exists(), "the legacy standard path must NOT be written when standard_path is supplied"
+
+
+def test_x1_run_root_uses_legacy_path(tmp_path: Path) -> None:
+    """ADR 0095 PR-E1 byte-identical gate: the run-root helper returns the LEGACY codex_runs path
+    when task_slug is None (X==1 default) and a task-scoped path only when a slug is supplied."""
+    active = _active_dir(_write_repo(tmp_path))
+    # None -> legacy path (byte-identical with the pre-PR-E single-task run-root).
+    assert agent_loop._omc_task_run_root(active, task_slug=None) == active / "codex_runs"
+    # Supplied slug -> per-task subtree (one level under codex_runs).
+    assert (
+        agent_loop._omc_task_run_root(active, task_slug="T-2026-1817")
+        == active / "codex_runs" / "T-2026-1817"
+    )
+
+
 # --- PR-D adversarial fixes (HIGH-1/2/3 + LOW-1) ---
 
 

--- a/tests/test_global_concurrency_limiter_regression.py
+++ b/tests/test_global_concurrency_limiter_regression.py
@@ -536,13 +536,23 @@ def test_blocker_break_straggler_inline_and_finally_release_no_over_release(tmp_
 
 
 # ---------------------------------------------------------------------------
-# (f) omc runner launch acquires EXACTLY one global slot (ADR 0095 PR-D)
+# (f) omc runner launch slot (ADR 0095 PR-D)
 #
 # ``omc team`` is a SINGLE out-of-process subprocess (it fans out its own tmux
 # workers out-of-process), so the in-process semaphore charges the launch ONE
-# permit — not one per omc worker. These tests pin that the omc path (a) acquires
-# exactly one slot for the launch+poll+capture span and (b) returns it on EVERY
-# exit (success or blocked), with no BoundedSemaphore over-release.
+# permit — not one per omc worker. The launch slot wraps launch + poll + per-worker
+# diff capture; teardown (omc shutdown) and the canonical-diff routing + finalize
+# run OUTSIDE the slot.
+#
+# (ADR 0095 PR-E1) There is NO second "publication" slot. An earlier E1 round wrapped
+# the finalize in a second slot as a "publication fence", but ``global_concurrency_limiter()``
+# is a BoundedSemaphore(M) capacity throttle, NOT a publication mutex — two sibling runs
+# can both hold a permit and still last-writer-wins the same ``standard_path``, so the slot
+# never provided exclusion. HIGH-4's X>1 publication race is closed honestly by PR-E2
+# injecting a per-task DISJOINT ``standard_path`` (the substrate this PR lays down), not by a
+# slot. So an omc run takes EXACTLY ONE launch slot: ``acquired == 1``, ``max_held == 1``.
+# These tests pin that 1-slot contract and that the permit is returned on EVERY exit
+# (success or blocked), with no BoundedSemaphore over-release.
 # ---------------------------------------------------------------------------
 
 
@@ -569,7 +579,9 @@ def _count_slot_acquisitions(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
 
 
 def test_omc_launch_acquires_exactly_one_global_slot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """A successful omc run takes exactly ONE global slot for its launch+poll+capture span."""
+    """A successful omc run takes EXACTLY ONE global slot (ADR 0095 PR-D launch slot): the
+    launch+poll+capture span. There is no publication slot (PR-E1 removed it — a semaphore is a
+    capacity throttle, not a publication mutex), so acquired == 1 and max_held == 1."""
     monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
     monkeypatch.setattr("time.sleep", lambda _: None)
     counter = _count_slot_acquisitions(monkeypatch)
@@ -584,22 +596,27 @@ def test_omc_launch_acquires_exactly_one_global_slot(monkeypatch: pytest.MonkeyP
     )
 
     assert result.decision == "completed"
-    assert counter["acquired"] == 1, f"omc launch must acquire exactly one slot, got {counter['acquired']}"
-    assert counter["max_held"] == 1, f"never more than one slot held, got {counter['max_held']}"
-    # The single permit was returned: the default-8 limiter is fully restored.
+    assert counter["acquired"] == 1, (
+        f"omc run takes exactly one launch slot (PR-E1 removed the publication slot), "
+        f"got {counter['acquired']}"
+    )
+    assert counter["max_held"] == 1, f"never more than one slot held simultaneously, got {counter['max_held']}"
+    # The launch permit was returned: the default-8 limiter is fully restored.
     _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
 
 
 def test_omc_launch_releases_slot_on_blocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """A blocked omc run (merge-base failure) still releases its one slot exactly once — no
-    leak, no BoundedSemaphore over-release ValueError."""
+    """A blocked omc run (merge-base failure) still releases the launch slot exactly once — no
+    leak, no BoundedSemaphore over-release ValueError. The merge-base failure blocks inside the
+    launch slot; the finalize that writes the blocked artifact runs OUTSIDE any slot (PR-E1
+    removed the publication slot), so the run takes exactly one slot."""
     monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
     monkeypatch.setattr("time.sleep", lambda _: None)
     counter = _count_slot_acquisitions(monkeypatch)
     repo = _write_repo(tmp_path)
     _write_expanded_active_runner_fixture(repo, task_id="T-2026-1804")
     omc = _fake_omc_runner()
-    # merge_base_sha="" → merge-base fails → BLOCKED inside the slot span.
+    # merge_base_sha="" → merge-base fails → BLOCKED inside the launch slot span.
     git = _fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n", merge_base_sha="")
 
     result = agent_loop.write_active_codex_runner(
@@ -608,9 +625,13 @@ def test_omc_launch_releases_slot_on_blocked(monkeypatch: pytest.MonkeyPatch, tm
     )
 
     assert result.decision == "blocked"
-    assert counter["acquired"] == 1, f"blocked omc run still acquires its one slot, got {counter['acquired']}"
-    assert counter["held"] == 0, "the slot must be released on the blocked path (no leak)"
-    # No ValueError (pytest would fail); the single permit is fully restored.
+    assert counter["acquired"] == 1, (
+        f"blocked omc run takes exactly one launch slot (PR-E1 removed the publication slot), "
+        f"got {counter['acquired']}"
+    )
+    assert counter["max_held"] == 1, f"never more than one slot held simultaneously, got {counter['max_held']}"
+    assert counter["held"] == 0, "the launch slot must be released on the blocked path (no leak)"
+    # No ValueError (pytest would fail); the launch permit is fully restored.
     _assert_all_permits_restored(agent_loop.global_concurrency_limiter())
 
 
@@ -618,9 +639,10 @@ def test_omc_multi_worker_launch_acquires_exactly_one_global_slot(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """LOW-2 (ADR 0095 PR-D N>1 semaphore variant): a multi-worker (read_agent='auto') omc run
-    also charges the in-process semaphore EXACTLY ONE permit for the entire launch+poll+capture
-    span (omc fans out its own workers out-of-process, so in-process M = 1 permit).
-    max_held must remain 1 — never 2+ regardless of the number of omc workers captured."""
+    charges the in-process semaphore ONE permit for the launch span (omc fans out its own workers
+    out-of-process, so in-process M = 1 permit regardless of worker count). PR-E1 removed the
+    publication slot, so the per-worker artifact writes + needs-human-selection routing run OUTSIDE
+    any slot — acquired == 1 and max_held == 1 regardless of the number of omc workers captured."""
     monkeypatch.setenv(agent_loop.OMC_RUNNER_ACK_ENV, "1")
     monkeypatch.setattr("time.sleep", lambda _: None)
     counter = _count_slot_acquisitions(monkeypatch)
@@ -640,12 +662,13 @@ def test_omc_multi_worker_launch_acquires_exactly_one_global_slot(
     # N>1 all-pass → needs-human-selection blocked (the result decision).
     assert result.decision == "blocked"
     assert any("needs human selection" in b.lower() for b in result.blockers), result.blockers
-    # Semaphore: exactly one slot acquired for the entire multi-worker span.
+    # Semaphore: exactly one launch slot (PR-E1 removed the publication slot) — never held twice.
     assert counter["acquired"] == 1, (
-        f"omc multi-worker launch must acquire exactly one global slot, got {counter['acquired']}"
+        f"omc multi-worker run takes exactly one launch slot (PR-E1 removed the publication slot), "
+        f"got {counter['acquired']}"
     )
     assert counter["max_held"] == 1, (
         f"never more than one slot held simultaneously, got {counter['max_held']}"
     )
-    assert counter["held"] == 0, "the single slot must be released after the multi-worker run"
+    assert counter["held"] == 0, "the launch slot must be released after the multi-worker run"
     _assert_all_permits_restored(agent_loop.global_concurrency_limiter())


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1817

XYZ 병렬화 epic (ADR 0094 substrate + ADR 0095 X+Y) 의 **brick 6a (PR-E1)**. X>1 task-pool(PR-E2/F)이 각 task 결과를 **disjoint 경로**에 publish할 수 있도록, omc/codex 실행 경로의 `standard_path`·run-root·redaction scope 를 **인자화하는 substrate** 를 깐다. 자체로는 **X=1 dark, byte-identical** — 아직 어떤 동작도 바뀌지 않는다 (모든 신규 인자의 default 가 기존 hardcoding 과 textually 동일한 legacy 값).

`scripts/agent_loop.py` 는 `scripts/_governance.py` `LOAD_BEARING_PATHS` 에 **없다** (real-data/eval surface 아님; CI 는 pytest-only).

## 2. 영향 파일

- `scripts/agent_loop.py` — **OFF load-bearing**. `_sanitize_task_slug` / `_omc_task_run_root` / `_is_standard_or_task_scoped_run_root` 신규; redaction 2함수 + `_finalize_omc_runner_result` 에 `task_slug`/`standard_path` 인자(default=legacy) 추가; HIGH-4 publication slot 제거.
- `tests/test_agent_loop.py`, `tests/test_global_concurrency_limiter_regression.py` — slug/redaction/fail-closed/byte-identical 테스트 + 1-slot launch contract 복원.
- `docs/adr/0095-task-parallel-bounded-loop.md` (Proposed), `docs/plans/xyz-parallelism-stack.md` — HIGH-4 를 "E1=substrate / E2=disjoint publication" 로 정정.

## 3. 리스크

- **X=1 산출 drift** (가장 가능성 높은 깨짐): standard_path/run-root/redaction 인자화가 기존 경로를 미세하게 바꾸면 byte-identical 위반 → ADR 0001 회귀. **배제**: ① finalize default + `_run_omc_team_runner` 초입 계산식이 제거된 4개 hardcoding 과 **textually 동일** (`_active_path(DEFAULT_ACTIVE_LEASES,...).parent / "patch_runs" / "implementer" / "patch_artifact.json"`); ② 10개 call-site 모두 동일 legacy 변수 전달; ③ `task_slug=None` (E1 default) → redaction 표준 스캔·run-root legacy 보존; ④ byte-identical regression 테스트 green.
- **privacy leak**: task-scoped redaction 이 per-task 데이터를 안 훑고 넘어감. **배제**: `_is_standard_or_task_scoped_run_root` 가 repo containment + (표준 OR 직계 task-scoped child) 만 허용하며 traversal 거부; task-scoped intent + unsafe slug → **fail-closed** (표준 경로 fallback 금지).

## 4. 테스트

- targeted `pytest tests/test_agent_loop.py tests/test_global_concurrency_limiter_regression.py -q` → **382 passed**.
- full CI gate `bash scripts/test.sh` → **3477 passed**, exit 0.
- 신규: slug `.`/구분자 strip, traversal slug 봉쇄, task-scoped unsafe slug fail-closed(표준 미스캔), finalize standard_path per-task, X=1 run-root legacy. byte-identical(`task_slug=None`) regression 유지.

## 5. Eval 영향

**동작 변화 없음.** `scripts/agent_loop.py` 는 `LOAD_BEARING_PATHS` 에 없는 OFF-load-bearing 자동화 스크립트 — RAG retrieval/answer/verifier/eval surface 와 무관하다. X=1 byte-identical (산출물 동일) 이므로 real-data 델타 0. real-eval 미실행 (eval surface 무변경).

## 6. 하위 호환

깨짐 없음. 모든 신규 인자(`task_slug`, `standard_path`)의 default 가 기존 동작을 그대로 재현 (byte-identical). 답변 계약(ADR 0003) 무관. CLI flag/스키마 변경 없음.

## 7. 범위 외

- **PR-E2 (#1816)**: X task-pool 활성화 (run_one_task + ThreadPoolExecutor) + per-task disjoint `standard_path`/slug **실제 주입** (이 substrate 를 wiring) + **M>1 concurrent regression 테스트** (HIGH-4 X>1 race 가 disjoint 경로로 실제 해소됨을 증명). 이 PR 은 그 토대만 깐다.
- HIGH-4 의 X>1 publication race 는 E1 범위 밖 (X=1 dark 라 동시 publication 자체가 없음).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)