### PR TITLE
chore(agent-loop): overlap-preflight path-scope 확장 + front-door 게이트 (closes #1836)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 
 ## 저장소 맵
 
-**Load-bearing** — 변경 시 reviewer 가 real-data 영향을 살펴야 하는 경로. **§5b real-data 델타 게이트는 ADR 0084 로 폐지** (PR body 강제 아님 — `make real-eval-delta` 측정 도구는 유지, 권장 근거). 기계 판독 가능 단일 출처는 [`scripts/_governance.py`](scripts/_governance.py) 의 `LOAD_BEARING_PATHS` ([.githooks/pre-push](.githooks/pre-push) reminders, [scripts/claude-hooks/pretooluse-loadbearing.sh](scripts/claude-hooks/pretooluse-loadbearing.sh) awareness 가 함께 읽음). 추가/제거 시 그 파일 먼저 수정.
+**Load-bearing** — 변경 시 reviewer 가 real-data 영향을 살펴야 하는 경로. **§5b real-data 델타 게이트는 ADR 0084 로 폐지** (PR body 강제 아님 — `make real-eval-delta` 측정 도구는 유지, 권장 근거). 기계 판독 가능 단일 출처는 [`scripts/_governance.py`](scripts/_governance.py) 의 `LOAD_BEARING_PATHS` ([.githooks/pre-push](.githooks/pre-push) reminders, [scripts/claude-hooks/pretooluse-loadbearing.sh](scripts/claude-hooks/pretooluse-loadbearing.sh) awareness, [scripts/agent_loop.py](scripts/agent_loop.py) `overlap-preflight --paths` path-scope 스캔이 함께 읽음). 추가/제거 시 그 파일 먼저 수정.
 
 - `rag_core.py` — RAG 파이프라인 코어 (검색·검증·답변 오케스트레이션)
 - `ingestion.py`, `visual_ingestion.py` — 문서 로딩/파싱. HWP/PDF backend = `HwpKordocLoader`/`PdfKordocLoader` (ADR 0049, `npx` 서브프로세스); `csv_text` 가 Node 부재/실패 시 무조건 fallback
@@ -76,6 +76,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - **하위 호환성.** Breaking 변경은 명시적 사유 필요. 답변 계약 (ADR 0003) 깨질 시 `schema_version` 증가
 - **ADR 임계값.** load-bearing 결정 (기준선/파이프라인/답변 계약/eval 표면) 제거·교체 시 ADR 필요. **새 측정 표면** (eval slice, reviewer evidence artifact, self-review 축) 도입도 포함 (reviewer 가 의존할 계약 고정). 기준: [`docs/adr/README.md`](docs/adr/README.md)
 - **ADR 번호 사전 예약.** ADR 작성 전 `ls docs/adr/` + `gh pr list --search "ADR" --state open` 양쪽 확인. 사용자 확인 후 파일 생성 — 동시 worktree 작업으로 0022→0023, 0023→0025, 0029→0030 충돌 반복 발생
+- **새 작업 시작 전 overlap 확인.** 완전 새 작업(새 issue/worktree) 착수 전 `make ship-start`/`make spawn-track` 이 base fetch 직후 `overlap-preflight` 를 돌려 (1) 로컬 HEAD 가 `origin/main` 을 포함하는지(stale base 차단) (2) 활성 worktree·열린 PR 이 같은 load-bearing 경로를 동시 수정 중인지 경고한다. 수동 `git worktree add`/`git switch -c` 우회 또는 세션 내 머지 후 follow-up 시작 시에도 `python3 scripts/agent_loop.py overlap-preflight --issue <N> --branch <b> --paths <load-bearing 경로>` 를 직접 호출. stale base 만 block (gh 비의존·결정적), path/PR overlap 은 warn-only. False-positive 시 `OVERLAP=ack` (front door) 또는 `--no-overlap-check`/`NO_OVERLAP_CHECK=1` 로 우회 (ADR 0079 확장, issue #1836)
 - **LLM 코딩 편향 가드.** `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills), 2026-05-15 fetch) 의 4 원칙 (Think Before / Simplicity First / Surgical Changes / Goal-Driven). **충돌 정책**: 위 프로젝트 규칙 (인시던트 유래) 이 karpathy 4 원칙 (범용) 보다 우선 — karpathy 는 프로젝트 규칙이 침묵할 때 leaning 기본값
 
 ## PR 설명

--- a/Makefile
+++ b/Makefile
@@ -1553,13 +1553,17 @@ SLUG ?=
 LABELS ?=
 BASE ?= origin/main
 WT_PARENT ?= ..
+OVERLAP ?=
+NO_OVERLAP_CHECK ?= 0
+OVERLAP_PATHS ?=
 
 ship-start:
 	@if [ -z "$(TITLE)" ]; then \
-	  echo "Usage: make ship-start TITLE='Issue title' [TYPE=docs] [SLUG=short-slug] [BODY='...'] [LABELS=a,b]"; \
+	  echo "Usage: make ship-start TITLE='Issue title' [TYPE=docs] [SLUG=short-slug] [BODY='...'] [LABELS=a,b] [OVERLAP=ack]"; \
+	  echo "  OVERLAP=ack overrides a stale-base overlap-preflight block (issue #1836)."; \
 	  exit 1; \
 	fi
-	@$(PYTHON) scripts/claude-hooks/_ship_start.py \
+	@OVERLAP="$(OVERLAP)" $(PYTHON) scripts/claude-hooks/_ship_start.py \
 	  --title "$(TITLE)" \
 	  --body "$(BODY)" \
 	  --type "$(TYPE)" \
@@ -1573,11 +1577,13 @@ ship-start:
 .PHONY: spawn-track
 spawn-track:
 	@if [ -z "$(ISSUE)" ] || [ -z "$(PROMPT)" ]; then \
-	  echo "Usage: make spawn-track ISSUE=N PROMPT='cold-start prompt' [TYPE=chore] [SLUG=slug] [BASE=origin/main] [WT_PARENT=..] [DRY_RUN=1]"; \
+	  echo "Usage: make spawn-track ISSUE=N PROMPT='cold-start prompt' [TYPE=chore] [SLUG=slug] [BASE=origin/main] [WT_PARENT=..] [DRY_RUN=1] [OVERLAP=ack] [OVERLAP_PATHS='p1 p2']"; \
+	  echo "  OVERLAP=ack overrides a stale-base overlap-preflight block; NO_OVERLAP_CHECK=1 skips it (issue #1836)."; \
 	  exit 1; \
 	fi
 	@ISSUE="$(ISSUE)" PROMPT="$(PROMPT)" TYPE="$(TYPE)" SLUG="$(SLUG)" \
 	  BASE="$(BASE)" WT_PARENT="$(WT_PARENT)" DRY_RUN="$(DRY_RUN)" \
+	  OVERLAP="$(OVERLAP)" NO_OVERLAP_CHECK="$(NO_OVERLAP_CHECK)" OVERLAP_PATHS="$(OVERLAP_PATHS)" \
 	  bash scripts/spawn_track_session.sh
 
 ship-arm:

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -3036,8 +3036,9 @@ def write_overlap_preflight(
     out: Path = DEFAULT_OVERLAP_PREFLIGHT,
     json_out: Path | None = None,
     repo_root: Path = ROOT_DIR,
+    paths: Sequence[str] | None = None,
 ) -> tuple[Path, Path | None, OverlapPreflightReport, str]:
-    report = build_overlap_preflight(issue=issue, branch=branch, repo_root=repo_root)
+    report = build_overlap_preflight(issue=issue, branch=branch, repo_root=repo_root, paths=paths)
     rendered = render_overlap_preflight(report, repo_root=repo_root)
     out = _default_output(out, DEFAULT_OVERLAP_PREFLIGHT, "overlap_preflight.md", repo_root=repo_root)
     safe_out = _safe_output_path(out, repo_root=repo_root)
@@ -3060,6 +3061,7 @@ def build_overlap_preflight(
     branch: str,
     repo_root: Path = ROOT_DIR,
     coordination_root: Path | None = None,
+    paths: Sequence[str] | None = None,
 ) -> OverlapPreflightReport:
     # ADR 0095 PR-E3a: the local checkout-state reads (current branch / HEAD / origin-main
     # ancestry / worktree path) are COORDINATION reads — at X>1 each cycle runs inside its own
@@ -3187,6 +3189,50 @@ def build_overlap_preflight(
         warnings.append("other remote branches exist for the target issue: " + ", ".join(f"`{item}`" for item in remote_other))
     if not remote_issue_branches:
         evidence.append("no remote branch matched the target issue")
+
+    # Path-scope overlap (issue #1836). Optional dimension on top of ADR 0079's
+    # issue-scope check: when the caller supplies --paths, warn (never block —
+    # the stacked-day pattern legitimately touches one load-bearing file from
+    # several branches) if a *load-bearing* path is concurrently in flight in
+    # another worktree (uncommitted) or an open PR. ``paths`` absent ⇒ scan is
+    # skipped and the issue-scope result stays byte-identical. Non-load-bearing
+    # paths are dropped to suppress false positives (LOAD_BEARING_PATHS is the
+    # single source of truth via is_load_bearing).
+    if paths:
+        load_bearing_paths = _dedupe_preserve_order(
+            _overlap_path_key(p) for p in paths if is_load_bearing(p)
+        )
+        if load_bearing_paths:
+            evidence.append("path-scan covered load-bearing paths: " + ", ".join(f"`{p}`" for p in load_bearing_paths))
+            # path-scan intentionally includes cycle worktrees (only self is
+            # skipped): this warn-only advisory wants to surface an active
+            # loop's in-flight edits to a shared load-bearing file.
+            for item in worktrees:
+                if Path(item.path).resolve() == current_path:
+                    continue
+                dirty = _worktree_dirty_paths(item, load_bearing_paths)
+                if dirty:
+                    rendered_wt = _display_path(_repo_path(Path(item.path), repo_root), repo_root=repo_root)
+                    wt_branch = _sanitize_inline_text(item.branch) if item.branch else "unknown"
+                    warnings.append(
+                        f"another worktree (branch `{wt_branch}`, path `{rendered_wt}`) "
+                        "has uncommitted changes to load-bearing path(s): "
+                        + ", ".join(f"`{p}`" for p in dirty)
+                    )
+            for pr in open_prs:
+                pr_paths = _pr_changed_paths(pr)
+                hits = [p for p in load_bearing_paths if p in pr_paths]
+                if not hits:
+                    continue
+                if _pr_matches_issue_or_branch(pr, issue=safe_issue, branch=safe_branch):
+                    # Same-issue/branch PR already surfaced as a blocker above;
+                    # do not double-report it as a path warning.
+                    continue
+                number = _sanitize_inline_text(str(pr.get("number") or "N/A"))
+                warnings.append(
+                    f"open PR #{number} touches the same load-bearing path(s): "
+                    + ", ".join(f"`{p}`" for p in hits)
+                )
 
     result = "blocked" if blockers else ("warn" if warnings else "clear")
     return OverlapPreflightReport(
@@ -7556,6 +7602,43 @@ def _git_worktree_entries(repo_root: Path) -> tuple[WorktreeSnapshot, ...]:
     return tuple(entries)
 
 
+def _worktree_dirty_paths(wt: WorktreeSnapshot, paths: Sequence[str]) -> tuple[str, ...]:
+    """Return which of ``paths`` have uncommitted changes in worktree ``wt``.
+
+    Path-scan ① of overlap-preflight (issue #1836). Runs a single
+    ``git -C <wt.path> status --porcelain -- <p1> <p2> …`` (no per-path fork)
+    and reports any requested path that shows up. The dirty model mirrors
+    ``.githooks/_pre-push-worktree-hygiene.sh`` (porcelain = staged ∪ unstaged ∪
+    untracked). On any git error the scan yields ``()`` — overlap-preflight is a
+    read-only advisory and must fail-open on transient/offline git state, never
+    block a fresh task on a flaky sibling worktree read.
+    """
+    if not paths:
+        return ()
+    try:
+        result = subprocess.run(
+            ["git", "-C", wt.path, "status", "--porcelain", "--", *paths],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return ()
+    dirty: list[str] = []
+    requested = set(paths)
+    for raw in result.stdout.splitlines():
+        # porcelain v1: 2 status columns, a space, then the path (rename shows
+        # `orig -> new`; take the post-arrow target). Match against the exact
+        # requested paths (exact string equality — a directory entry like `api/`
+        # matches only the literal dir, not its child files).
+        entry = raw[3:].strip()
+        if " -> " in entry:
+            entry = entry.split(" -> ", 1)[1].strip()
+        if entry in requested and entry not in dirty:
+            dirty.append(entry)
+    return tuple(dirty)
+
+
 def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
     found: dict[str, set[str]] = {}
     try:
@@ -7633,9 +7716,13 @@ def _issue_info(issue: str, *, repo_root: Path) -> dict[str, object]:
 
 
 def _open_pr_items(*, repo_root: Path) -> list[dict[str, object]]:
+    # ``files`` is added (one extra JSON field, no extra gh call) so overlap-
+    # preflight path-scan ② can intersect each open PR's changed paths with the
+    # requested load-bearing paths (issue #1836). Every existing consumer reads
+    # other keys, so the added field is inert for them.
     try:
         result = subprocess.run(
-            ["gh", "pr", "list", "--state", "open", "--json", "number,title,url,headRefName,state,mergedAt"],
+            ["gh", "pr", "list", "--state", "open", "--json", "number,title,url,headRefName,state,mergedAt,files"],
             cwd=repo_root,
             capture_output=True,
             check=True,
@@ -7670,6 +7757,40 @@ def _branch_pr_items(branch: str, *, repo_root: Path) -> list[dict[str, object]]
 def _pr_matches_issue_or_branch(pr: dict[str, object], *, issue: str, branch: str) -> bool:
     head = str(pr.get("headRefName") or "")
     return head == branch or _issue_from_branch(head) == issue
+
+
+def _overlap_path_key(path: str) -> str:
+    """Light, filesystem-free normalization for overlap path-scan matching.
+
+    Strips a leading ``./`` and surrounding backticks only (mirrors
+    ``scripts/_governance._normalize``). Path-scan ② (issue #1836) compares the
+    user's ``--paths`` against a PR's changed paths purely as repo-relative
+    strings; using the heavier ``_normalize_changed_file`` would resolve against
+    the local filesystem and could fold an out-of-tree path to
+    ``[redacted-local-path]``, which is not wanted for plain string overlap.
+    """
+    raw = path.strip().strip("`")
+    return raw[2:] if raw.startswith("./") else raw
+
+
+def _pr_changed_paths(pr: dict[str, object]) -> frozenset[str]:
+    """Repo-relative paths a PR touches, from the ``files`` gh JSON field.
+
+    ``gh pr list --json …,files`` returns ``files: [{"path": "...", ...}, …]``.
+    Path-scan ② (issue #1836) reads only ``path``; the field is absent on PR
+    payloads fetched without ``files`` (every other caller), so this returns an
+    empty set there and the scan simply finds no hits.
+    """
+    files = pr.get("files")
+    if not isinstance(files, list):
+        return frozenset()
+    out: set[str] = set()
+    for entry in files:
+        if isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str) and path:
+                out.add(_overlap_path_key(path))
+    return frozenset(out)
 
 
 def _pr_is_merged(pr: dict[str, object]) -> bool:
@@ -20060,6 +20181,14 @@ def build_parser() -> argparse.ArgumentParser:
     overlap.add_argument("--branch", required=True)
     overlap.add_argument("--out", type=Path, default=DEFAULT_OVERLAP_PREFLIGHT)
     overlap.add_argument("--json-out", type=Path)
+    overlap.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional repo-relative paths to add a load-bearing path-scope overlap scan "
+        "(warns if a load-bearing path is dirty in another worktree or touched by an open PR). "
+        "Omitted = issue-scope check only.",
+    )
 
     pr_scan = sub.add_parser("pr-scan", help="Export read-only PR state for planning.")
     pr_scan.add_argument("--out", type=Path, default=DEFAULT_PR_STATE)
