### PR TITLE
fix(hooks): delegation-gate 키워드 정밀도 — \beval 경계 + analy[sz] recall

### DIFF
--- a/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
+++ b/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
@@ -23,8 +23,21 @@
 #     마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|
 #     재설계|redesign
 #   Group B — measurement/investigation/parallel (new): 측정|진단|조사|
-#     분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analyz|
-#     benchmark|eval|multiple|parallel|concurrent|several
+#     분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analy[sz]|
+#     benchmark|\beval|multiple|parallel|concurrent|several
+# Keyword precision (issue #1761):
+#   - `\beval` (leading word-boundary) matches eval/evaluate/evaluation/evals
+#     but excludes the retrieval/medieval substring false-positives. Bare
+#     `eval` fired on "retrieval" — ubiquitous in this RFP-retrieval repo —
+#     causing near-constant nudges (nudge blindness). `\b` works on GNU
+#     (Linux CI) and BSD (macOS) grep alike. Note: `\beval\b` would also drop
+#     evaluate/evaluation, so the trailing boundary is intentionally omitted.
+#   - `analy[sz]` adds analysis (noun) / analyse (British) recall; bare
+#     `analyz` only matched the US verb stem.
+#   - Korean `여러` keeps a known accepted false-positive on `여러분`
+#     (greeting). Dropping it would lose `여러 파일`(multiple files) recall and
+#     grep word-boundaries are unreliable for Hangul, so it is documented
+#     rather than over-engineered (issue #1761 LOW, accepted FP).
 # Conservative tuning: single typo fixes, yes/no questions, and
 # one-liner prompts should NOT trigger. Multi-word compound patterns
 # (전체.*수정) kept from Group A for specificity.
@@ -64,7 +77,7 @@ print(p)
 #
 # Group A: code change-intent (original set)
 # Group B: measurement / investigation / parallel tasks (issue #1753)
-if printf '%s' "$prompt" | grep -qiE "리팩토링|refactor|구현해|implement|다 고쳐|전체.*수정|all files|새 기능|new feature|마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|재설계|redesign|측정|진단|조사|분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analyz|benchmark|eval|multiple|parallel|concurrent|several"; then
+if printf '%s' "$prompt" | grep -qiE "리팩토링|refactor|구현해|implement|다 고쳐|전체.*수정|all files|새 기능|new feature|마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|재설계|redesign|측정|진단|조사|분석|벤치|평가|여러|병렬|동시|measure|diagnos|investigat|analy[sz]|benchmark|\beval|multiple|parallel|concurrent|several"; then
   # stdout → prepended to Claude's next-turn context.
   cat <<'EOF'
 

--- a/tests/test_hook_delegation_gate.py
+++ b/tests/test_hook_delegation_gate.py
@@ -71,6 +71,12 @@ _GROUP_B_TRIGGERS = [
     "동시에 실행",
     "concurrent execution",
     "several tasks",
+    # issue #1761: \beval inclusion lock — evaluate/evaluation must still fire
+    "evaluate the model",
+    "evaluation framework",
+    # issue #1761: analy[sz] recall — analysis (noun) / analyse (British) now covered
+    "send me the analysis",
+    "analyse the data",
 ]
 
 _NON_TRIGGERS = [
@@ -87,6 +93,10 @@ _NON_TRIGGERS = [
     "what does this function do?",  # pure question
     "git status 알려줘",              # simple lookup
     "버전 확인해줘",
+    # issue #1761: \beval word-boundary — retrieval/medieval substring must NOT fire
+    "is retrieval hybrid by default?",
+    "fix typo in retrieval docstring",
+    "this is medieval history",
 ]
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` 의 키워드 regex 정밀도를 개선한다 (PR #1754 code-reviewer 패스의 비차단 NIT follow-up). bare `eval` substring 이 `retrieval`(retri·**eval**)/`medieval` 내부까지 매치해, RFP-retrieval repo 특성상 거의 모든 프롬프트에서 훅이 발화 → nudge blindness(읽는 사람이 무시하도록 훈련, 기능 목적 부분 무력화)를 유발하던 핵심 FP 를 `\beval` leading word-boundary 로 제거하고, `analyz` → `analy[sz]` 로 `analysis`(명사)/`analyse`(영국식) recall gap 을 보완한다.

Closes #1761

## 2. 영향 파일

- `scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` — regex 2곳(`analyz`→`analy[sz]`, `eval`→`\beval`) + 정밀도 근거 / `여러` accepted-FP 주석. **non-load-bearing** (`scripts/_governance.py` `LOAD_BEARING_PATHS` 비포함).
- `tests/test_hook_delegation_gate.py` — 회귀 케이스 +7 (NON_TRIGGER 3, GROUP_B 4).

## 3. 리스크

- **inclusion 회귀** (eval/evaluate/evaluation 누락): `\beval\b` 대신 `\beval`(leading-only) 채택으로 evaluate/evaluation 유지. `evaluate the model`/`evaluation framework` inclusion-lock 테스트로 가드.
- **grep 이식성** (`\b` 미지원 우려): GNU(Linux CI) + BSD(`/usr/bin/grep`) + ugrep(로컬 PATH) 3종 모두 `retrieval`/`medieval`→no, `eval`/`evaluation`/`analysis`/`analyse`→match 실측 확인.
- nudge-only 훅(항상 exit 0, 차단 없음)이라 최악의 경우에도 next-turn context 텍스트 1줄 차이.

## 4. 테스트

`tests/test_hook_delegation_gate.py` (기존 hook contract 테스트 확장 — 이슈 지정 파일):
- 변경 전: **5 failed** — `send me the analysis`/`analyse the data`(GROUP_B no-fire) + `is retrieval hybrid by default?`/`fix typo in retrieval docstring`/`this is medieval history`(NON_TRIGGER unexpected FIRE).
- 변경 후: **8 passed, 110 subtests passed**.
- behavior-change 변경 전 fail / 후 pass 동반 충족 ✓.

## 5. Eval 영향

**동작 변화 없음 (eval surface 무관).** 변경 파일은 Claude Code UserPromptSubmit 훅 + 그 단위 테스트로, `LOAD_BEARING_PATHS`(`rag_*`, `ingestion`, `eval/`, `api/`, `docs/adr/`, `build_index`) 어디에도 속하지 않는다. RAG 파이프라인/검색/검증/답변/eval 산출물에 영향 없음 → CI eval delta All `·`. real-eval 미실행 (런타임 개발 훅 변경, eval 경로 무관).

## 6. 하위 호환

깨짐 없음. 훅은 nudge-only(stdout context injection, 항상 exit 0) 계약 유지 — exit code / 차단 동작 / 출력 마커(`agent-delegation-gate`) 불변. 키워드 매칭 정밀도만 조정. 답변 계약(ADR 0003)/스키마/CLI flag 무관.

## 7. 범위 외

- 한국어 `여러` → `여러분`(인사) accepted-FP: 이슈 #1761 LOW. drop 시 `여러 파일`(multiple files) recall 손실 + 한글 grep word-boundary 불안정 → over-engineering 회피하고 hook 주석에 명문화 (코드 미변경).
