### PR TITLE
fix(agent-loop): seed e3b overlap lease against wall-clock not FIXED_NOW (#1847)

### DIFF
--- a/tests/test_e3b_active_loop_coordination.py
+++ b/tests/test_e3b_active_loop_coordination.py
@@ -281,7 +281,11 @@ def test_e3b_write_active_start_rejects_overlapping_second_cycle_claim(monkeypat
     # Seed an existing ACTIVE write lease with the shared file so the second claimer sees overlap.
     leases_path = _leases_path(repo)
     leases_path.parent.mkdir(parents=True, exist_ok=True)
-    future = agent_loop._isoformat(FIXED_NOW + agent_loop.timedelta(minutes=60))
+    # write_active_start -> write_active_loop reads wall-clock now (no now= seam on that path), unlike the
+    # sibling tests that inject now=FIXED_NOW into claim_disjoint. Seed the lease expiry against the REAL
+    # clock so it stays unexpired regardless of when the suite runs; a FIXED_NOW+60min absolute coordinate
+    # (13:00 UTC) was silently mis-judged recovery-needed once real time passed it (#1847).
+    future = agent_loop._isoformat(datetime.now(timezone.utc) + timedelta(minutes=60))
     shared = "docs/operations/active-agent-loop.md"
     agent_loop._write_active_leases(
         leases_path,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1847

`test_e3b_write_active_start_rejects_overlapping_second_cycle_claim` 이 **시각 의존**으로 깨져 origin/main 의 CI shard 2 가 영구 RED → 레포 전체 PR 머지가 막힌 상태였다. 테스트가 기존 active write lease 의 만료시각을 `FIXED_NOW(12:00 UTC) + 60min = 13:00 UTC` 라는 절대 wall-clock 좌표로 시드했는데, 검증 대상 경로 `write_active_start`→`write_active_loop` 는 `now=` 주입 seam 이 없어 비교 기준을 실제 `datetime.now(timezone.utc)` 로 읽는다. 실제 시각이 13:00 UTC(=KST 22:00)를 넘는 순간부터 시드 lease 가 만료 판정 → `missing-worktree` → `recovery-needed` 로 흘러가 테스트가 단언하는 overlap blocker 대신 recovery blocker 가 반환된다. 시드 만료를 실제 wall-clock(`datetime.now(utc)+60min`) 기준으로 바꿔 실행 시각과 무관하게 항상 미만료가 되도록 했다.

#1837(테스트 도입) 머지가 05:18 UTC 라 직후 CI 는 pass 했고, 오늘 13:00 UTC 를 실제 시각이 통과한 뒤부터 fail 로 전환됐다.

## 2. 영향 파일

- `tests/test_e3b_active_loop_coordination.py` — 시드 lease 만료 기준 1줄(+설명 주석 3줄). **load-bearing 아님.**

## 3. 리스크

- 가장 가능성 높은 깨짐: '실제 wall-clock 사용 = 또 다른 비결정성' 우려. → 시드(`now+60min`)와 비교(`now`) 사이 간격은 테스트 실행 중 ms 단위라 60분이 경과할 수 없어 항상 미만료. 결정론적으로 안전.
- 프로덕션 `scripts/agent_loop.py` 무변경 — lease 비교 로직(`expires >= now`)은 정상이며, 결함은 테스트의 시각 고정 누락이었다. 자매 테스트들이 `now=FIXED_NOW` 주입으로 같은 lease 로직을 결정론 검증 중.

## 4. 테스트

- 수정 전: target FAIL (`expected overlap blocker ..., got: ('lease first-writer-lease requires recovery',)`).
- 수정 후: target `1 passed`, 파일 전체 `python3 -m pytest tests/test_e3b_active_loop_coordination.py -q` → **17 passed** (회귀 없음).
- 신규 테스트 미추가 사유: 기존 회귀 테스트의 시각-고정 결함 수정이며, 동작 계약 변경이 아니라 테스트 결정성 복원이다.

## 5. Eval 영향

All `·` — RAG 파이프라인(`rag_core`/`rag_retrieval`/`rag_verifier`/`rag_answer`/`rag_query`/`ingestion`/`eval`/`api`/`docs/adr`/`scripts/build_index.py`) 미변경. active-loop coordination 테스트 한정, real-eval 영향 없음.

## 6. 하위 호환

없음. 테스트 내부 시드 값만 변경, 공개 계약/스키마/CLI flag 무변경.

## 7. 범위 외

- `tests/test_e3b_active_loop_coordination.py` 의 기존 Pyright noise(`_patch_auto_loop_inner`/`lease_id`/`_is_task_cycle_branch`/`reject_on_overlap`)는 origin/main 의 동적-패치 패턴에서 비롯된 것으로 본 변경과 무관(런타임 17 passed 가 시그니처 실재를 증명). 별건.
- `write_active_start` 경로에 `now=` 주입 seam 을 추가해 자매 테스트와 패턴을 통일하는 리팩토링은 프로덕션 변경이라 hotfix 범위 밖 — 필요 시 별도 follow-up.