@@ -20792,6 +20921,7 @@ def main(argv: list[str] | None = None) -> int:
                 branch=args.branch,
                 out=args.out,
                 json_out=args.json_out,
+                paths=args.paths,
             )
             if json_out is None:
                 sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")

--- a/scripts/claude-hooks/_ship_start.py
+++ b/scripts/claude-hooks/_ship_start.py
@@ -14,10 +14,28 @@ editing starts.
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# overlap-preflight confines its --out / --json-out under reports/agent_loop/
+# (scripts/agent_loop.py::_safe_output_path), so the gate's mktemp files MUST
+# live there too — a plain /tmp mktemp is rejected. Per-invocation unique names
+# (mktemp, not a fixed /tmp path) avoid the multi-worktree shared-file footgun
+# (memory issue #1274).
+OVERLAP_REPORT_DIR = REPO_ROOT / "reports" / "agent_loop"
+# Stable substring of the deterministic, gh-independent base-staleness blocker
+# emitted by build_overlap_preflight. Only THIS blocker hard-blocks ship-start;
+# every other blocker/warning is advisory (a fresh issue+branch cannot have an
+# open PR / sibling worktree yet, and we never hard-fail on gh non-determinism).
+STALE_BASE_MARKER = "does not contain origin/main"
 
 
 ALLOWED_TYPES = {
@@ -104,6 +122,82 @@ def create_issue(title: str, body: str, labels: str | None) -> tuple[int, str]:
     return issue_number, url
 
 
+def run_overlap_gate(
+    issue: int,
+    branch: str,
+    *,
+    ack: bool,
+    paths: Sequence[str] | None,
+) -> None:
+    """Run overlap-preflight between fetch and branch creation (issue #1836).
+
+    Policy:
+      * a base-staleness blocker (local HEAD lacks origin/main) raises SystemExit
+        unless ``ack`` — deterministic + gh-independent, safe to hard-block;
+      * path / open-PR overlap warnings (and any other non-staleness blocker)
+        print to stderr and the function returns so the branch is still created;
+      * any failure to RUN the scan (non-zero exit with no staleness blocker,
+        timeout, unparseable JSON, missing report) fails OPEN — overlap-preflight
+        is a read-only advisory and must never hard-fail a fresh task on
+        transient/offline git/gh state (memory feedback_merge_admin_gate §7).
+    """
+    OVERLAP_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    md_fd, md_path = tempfile.mkstemp(dir=str(OVERLAP_REPORT_DIR), prefix="overlap_", suffix=".md")
+    os.close(md_fd)
+    json_fd, json_path = tempfile.mkstemp(dir=str(OVERLAP_REPORT_DIR), prefix="overlap_", suffix=".json")
+    os.close(json_fd)
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "agent_loop.py"),
+        "overlap-preflight",
+        "--issue",
+        str(issue),
+        "--branch",
+        branch,
+        "--out",
+        md_path,
+        "--json-out",
+        json_path,
+    ]
+    if paths:
+        cmd.extend(["--paths", *paths])
+    try:
+        proc = subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False)
+        report = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"ship-start: overlap-preflight could not run ({exc}); continuing (fail-open).", file=sys.stderr)
+        return
+    finally:
+        for p in (md_path, json_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+    blockers = [str(b) for b in report.get("blockers", [])]
+    warnings = [str(w) for w in report.get("warnings", [])]
+    stale = any(STALE_BASE_MARKER in b for b in blockers)
+
+    for warning in warnings:
+        print(f"ship-start: overlap warning — {warning}", file=sys.stderr)
+
+    if stale and not ack:
+        for b in blockers:
+            print(f"ship-start: overlap blocker — {b}", file=sys.stderr)
+        raise SystemExit(
+            "ship-start: refuse — local HEAD does not contain origin/main (stale base). "
+            "Refresh from latest main, or pass --overlap-ack / OVERLAP=ack to override."
+        )
+    if stale and ack:
+        print("ship-start: overlap — stale base acknowledged (--overlap-ack); continuing.", file=sys.stderr)
+        return
+    if proc.returncode != 0 and not blockers:
+        # overlap-preflight exited non-zero but recorded no blockers we can read
+        # (e.g. it crashed). Diagnostic only — the function already falls through
+        # to a fail-open return below rather than wedging a fresh task.
+        print("ship-start: overlap-preflight exited non-zero with no blocker payload; continuing (fail-open).", file=sys.stderr)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--title", required=True, help="GitHub issue title")
@@ -116,6 +210,24 @@ def main() -> int:
         "--no-fetch",
         action="store_true",
         help="Do not fetch origin/main before creating the branch",
+    )
+    parser.add_argument(
+        "--overlap-ack",
+        action="store_true",
+        help="Acknowledge a stale-base overlap blocker and create the branch anyway "
+        "(env OVERLAP=ack has the same effect).",
+    )
+    parser.add_argument(
+        "--no-overlap-check",
+        action="store_true",
+        help="Skip the overlap-preflight start-of-task gate entirely (mirrors --no-fetch).",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Repo-relative load-bearing paths to add a path-scope overlap scan "
+        "(warns if another worktree/open PR touches them).",
     )
     args = parser.parse_args()
 
