### PR TITLE
fix(rag_vector_store): numpy exact fallback for chroma HNSW full-scan shortfall

### DIFF
--- a/rag_vector_store.py
+++ b/rag_vector_store.py
@@ -350,6 +350,14 @@ class ChromaVectorStore:
         pairs = self._query_chroma_pairs(qvec_f32, n_results=limit)
         actual_ids = [idx for idx, _ in pairs]
         if len(actual_ids) != limit:
+            if limit == len(self):
+                # Full-corpus scan: chroma's in-memory HNSW (search_ef ≪ k,
+                # num_threads=cpu_count) can nondeterministically drop rows when
+                # n_results ≈ collection size. We already hold the exact numpy
+                # ranking, so fall back to it instead of crashing. Partial
+                # top-k stays strict — a short result there is a real defect.
+                # (#1841)
+                return [(idx, float(scores[idx])) for idx in expected_ids]
             raise ValueError(
                 "Chroma query returned "
                 f"{len(actual_ids)} rows for requested top-k {limit}."

--- a/tests/test_vector_store_chroma.py
+++ b/tests/test_vector_store_chroma.py
@@ -233,6 +233,66 @@ def test_chroma_query_uses_collection_for_full_scan() -> None:
     assert result == expected
 
 
+def test_chroma_full_scan_survives_lossy_collection() -> None:
+    """Regression for #1841: a full-corpus scan must not crash when chroma's
+    in-memory HNSW returns fewer rows than requested. The exact numpy ranking
+    is served instead; the lossy collection result is discarded."""
+
+    class LossyCollection:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        def query(
+            self,
+            *,
+            query_embeddings: list[list[float]],
+            n_results: int,
+            include: list[str],
+        ) -> dict[str, list[list[str | float]]]:
+            self.calls.append(n_results)
+            # Drop one row, as HNSW does when n_results ≈ collection size.
+            return {"ids": [["2", "0", "1"]], "distances": [[0.0, 1.0, 1.0]]}
+
+    matrix = np.eye(4, dtype=np.float32)
+    expected = InMemoryVectorStore(vectors=matrix).query(matrix[2], top_k=len(matrix))
+    collection = LossyCollection()
+    store = ChromaVectorStore(
+        vectors=matrix,
+        client=object(),
+        collection=collection,
+    )
+
+    result = store.query(matrix[2], top_k=len(matrix))  # must not raise
+
+    assert collection.calls == [len(matrix)]  # chroma still attempted
+    assert result == expected  # exact numpy ranking served on shortfall
+
+
+def test_chroma_partial_top_k_short_result_still_raises() -> None:
+    """A short result for a *partial* top-k is a real defect, not HNSW
+    boundary noise — keep failing closed there (#1841)."""
+
+    class LossyCollection:
+        def query(
+            self,
+            *,
+            query_embeddings: list[list[float]],
+            n_results: int,
+            include: list[str],
+        ) -> dict[str, list[list[str | float]]]:
+            return {"ids": [["2"]], "distances": [[0.0]]}  # 1 row for top_k=2
+
+    matrix = np.eye(4, dtype=np.float32)
+    store = ChromaVectorStore(
+        vectors=matrix,
+        client=object(),
+        collection=LossyCollection(),
+    )
+
+    with pytest.raises(ValueError, match="rows for requested top-k"):
+        store.query(matrix[2], top_k=2)
+
+
 def test_naive_baseline_retrieval_uses_chroma_top_k_query() -> None:
     class SpyCollection:
         def __init__(self, inner: object) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

chroma in-memory HNSW가 full-corpus query(`n_results ≈ collection size`)에서
`search_ef`(기본 100) ≪ k + `num_threads=cpu_count()` 멀티스레드 근사 탐색으로
요청보다 적은 행을 **비결정적으로** 반환 → `ChromaVectorStore.query`의 strict
row-count assert가 크래시. 대형 인덱스(~24.6K chunks)에서 같은 인덱스·같은 쿼리인데
반환 행이 24613/24612/24609로 흔들렸다. hybrid retrieval은 RRF fusion을 위해 dense
전체 코퍼스 랭킹(`top_k=len(store)`)을 요청하므로 대형 인덱스를 chroma로 조회할
때마다 노출됐다.

full-scan일 때 이미 계산해 둔 numpy exact 랭킹으로 fallback하여 해소.

Closes #1841

## 2. 영향 파일

- `rag_vector_store.py` (Supporting; chroma query 경로) — full-scan shortfall 시 numpy exact fallback
- `tests/test_vector_store_chroma.py` — 회귀 테스트 2개

## 3. 리스크

가장 가능성 높은 깨짐: naive_baseline ranking이 바뀌어 ADR 0001 baseline 위반.
배제 근거: fix는 chroma가 **부족하게 반환할 때만** 발동(정상/작은 인덱스는 chroma
경로 그대로). `test_naive_baseline_ranking_invariance`, `test_regen_naive_baseline_golden`,
`test_hybrid_retrieval_regression`, qdrant parity 포함 retrieval/baseline 회귀 143
통과. smoke answer byte-identical(latency noise만).

## 4. 테스트

- `test_chroma_full_scan_survives_lossy_collection` — full-scan에서 collection이 행을
  누락해도 numpy exact로 복구(변경 전 raise → 후 pass).
- `test_chroma_partial_top_k_short_result_still_raises` — 부분 top-k의 short result는
  실제 결함이므로 strict 유지(fail-closed 보존).
- chroma 단위 25 통과(기존 `test_chroma_query_uses_collection_for_full_scan` 포함).

## 5. Eval 영향

`rag_vector_store.py`는 Supporting(§저장소맵; load-bearing 목록 외)이나 retrieval
코어라 명시한다:
- **작은/정상 인덱스: 동작 무변경** — fix는 chroma shortfall 시에만 발동, 정상
  케이스는 chroma 경로 그대로 byte-identical(naive_baseline invariance 통과).
- **대형 인덱스(search_ef 경계 초과): 기존 크래시 → 정상 완주** — page-aware
  24.6K-chunk private 인덱스에서 chroma+full-scan eval이 이전엔 비결정적 크래시,
  fix 후 300-case 완주 확인.
- 이 PR은 retrieval **ranking 정확도를 바꾸지 않는다**(numpy exact = chroma 정상
  결과). private real100_v2의 recall/abstention_calibration 절대수치는 별개의
  데이터셋 gold-라벨 이슈에 좌우되며 #1829(PR-2)에서 다룬다 — 이 PR과 독립.

## 6. 하위 호환

`VectorStore.query` 계약·반환 형식 불변. `schema_version` 변경 없음. 다른
backend(memory/qdrant) 무영향.

## 7. 범위 외

- chroma HNSW `search_ef` 튜닝(ANN 부분 top-k 정확도) — full-scan은 numpy가 정답이라 불필요.
- #1829(PR-2)의 abstention_calibration baseline 갱신 및 gold-라벨 품질 — 별도 issue/PR.
