### PR TITLE
refactor(scripts): harden board ADR 0005 boundary defense-in-depth

### DIFF
--- a/scripts/render_agent_loop_board.py
+++ b/scripts/render_agent_loop_board.py
@@ -1128,8 +1128,12 @@ def render_event_log(events: list[dict]) -> str:
             "ts", "event", "decision", "task_id", "blockers", "warnings",
             "guidance", "prompt", "last_message", "command", "stdout", "stderr",
         }
+        # Surfaced scalar values pass through _sanitize_text too: even a
+        # structural field (e.g. branch) could embed a run-artifact/scratch
+        # path token, so the board masks it before exposing/searching it
+        # (defense-in-depth, ADR 0005). skip/exclusion logic is unchanged.
         extra_fields = [
-            (k, v) for k, v in ev.items()
+            (k, _sanitize_text(str(v))) for k, v in ev.items()
             if k not in skip and not isinstance(v, (list, dict))
         ]
         if extra_fields:

--- a/tests/test_render_agent_loop_board.py
+++ b/tests/test_render_agent_loop_board.py
@@ -25,6 +25,8 @@ from scripts.render_agent_loop_board import (
     _sanitize_text,
     main,
     render,
+    render_blockers_summary,
+    render_event_log,
 )
 
 # The sentinel ``_sanitize_text`` substitutes for a matched run-artifact path.
@@ -196,6 +198,11 @@ def _events() -> list[dict[str, object]]:
             # surrounding diagnostic text is still surfaced.
             "blockers": [f"gate failed reading {RAW_RUN_ARTIFACT_PATH}"],
             "warnings": [f"scratch dir {RAW_SCRATCH_BRANCH} left behind"],
+            # Structural scalar field NOT in the skip set: render_event_log
+            # surfaces it via the extra_fields path. Its value embeds a
+            # run-artifact path → _sanitize_text must mask it there too
+            # (Low-2 defense-in-depth, ADR 0005).
+            "scratch_log": RAW_RUN_ARTIFACT_PATH,
             # Free-text fields the event log explicitly skips (ADR 0005).
             "guidance": SECRET_EVENT_GUIDANCE,
             "prompt": SECRET_PROMPT,
@@ -414,3 +421,52 @@ def test_structural_metadata_still_surfaced_alongside_redaction(tmp_path: Path) 
     assert "scratch dir" in html  # warning diagnostic text retained
     assert "T-1003" in html  # task id from the blocked event/backlog
     assert "implementer" in html  # worker role still rendered
+
+    # The blocked event's diagnostic blocker/warning text is rendered in TWO
+    # independent sections (the event log AND the aggregated blockers summary).
+    # The full-page assertions above pass as long as *either* section renders
+    # the text, so they cannot catch an over-redaction regression isolated to
+    # one section. Verify each section's fragment independently so a break in
+    # exactly one section fails this guard.
+    events = _events()
+    event_log = render_event_log(events)
+    blockers_summary = render_blockers_summary(events)
+
+    for section_name, fragment in (
+        ("event_log", event_log),
+        ("blockers_summary", blockers_summary),
+    ):
+        # Diagnostic text + structural id survive in this section …
+        assert "gate failed reading" in fragment, (
+            f"{section_name} dropped the blocker diagnostic text"
+        )
+        assert "scratch dir" in fragment, (
+            f"{section_name} dropped the warning diagnostic text"
+        )
+        # … and the embedded run-artifact/scratch path is masked here, not in
+        # the *other* section: each section must carry its own redaction marker
+        # and must never leak the raw path token.
+        assert RAW_RUN_ARTIFACT_PATH not in fragment, (
+            f"{section_name} leaked the raw run-artifact path"
+        )
+        assert RAW_SCRATCH_BRANCH not in fragment, (
+            f"{section_name} leaked the raw scratch branch token"
+        )
+        assert REDACT_MARKER in fragment, (
+            f"{section_name} did not mask the embedded path (no redact marker)"
+        )
+
+    # Low-2 (extra_fields scalar masking): the event fixture includes a structural
+    # scalar field ``scratch_log: RAW_RUN_ARTIFACT_PATH`` that is NOT in the skip
+    # set and not a list/dict, so render_event_log surfaces it via the extra_fields
+    # path (display cell + data-search blob). _sanitize_text must mask it there too.
+    # Verify: raw token absent from the event_log fragment (covers both the <li>
+    # display cell and the data-search="" searchable blob).
+    assert RAW_RUN_ARTIFACT_PATH not in event_log, (
+        "extra_fields scalar value leaked raw run-artifact path in event_log "
+        "(display cell or data-search blob — Low-2 regression)"
+    )
+    assert "codex_runs" not in event_log, (
+        "extra_fields scalar value leaked 'codex_runs' token in event_log "
+        "(Low-2 regression)"
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR #1834 (render board IA 재설계) code-review Low 2건 follow-up — ADR 0005 데이터 경계 **방어 깊이** + 테스트 견고성. 누출/버그 아님.
- **Low-2**: event_log extra_fields scalar 에 `_sanitize_text` 적용 → 새 구조 필드가 run-artifact 경로 토큰을 담아도 board 가 직접 마스킹(자체 방어선 닫힘)
- **Low-1**: over-redaction 가드를 섹션별(event_log / blockers_summary) 독립 검증으로 강화 → 한 섹션만 깨져도 검출

Closes #1838

## 2. 영향 파일

- `scripts/render_agent_loop_board.py` (+6/-1) — load-bearing 아님
- `tests/test_render_agent_loop_board.py` (+56)

## 3. 리스크

거의 없음. 기존 마스킹/미노출 동작 회귀 0(기존 회귀 테스트 그대로 통과). extra_fields scalar 추출 시 1회 마스킹 → 노출 셀 + 검색 blob 정합.

## 4. 테스트

- 기존 7 tests 전부 통과 (회귀 0)
- **Low-2 커버 (갭 보강)**: `_events()` fixture 에 extra_fields scalar 필드(`scratch_log`=run-artifact 경로) 주입 + event_log fragment 에서 마스킹 검증. **mutation 으로 non-vacuous 입증** — extra_fields `_sanitize_text` 제거 시 2 tests FAIL(보강 전엔 0 FAIL = 갭이었음, verify 에서 포착)
- **Low-1 강화**: 섹션별 fragment 독립 렌더 후 진단 텍스트 잔존 + raw 미누출 + redact 마커를 각 섹션에서 검증

## 5. Eval 영향

All `·` (RAG 외). 운영 대시보드 도구 — retrieval/answer/eval 무관.

## 6. 하위 호환

N/A — 마스킹 범위만 확대(노출 free-text 정책 불변), CLI/계약 무변경.

## 7. 범위 외

- render board 의 다른 부분 변경 없음 (scope = Low-1/Low-2)