@@ -136,6 +248,9 @@ def main() -> int:
 
     if not args.no_fetch:
         run(["git", "fetch", "origin", "main"])
+    if not args.no_overlap_check:
+        ack = args.overlap_ack or os.environ.get("OVERLAP", "").strip().lower() == "ack"
+        run_overlap_gate(issue_number, branch, ack=ack, paths=args.paths)
     run(["git", "switch", "-c", branch, args.base])
 
     sys.stdout.write(

--- a/scripts/spawn_track_session.sh
+++ b/scripts/spawn_track_session.sh
@@ -43,6 +43,9 @@ set -euo pipefail
 #   WT_PARENT  parent dir for the new worktree (default .. = sibling)
 #   CMUX_BIN   cmux CLI path (default the macOS app-bundle absolute path)
 #   DRY_RUN    1 = print the git/cmux commands without executing (default 0)
+#   OVERLAP    ack = acknowledge a stale-base overlap blocker and proceed (#1836)
+#   NO_OVERLAP_CHECK  1 = skip the overlap-preflight start-of-task gate (#1836)
+#   OVERLAP_PATHS     space-separated load-bearing paths for the path-scope scan
 
 ISSUE="${ISSUE:?ISSUE=N (existing issue number) required}"
 PROMPT="${PROMPT:?PROMPT='cold-start prompt' required}"
@@ -99,11 +102,76 @@ run() {
   fi
 }
 
+# --- Overlap-preflight gate (issue #1836) ----------------------------------
+# Between the fetch and the worktree add, run overlap-preflight so the new
+# track does not start on a stale base or silently collide on a load-bearing
+# path. Policy: a base-staleness blocker (local HEAD lacks origin/main) BLOCKS
+# unless OVERLAP=ack; path/open-PR overlap warns + continues; any failure to
+# RUN the scan fails OPEN (read-only advisory, never hard-fail a fresh task on
+# transient git/gh state — memory feedback_merge_admin_gate §7). Skip entirely
+# with NO_OVERLAP_CHECK=1 (mirrors the --no-fetch escape on ship-start).
+# overlap-preflight confines --out/--json-out under reports/agent_loop/, so the
+# report goes there via mktemp (unique per run — no fixed /tmp, memory #1274).
+OVERLAP="${OVERLAP:-}"
+NO_OVERLAP_CHECK="${NO_OVERLAP_CHECK:-0}"
+OVERLAP_PATHS="${OVERLAP_PATHS:-}"
+overlap_gate() {
+  [ "$NO_OVERLAP_CHECK" = 1 ] && return 0
+  # Assemble the command once so DRY_RUN can echo the exact invocation.
+  local report_dir="reports/agent_loop"
+  if [ "$DRY_RUN" = 1 ]; then
+    run python3 scripts/agent_loop.py overlap-preflight --issue "$ISSUE" --branch "$BRANCH" ${OVERLAP_PATHS:+--paths $OVERLAP_PATHS}
+    return 0
+  fi
+  mkdir -p "$report_dir"
+  local md json verdict
+  md="$(mktemp "${report_dir}/overlap_XXXXXX.md")"
+  json="$(mktemp "${report_dir}/overlap_XXXXXX.json")"
+  # shellcheck disable=SC2086  # OVERLAP_PATHS is an intentional word-split list.
+  python3 scripts/agent_loop.py overlap-preflight \
+    --issue "$ISSUE" --branch "$BRANCH" --out "$md" --json-out "$json" \
+    ${OVERLAP_PATHS:+--paths $OVERLAP_PATHS} >/dev/null 2>&1 || true
+  # Parse the JSON in python: emit a verdict token on stdout + warnings on
+  # stderr. Missing/garbled report => FAILOPEN (the scan could not run).
+  verdict="$(
+    OVERLAP_ACK="$OVERLAP" python3 - "$json" <<'PY'
+import json, os, sys
+try:
+    rep = json.loads(open(sys.argv[1], encoding="utf-8").read())
+except Exception:
+    print("FAILOPEN")
+    sys.exit(0)
+blockers = [str(b) for b in rep.get("blockers", [])]
+warnings = [str(w) for w in rep.get("warnings", [])]
+for w in warnings:
+    sys.stderr.write("spawn: overlap warning — %s\n" % w)
+stale = any("does not contain origin/main" in b for b in blockers)
+ack = os.environ.get("OVERLAP_ACK", "").strip().lower() == "ack"
+if stale and not ack:
+    for b in blockers:
+        sys.stderr.write("spawn: overlap blocker — %s\n" % b)
+    print("BLOCK_STALE")
+elif stale and ack:
+    sys.stderr.write("spawn: overlap — stale base acknowledged (OVERLAP=ack); continuing.\n")
+    print("WARN")
+else:
+    print("WARN" if warnings else "CLEAR")
+PY
+  )"
+  rm -f "$md" "$json"
+  if [ "$verdict" = BLOCK_STALE ]; then
+    echo "spawn: refuse — local HEAD does not contain origin/main (stale base)." >&2
+    echo "spawn: refresh from latest main, or pass OVERLAP=ack to override." >&2
+    exit 1
+  fi
+}
+
 # --- Isolated worktree (memory project_omc_teleport_adr0007) ---------------
 # Fetch first so origin/main is fresh (stale-ref false-negative gotcha), then
 # add the worktree off origin/main for isolation. worktree add never moves the
 # caller's HEAD, so spawning from any worktree is safe.
 run git fetch origin main
+overlap_gate
 run git worktree add "$WT" -b "$BRANCH" "$BASE"
 
 # --- cmux detect → spawn / fallback ---------------------------------------

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -548,6 +548,7 @@ def _stub_overlap_environment(
     branch_prs: list[dict[str, object]] | None = None,
     issue_state: str = "OPEN",
     remote_branches: set[str] | None = None,
+    worktree_dirty_paths: dict[str, list[str]] | None = None,
 ) -> None:
     current = branch if current_branch is None else current_branch
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: current)
@@ -562,6 +563,15 @@ def _stub_overlap_environment(
     )
     monkeypatch.setattr(agent_loop, "_local_issue_branches", lambda repo_root: {issue: {branch}})
     monkeypatch.setattr(agent_loop, "_remote_issue_branches", lambda selected_issue, *, repo_root: remote_branches or set())
+    # Map worktree path -> dirty paths it reports. _worktree_dirty_paths is the
+    # single git-status seam path-scan ① reads; stubbing it keeps these tests
+    # free of a real `git status --porcelain` invocation.
+    dirty_by_wt = worktree_dirty_paths or {}
+    monkeypatch.setattr(
+        agent_loop,
+        "_worktree_dirty_paths",
+        lambda wt, paths, **_kwargs: tuple(p for p in paths if p in dirty_by_wt.get(str(getattr(wt, "path", wt)), [])),
+    )
     monkeypatch.setattr(agent_loop, "_open_pr_items", lambda *, repo_root: open_prs or [])
     monkeypatch.setattr(agent_loop, "_branch_pr_items", lambda selected_branch, *, repo_root: branch_prs or [])
     monkeypatch.setattr(
@@ -714,6 +724,130 @@ def test_overlap_preflight_writes_markdown_and_optional_json(monkeypatch, tmp_pa
     assert payload["result"] == "clear"
     assert payload["issue"] == "1541"
     assert str(repo) not in json_out.read_text(encoding="utf-8")
+
+
+def test_overlap_preflight_warns_load_bearing_dirty_in_other_worktree(monkeypatch, tmp_path: Path) -> None:
+    # Path-scan ①: another worktree has rag_retrieval.py (load-bearing) dirty.
+    # That is a warn (not a block) so the stacked-day pattern stays possible.
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    other = tmp_path / "other"
+    worktrees = (
+        agent_loop.WorktreeSnapshot(path=str(repo), branch=branch, head="abc1234"),
+        agent_loop.WorktreeSnapshot(path=str(other), branch="docs/issue-1599-doc", head="def5678"),
+    )
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        worktrees=worktrees,
+        worktree_dirty_paths={str(other): ["rag_retrieval.py"]},
+    )
+
+    report = agent_loop.build_overlap_preflight(
+        issue="1541", branch=branch, repo_root=repo, paths=["rag_retrieval.py"]
+    )
+
+    assert report.result == "warn"
+    assert not report.blockers
+    assert any("rag_retrieval.py" in warning for warning in report.warnings)
+    assert any("worktree" in warning and "rag_retrieval.py" in warning for warning in report.warnings)
+
+
+def test_overlap_preflight_warns_open_pr_touches_same_load_bearing_path(monkeypatch, tmp_path: Path) -> None:
+    # Path-scan ②: an unrelated open PR touches rag_core.py (load-bearing).
+    # warn-only — overlapping load-bearing edits across PRs are allowed but flagged.
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    open_prs = [
+        {
+            "number": 42,
+            "title": "Unrelated retriever change",
+            "headRefName": "feat/issue-1600-other",
+            "state": "OPEN",
+            "files": [{"path": "rag_core.py"}, {"path": "docs/notes.md"}],
+        }
+    ]
+    _stub_overlap_environment(monkeypatch, repo, branch=branch, open_prs=open_prs)
+
+    report = agent_loop.build_overlap_preflight(
+        issue="1541", branch=branch, repo_root=repo, paths=["rag_core.py"]
+    )
+
+    assert report.result == "warn"
+    assert not report.blockers
+    assert any("rag_core.py" in warning and "#42" in warning for warning in report.warnings)
+
+
+def test_overlap_preflight_path_scan_ignores_non_load_bearing_paths(monkeypatch, tmp_path: Path) -> None:
+    # False-positive guard: a non-load-bearing path (README.md) dirty in another
+    # worktree AND touched by an open PR must NOT raise any path-scan warning.
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    other = tmp_path / "other"
+    worktrees = (
+        agent_loop.WorktreeSnapshot(path=str(repo), branch=branch, head="abc1234"),
+        agent_loop.WorktreeSnapshot(path=str(other), branch="docs/issue-1599-doc", head="def5678"),
+    )
+    open_prs = [
+        {
+            "number": 43,
+            "title": "Docs tweak",
+            "headRefName": "docs/issue-1601-readme",
+            "state": "OPEN",
+            "files": [{"path": "README.md"}],
+        }
+    ]
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        worktrees=worktrees,
+        open_prs=open_prs,
+        worktree_dirty_paths={str(other): ["README.md"]},
+    )
+
+    report = agent_loop.build_overlap_preflight(
+        issue="1541", branch=branch, repo_root=repo, paths=["README.md"]
+    )
+
+    assert report.result == "clear"
+    assert not any("README.md" in warning for warning in report.warnings)
+
+
+def test_overlap_preflight_path_scan_skipped_when_no_paths_arg(monkeypatch, tmp_path: Path) -> None:
+    # Back-compat: without --paths the path-scan is skipped entirely, so even a
+    # load-bearing overlap in another worktree / open PR stays invisible (the
+    # issue-scope behavior is byte-identical to before this change).
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    other = tmp_path / "other"
+    worktrees = (
+        agent_loop.WorktreeSnapshot(path=str(repo), branch=branch, head="abc1234"),
+        agent_loop.WorktreeSnapshot(path=str(other), branch="docs/issue-1599-doc", head="def5678"),
+    )
+    open_prs = [
+        {
+            "number": 44,
+            "title": "Retriever change",
+            "headRefName": "feat/issue-1602-other",
+            "state": "OPEN",
+            "files": [{"path": "rag_retrieval.py"}],
+        }
+    ]
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        worktrees=worktrees,
+        open_prs=open_prs,
+        worktree_dirty_paths={str(other): ["rag_retrieval.py"]},
+    )
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert report.result == "clear"
+    assert not any("rag_retrieval.py" in warning for warning in report.warnings)
 
 
 def test_pr_selector_rejects_gh_option_like_values() -> None:

--- a/tests/test_ship_start_overlap_gate.py
+++ b/tests/test_ship_start_overlap_gate.py
@@ -1,0 +1,239 @@
+"""Guard: ship-start overlap-preflight gate (issue #1836).
+
+``scripts/claude-hooks/_ship_start.py`` runs ``overlap-preflight`` between the
+``git fetch origin main`` and the ``git switch -c`` so a brand-new shipping
+branch is not cut on a stale base. The gate's policy (decision 2 of the plan):
+
+  * a base-staleness blocker (local HEAD does not contain origin/main) is a
+    hard BLOCK (non-zero exit) — it is gh-independent and deterministic — unless
+    ``--overlap-ack`` / ``OVERLAP=ack`` is supplied;
+  * path / open-PR overlap *warnings* print and the branch is still created;
+  * a scan-process error (gh down / offline / non-zero exit that is not a
+    staleness block) fails OPEN — overlap-preflight is a read-only advisory and
+    must never hard-fail a fresh task on transient git/gh state
+    (memory feedback_merge_admin_gate §7);
+  * ``--no-overlap-check`` skips the gate entirely (mirrors ``--no-fetch``).
+
+The script shells out to ``git`` and ``gh`` (non-deterministic in CI), so both
+are replaced by Python stubs on PATH whose behavior is driven by env vars the
+test sets. The stubs dispatch on argv exactly like
+tests/test_hook_pretooluse_adr_collision.py's fake ``gh``. The script is run
+from the real repo root so ``python3 scripts/agent_loop.py overlap-preflight``
+resolves the real implementation under test.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SHIP_START = REPO / "scripts" / "claude-hooks" / "_ship_start.py"
+
+
+GIT_STUB = r'''#!/usr/bin/env python3
+import os, sys
+
+argv = sys.argv[1:]
+# `git -C <path> ...` — drop the -C pair, it does not change our canned answers.
+if len(argv) >= 2 and argv[0] == "-C":
+    argv = argv[2:]
+
+stale = os.environ.get("STUB_STALE_BASE") == "1"
+
+def out(s=""):
+    sys.stdout.write(s)
+    if s and not s.endswith("\n"):
+        sys.stdout.write("\n")
+
+if not argv:
+    sys.exit(0)
+cmd = argv[0]
+
+if cmd == "status":
+    # ensure_clean_worktree (no -- args) -> clean; path-scan (-- <paths>) -> clean.
+    sys.exit(0)
+if cmd == "fetch":
+    sys.exit(0)
+if cmd == "switch":
+    # branch creation — record it so the test can assert it happened.
+    marker = os.environ.get("STUB_SWITCH_MARKER")
+    if marker:
+        open(marker, "a").write(" ".join(argv) + "\n")
+    sys.exit(0)
+if cmd == "rev-parse":
+    ref = argv[-1]
+    if ref == "HEAD":
+        out("head1111")
+    elif ref == "origin/main":
+        out("new2222" if stale else "head1111")
+    else:
+        out("ref0000")
+    sys.exit(0)
+if cmd == "merge-base":
+    # `merge-base --is-ancestor origin/main HEAD` -> exit 0 means HEAD contains
+    # origin/main. Stale base => non-zero.
+    sys.exit(1 if stale else 0)
+if cmd == "worktree":
+    # `worktree list --porcelain` — a single self entry on the current branch.
+    if len(argv) >= 2 and argv[1] == "list":
+        out("worktree %s" % os.getcwd())
+        out("HEAD head1111")
+        out("branch refs/heads/chore/issue-4242-demo")
+        out("")
+    sys.exit(0)
+if cmd == "ls-remote":
+    # no remote issue branches
+    sys.exit(0)
+if cmd == "rev-list":
+    out("0")
+    sys.exit(0)
+# default: succeed quietly
+sys.exit(0)
+'''
+
+
+GH_STUB = r'''#!/usr/bin/env python3
+import json, os, sys
+
+argv = sys.argv[1:]
+
+def out(s):
+    sys.stdout.write(s)
+
+if not argv:
+    sys.exit(0)
+
+# `gh issue create ...` -> print an issue URL ship-start parses for the number.
+if argv[0] == "issue" and len(argv) >= 2 and argv[1] == "create":
+    out("https://github.com/acme/repo/issues/4242\n")
+    sys.exit(0)
+
+# `gh issue view <n> --json ...` (overlap-preflight) -> an OPEN issue.
+if argv[0] == "issue" and len(argv) >= 2 and argv[1] == "view":
+    out(json.dumps({"number": 4242, "title": "demo", "state": "OPEN",
+                    "url": "https://github.com/acme/repo/issues/4242"}))
+    sys.exit(0)
+
+# `gh issue edit ...` (label apply) -> succeed.
+if argv[0] == "issue" and len(argv) >= 2 and argv[1] == "edit":
+    sys.exit(0)
+
+# `gh pr list ...` (overlap-preflight open + branch history).
+if argv[0] == "pr" and len(argv) >= 2 and argv[1] == "list":
+    if os.environ.get("STUB_GH_DOWN") == "1":
+        sys.stderr.write("gh: could not connect\n")
+        sys.exit(1)
+    prs = json.loads(os.environ.get("STUB_OPEN_PRS", "[]"))
+    # branch-history query (`--head <branch>`) -> always empty for a fresh branch.
+    if "--head" in argv:
+        out("[]")
+        sys.exit(0)
+    out(json.dumps(prs))
+    sys.exit(0)
+
+sys.exit(0)
+'''
+
+
+class TestShipStartOverlapGate(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="ship-start-gate-")
+        self.addCleanup(shutil.rmtree, self._tmp, ignore_errors=True)
+        self._bin = Path(self._tmp) / "bin"
+        self._bin.mkdir()
+        self._write_stub("git", GIT_STUB)
+        self._write_stub("gh", GH_STUB)
+        self._switch_marker = Path(self._tmp) / "switch_called"
+
+    def _write_stub(self, name: str, body: str) -> None:
+        p = self._bin / name
+        p.write_text(body, encoding="utf-8")
+        p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _run(self, *extra_args: str, stale: bool = False, gh_down: bool = False,
+             open_prs: list | None = None, overlap_ack_env: bool = False):
+        env = dict(os.environ)
+        # Stub git/gh win over the real ones.
+        env["PATH"] = f"{self._bin}{os.pathsep}{env['PATH']}"
+        env["STUB_SWITCH_MARKER"] = str(self._switch_marker)
+        if stale:
+            env["STUB_STALE_BASE"] = "1"
+        if gh_down:
+            env["STUB_GH_DOWN"] = "1"
+        if open_prs is not None:
+            env["STUB_OPEN_PRS"] = json.dumps(open_prs)
+        if overlap_ack_env:
+            env["OVERLAP"] = "ack"
+        return subprocess.run(
+            ["python3", str(SHIP_START), "--title", "demo", "--type", "chore",
+             "--slug", "demo", *extra_args],
+            cwd=str(REPO),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _switched(self) -> bool:
+        return self._switch_marker.exists()
+
+    # -- staleness BLOCK --------------------------------------------------
+
+    def test_stale_base_blocks_branch_creation(self) -> None:
+        r = self._run(stale=True)
+        self.assertNotEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertIn("origin/main", (r.stdout + r.stderr))
+        self.assertFalse(self._switched(), "branch must NOT be created on a stale base")
+
+    def test_stale_base_with_ack_flag_warns_and_continues(self) -> None:
+        r = self._run("--overlap-ack", stale=True)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched(), "ack must let the branch be created")
+
+    def test_stale_base_with_ack_env_warns_and_continues(self) -> None:
+        r = self._run(stale=True, overlap_ack_env=True)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched())
+
+    # -- fresh base / warnings continue -----------------------------------
+
+    def test_fresh_base_creates_branch(self) -> None:
+        r = self._run(stale=False)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched())
+
+    def test_path_overlap_warns_but_continues(self) -> None:
+        # An unrelated open PR touches a load-bearing path. Fresh base, so the
+        # gate must warn (path scope is warn-only) and still create the branch.
+        prs = [{"number": 77, "title": "other", "headRefName": "feat/issue-9-x",
+                "state": "OPEN", "files": [{"path": "rag_core.py"}]}]
+        r = self._run("--paths", "rag_core.py", open_prs=prs)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched())
+
+    # -- fail-open on scan error ------------------------------------------
+
+    def test_gh_down_fails_open_and_creates_branch(self) -> None:
+        # gh errors during overlap-preflight -> a blocker is recorded but it is
+        # NOT a staleness block, so ship-start must fail open and proceed.
+        r = self._run(gh_down=True, stale=False)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched())
+
+    # -- full bypass ------------------------------------------------------
+
+    def test_no_overlap_check_skips_gate_even_when_stale(self) -> None:
+        r = self._run("--no-overlap-check", stale=True)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._switched())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ship_start_review_gate.py
+++ b/tests/test_ship_start_review_gate.py
@@ -67,6 +67,11 @@ def test_ship_start_creates_issue_then_switches_branch(monkeypatch, capsys) -> N
             "--type",
             "chore",
             "--no-fetch",
+            # The overlap-preflight gate (issue #1836) shells to git/gh against
+            # the real repo, which this issue-creation/branch-switch unit does
+            # not model; skip it here exactly like --no-fetch. The gate's own
+            # behavior is covered by tests/test_ship_start_overlap_gate.py.
+            "--no-overlap-check",
         ],
     )
 
@@ -120,6 +125,9 @@ def test_ship_start_label_failure_warns_without_aborting(monkeypatch, capsys) ->
             "--labels",
             "enhancement,rag",
             "--no-fetch",
+            # See the note in test_ship_start_creates_issue_then_switches_branch:
+            # skip the overlap gate, which is exercised separately.
+            "--no-overlap-check",
         ],
     )
 

--- a/tests/test_spawn_track_session_script.py
+++ b/tests/test_spawn_track_session_script.py
@@ -14,6 +14,7 @@ families mirror tests/test_test_sh_bash32_regression.py:
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import stat
@@ -151,6 +152,168 @@ class TestSpawnTrackBehavior(unittest.TestCase):
     def test_missing_issue_fails(self) -> None:
         r = self._run("measure recall", drop_issue=True)
         self.assertNotEqual(0, r.returncode)
+
+
+# Behavioral overlap-preflight gate (issue #1836). Unlike TestSpawnTrackBehavior
+# (DRY_RUN=1, real git echoed), the gate must actually execute, so these run with
+# DRY_RUN=0 and stub BOTH git and gh so `overlap-preflight` is deterministic. The
+# real `python3 scripts/agent_loop.py overlap-preflight` runs (cwd=REPO). Policy:
+# a stale base (local HEAD lacks origin/main) BLOCKS the worktree add unless
+# OVERLAP=ack; path/PR overlap warns + continues; gh-down fails open.
+GIT_STUB = r'''#!/usr/bin/env python3
+import os, sys
+argv = sys.argv[1:]
+if len(argv) >= 2 and argv[0] == "-C":
+    argv = argv[2:]
+stale = os.environ.get("STUB_STALE_BASE") == "1"
+def out(s=""):
+    sys.stdout.write(s)
+    if s and not s.endswith("\n"):
+        sys.stdout.write("\n")
+if not argv:
+    sys.exit(0)
+cmd = argv[0]
+if cmd == "fetch":
+    sys.exit(0)
+if cmd == "status":
+    sys.exit(0)
+if cmd == "worktree":
+    if len(argv) >= 2 and argv[1] == "add":
+        marker = os.environ.get("STUB_WT_ADD_MARKER")
+        if marker:
+            open(marker, "a").write(" ".join(argv) + "\n")
+        sys.exit(0)
+    if len(argv) >= 2 and argv[1] == "list":
+        out("worktree %s" % os.getcwd())
+        out("HEAD head1111")
+        out("branch refs/heads/chore/issue-4242-demo")
+        out("")
+    sys.exit(0)
+if cmd == "rev-parse":
+    ref = argv[-1]
+    if ref == "HEAD":
+        out("head1111")
+    elif ref == "origin/main":
+        out("new2222" if stale else "head1111")
+    else:
+        out("ref0000")
+    sys.exit(0)
+if cmd == "merge-base":
+    sys.exit(1 if stale else 0)
+if cmd == "ls-remote":
+    sys.exit(0)
+sys.exit(0)
+'''
+
+GH_STUB = r'''#!/usr/bin/env python3
+import json, os, sys
+argv = sys.argv[1:]
+if not argv:
+    sys.exit(0)
+if argv[0] == "issue" and len(argv) >= 2 and argv[1] == "view":
+    sys.stdout.write(json.dumps({"number": 4242, "title": "demo", "state": "OPEN",
+                                 "url": "https://github.com/acme/repo/issues/4242"}))
+    sys.exit(0)
+if argv[0] == "pr" and len(argv) >= 2 and argv[1] == "list":
+    if os.environ.get("STUB_GH_DOWN") == "1":
+        sys.stderr.write("gh: could not connect\n")
+        sys.exit(1)
+    if "--head" in argv:
+        sys.stdout.write("[]")
+        sys.exit(0)
+    sys.stdout.write(os.environ.get("STUB_OPEN_PRS", "[]"))
+    sys.exit(0)
+sys.exit(0)
+'''
+
+
+class TestSpawnTrackOverlapGate(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="spawn-track-gate-")
+        self.addCleanup(shutil.rmtree, self._tmp, ignore_errors=True)
+        self._bin = Path(self._tmp) / "bin"
+        self._bin.mkdir()
+        self._stub_bin("git", GIT_STUB)
+        self._stub_bin("gh", GH_STUB)
+        # cmux stub: `identify` exits non-zero (outside cmux) so the spawn path
+        # is the harmless fallback; the gate runs before that regardless.
+        _stub(self._bin / "cmux", '#!/bin/sh\nif [ "$1" = identify ]; then exit 1; fi\nexit 0\n')
+        self._wt_marker = Path(self._tmp) / "wt_add_called"
+
+    def _stub_bin(self, name: str, body: str) -> None:
+        p = self._bin / name
+        p.write_text(body, encoding="utf-8")
+        p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _run(self, *, paths: str | None = None, stale: bool = False,
+             gh_down: bool = False, open_prs: list | None = None,
+             overlap_ack: bool = False, skip: bool = False):
+        env = dict(os.environ)
+        env["PATH"] = f"{self._bin}{os.pathsep}{env['PATH']}"
+        env["CMUX_BIN"] = str(self._bin / "cmux")
+        env["DRY_RUN"] = "0"  # the gate must actually run
+        env["ISSUE"] = "4242"
+        env["TYPE"] = "chore"
+        env["SLUG"] = "demo"
+        env["PROMPT"] = "measure recall"
+        env["STUB_WT_ADD_MARKER"] = str(self._wt_marker)
+        if paths is not None:
+            env["OVERLAP_PATHS"] = paths
+        if stale:
+            env["STUB_STALE_BASE"] = "1"
+        if gh_down:
+            env["STUB_GH_DOWN"] = "1"
+        if open_prs is not None:
+            env["STUB_OPEN_PRS"] = json.dumps(open_prs)
+        if overlap_ack:
+            env["OVERLAP"] = "ack"
+        if skip:
+            env["NO_OVERLAP_CHECK"] = "1"
+        bash = "/bin/bash" if Path("/bin/bash").exists() else "bash"
+        return subprocess.run(
+            [bash, str(SCRIPT)],
+            cwd=REPO,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _wt_added(self) -> bool:
+        return self._wt_marker.exists()
+
+    def test_stale_base_blocks_worktree_add(self) -> None:
+        r = self._run(stale=True)
+        self.assertNotEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertIn("origin/main", (r.stdout + r.stderr))
+        self.assertFalse(self._wt_added(), "worktree must NOT be added on a stale base")
+
+    def test_stale_base_with_ack_continues(self) -> None:
+        r = self._run(stale=True, overlap_ack=True)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._wt_added())
+
+    def test_fresh_base_adds_worktree(self) -> None:
+        r = self._run(stale=False)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._wt_added())
+
+    def test_path_overlap_warns_but_continues(self) -> None:
+        prs = [{"number": 88, "title": "other", "headRefName": "feat/issue-9-x",
+                "state": "OPEN", "files": [{"path": "rag_core.py"}]}]
+        r = self._run(paths="rag_core.py", open_prs=prs)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._wt_added())
+
+    def test_gh_down_fails_open(self) -> None:
+        r = self._run(gh_down=True, stale=False)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._wt_added())
+
+    def test_skip_flag_bypasses_gate_even_when_stale(self) -> None:
+        r = self._run(skip=True, stale=True)
+        self.assertEqual(0, r.returncode, msg=r.stdout + r.stderr)
+        self.assertTrue(self._wt_added())
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

완전 새 작업(새 issue/worktree, 세션 내 머지 후 follow-up) 착수 시 (1) `origin/main` 최신 base (2) 동시 worktree·열린 PR 과의 load-bearing scope 충돌 회피를 강제한다. `overlap-preflight`(ADR 0079)가 issue-scope overlap + base-staleness 를 이미 구현하나 두 갭: (a) load-bearing **path-scope** 미지원 — 다른 issue 의 두 worktree 가 같은 `rag_retrieval.py` 를 동시 수정해도 `clear` (b) front door(`make ship-start`/`make spawn-track`) 미연동 — 수동 호출만 가능. 이 PR 이 둘을 메운다.

Closes #1836

## 2. 영향 파일

- `scripts/agent_loop.py` — `overlap-preflight --paths` path-scope 충돌 감지(신규 `_worktree_dirty_paths`/`_pr_changed_paths`/`_overlap_path_key`). **load-bearing 아님**(LOAD_BEARING_PATHS 비포함 governance 도구)
- `scripts/claude-hooks/_ship_start.py` — `run_overlap_gate()` + `--overlap-ack`/`--no-overlap-check`/`--paths`
- `scripts/spawn_track_session.sh` — `overlap_gate()` + `OVERLAP`/`NO_OVERLAP_CHECK`/`OVERLAP_PATHS` env
- `Makefile` — ship-start/spawn-track usage 에 `OVERLAP=ack`/`OVERLAP_PATHS` 문서화
- `CLAUDE.md` — 핵심 원칙에 "새 작업 시작 전 overlap 확인" soft 규칙
- `tests/test_agent_loop.py`, `tests/test_ship_start_overlap_gate.py`(신규), `tests/test_spawn_track_session_script.py`, `tests/test_ship_start_review_gate.py`

## 3. 리스크

가장 가능성 높은 깨짐: 게이트가 false-positive 로 새 작업을 차단. 배제 근거:
- **staleness 만 hard-block**(gh 비의존·결정적, fetch 직후 평가) — `"does not contain origin/main"` blocker 1개에만 매칭(전수 확인)
- **path/PR-overlap = warn-only**(stacked-day 패턴 보호)
- **gh-down/crash = fail-open**(메모리 §7 governance hard fail-closed 금지)
- override: `--overlap-ack`/`OVERLAP=ack`(staleness), `--no-overlap-check`(전체 스킵)

code-reviewer APPROVE (Critical/High/Medium 0, Low 4 보강 완료).

## 4. 테스트

- **path-scan 4**(test_agent_loop): worktree dirty / open PR files∩path / non-load-bearing 배제 / no-`--paths` back-compat(byte-identical)
- **front-door gate**(test_ship_start_overlap_gate 신규 + spawn-track): stale→block / `--overlap-ack`·`OVERLAP=ack`→pass / overlap→warn / gh-down→fail-open
- stub 은 git/gh seam 만(게이트 우회 아님). `bash scripts/test.sh` **exit 0**(rebase 후 #1837 ADR0095 통합 포함)

## 5. Eval 영향

`scripts/agent_loop.py` 는 LOAD_BEARING_PATHS(`rag_*`/`eval/`/`api/`/`ingestion`/`build_index.py`) **비포함** — retrieval/answer/eval 무관 governance·orchestration 도구. **동작 변화 없음**(ADR 0001 baseline·답변 계약 ADR 0003·인덱스 경로 전부 무관). real-eval delta = N/A(RAG 외 변경).

## 6. 하위 호환

`--paths` opt-in: 생략 시 path-scan skip → issue-scope 결과 **byte-identical**(back-compat 테스트가 직접 보호). #1837 X>1 coordination caller 는 `paths` 미전달 → 무영향. 답변 계약/스키마/CLI flag 깨짐 없음.

## 7. 범위 외

- SessionStart 훅 역할 확대(ADR 0096 cleanup 과 분리 유지)
- Bash 매처로 수동 `git worktree add` 차단(노이즈 대비 ROI 낮음 — soft 규칙으로 커버)
- 디렉터리 `--paths` prefix 매칭(현재 정확 문자열 일치 — 파일 경로 케이스만; follow-up 가능)
- 새 ADR(0079 확장 + warn-only 새 차원 → ADR 임계값 미달)