### PR TITLE
feat(scripts): add session/lease staleness summary banner to agent-loop board

### DIFF
--- a/scripts/render_agent_loop_board.py
+++ b/scripts/render_agent_loop_board.py
@@ -1946,6 +1946,43 @@ LOG_FILTER_JS = """
 # Main render
 # ---------------------------------------------------------------------------
 
+def render_staleness_banner(registry: dict, leases_data: dict) -> str:
+    """Top banner: session/lease staleness at a glance.
+
+    Aggregates already-computed ledger enum fields (heartbeat_state,
+    status) only — no now()-based recomputation, so the rendered counts
+    are deterministic. ADR 0005: emits counts and enum labels only, never
+    free-text (no stdout/prompt/command/guidance/plan/last_message).
+    """
+    sessions = _as_list(registry.get("sessions"))
+    leases = _as_list(leases_data.get("leases"))
+    total = len(sessions)
+    if total == 0 and not leases:
+        return ""
+
+    stale_hb = sum(1 for r in sessions if _as_dict(r).get("heartbeat_state") == "stale")
+    stale_status = sum(1 for r in sessions if _as_dict(r).get("status") == "stale")
+    idle = sum(1 for r in sessions if _as_dict(r).get("status") == "idle")
+    expired_leases = sum(1 for r in leases if _as_dict(r).get("status") == "expired")
+    has_stale = bool(stale_hb or stale_status or expired_leases)
+
+    chips = [badge(f"sessions {total}", tone="neutral")]
+    if stale_hb:
+        chips.append(badge(f"hb-stale {stale_hb}/{total}", tone="warn"))
+    if stale_status:
+        chips.append(badge(f"status-stale {stale_status}", tone="warn"))
+    if idle:
+        chips.append(badge(f"idle {idle}", tone="neutral"))
+    if leases:
+        chips.append(badge(f"leases {len(leases)}", tone="neutral"))
+    if expired_leases:
+        chips.append(badge(f"expired-lease {expired_leases}", tone="warn"))
+
+    headline = "⚠ STALENESS" if has_stale else "✓ HEALTHY"
+    body = f'<div class="banner-chips">{" ".join(chips)}</div>'
+    return panel(headline, body, sub="session / lease at a glance")
+
+
 def render(state_dir: Path, out: Path, *, auto_refresh: bool = True) -> None:
     now_str = _dt.datetime.now(_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -1974,6 +2011,7 @@ def render(state_dir: Path, out: Path, *, auto_refresh: bool = True) -> None:
     # 2 status · 3 trend|mix · 4 cycles · 5 topology · 6 workers|queue ·
     # 7 blockers|mix · 8 event log · 9 drawer
     body_sections = "\n".join([
+        render_staleness_banner(registry, leases_data),
         render_mission_status(auto, runner, registry, events),
         (
             '<div class="grid-2">'

--- a/tests/test_render_agent_loop_board.py
+++ b/tests/test_render_agent_loop_board.py
@@ -1,7 +1,7 @@
 """Regression guard for the agent-loop ``make 시작`` mission-control HTML board.
 
-Covers three behaviours the renderer must hold (the board itself is frozen — these
-tests assert its *actual* behaviour, never drive a code change):
+Covers four behaviours the renderer must hold (tests assert the renderer's
+*actual* behaviour — a regression guard plus the staleness banner added here):
 
 1. ``render()`` builds a self-contained, network-free HTML page from a synthetic
    ``--state-dir`` of ledger JSON/JSONL files (the same filenames the renderer
@@ -14,6 +14,9 @@ tests assert its *actual* behaviour, never drive a code change):
    never surfaces (codex ``last_message``/``stdout``/``stderr``/``prompt``/
    ``command``, cycle escalation ``guidance``, backlog ``plan``) do not leak into
    the rendered HTML; only structural metadata is exposed.
+4. the top staleness banner aggregates already-computed ledger enum fields
+   (session ``heartbeat_state``/``status``, lease ``status``) into at-a-glance
+   counts, surfacing only counts and enum labels (ADR 0005).
 """
 from __future__ import annotations
 
@@ -27,6 +30,7 @@ from scripts.render_agent_loop_board import (
     render,
     render_blockers_summary,
     render_event_log,
+    render_staleness_banner,
 )
 
 # The sentinel ``_sanitize_text`` substitutes for a matched run-artifact path.
@@ -470,3 +474,51 @@ def test_structural_metadata_still_surfaced_alongside_redaction(tmp_path: Path) 
         "extra_fields scalar value leaked 'codex_runs' token in event_log "
         "(Low-2 regression)"
     )
+
+
+# ---------------------------------------------------------------------------
+# 4. Staleness banner — aggregate session/lease health at a glance.
+# ---------------------------------------------------------------------------
+
+def test_staleness_banner_aggregates_session_lease_counts(tmp_path: Path) -> None:
+    # Counts already-computed ledger enum fields (heartbeat_state/status, lease
+    # status) — deterministic (no now() recomputation), ADR 0005 (counts/enums
+    # only). Fixture: 2 sessions (1 active/fresh-hb, 1 stale/stale-hb) + 1 lease.
+    reg = _session_registry()
+    leases = _leases()
+
+    banner = render_staleness_banner(reg, leases)
+    assert "sessions 2" in banner
+    assert "hb-stale 1/2" in banner      # reviewer heartbeat_state == "stale"
+    assert "status-stale 1" in banner    # reviewer status == "stale"
+    assert "leases 1" in banner
+    assert "STALENESS" in banner         # warn headline when any stale present
+
+    # Surfaced at the top of the full render.
+    html = _render_to_html(tmp_path)
+    assert "session / lease at a glance" in html
+
+    # ADR 0005: the banner emits no free-text secret.
+    for secret in _FREE_TEXT_SECRETS:
+        assert secret not in banner, f"banner leaked free-text: {secret}"
+
+
+def test_staleness_banner_healthy_when_no_stale() -> None:
+    # All-fresh sessions and no expired lease → ✓ HEALTHY, no warn count chips.
+    healthy = {
+        "sessions": [
+            {"role": "orchestrator", "session_id": "s1",
+             "status": "active", "heartbeat_state": "fresh"},
+        ],
+    }
+    banner = render_staleness_banner(healthy, {"leases": []})
+    assert "HEALTHY" in banner
+    assert "sessions 1" in banner
+    assert "hb-stale" not in banner
+    assert "status-stale" not in banner
+    assert "expired-lease" not in banner
+
+
+def test_staleness_banner_empty_when_no_data() -> None:
+    # No sessions and no leases → banner renders nothing (empty string).
+    assert render_staleness_banner({}, {}) == ""


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1853

agent-loop render board(#1834)는 session heartbeat staleness 를 세션별 `hb:stale` badge 하나로만, lease `expires_at` 은 raw 문자열로만 보여줘서 "전체 중 몇 개가 stale 인지" 를 한눈에 못 봤다. board 상단에 staleness 종합 배너를 추가 — stale/idle 세션 수와 expired lease 수를 카드 일일이 안 봐도 즉시 인지.

실측 동기(2026-06-03): session_registry 8세션이 전부 stale + orphan worktree 5개 누적인데 종합 신호가 없었음.

## 2. 영향 파일

- `scripts/render_agent_loop_board.py` — `render_staleness_banner()` 추가 + `body_sections` 최상단 삽입 (**load-bearing 아님** — LOAD_BEARING_PATHS 외)
- `tests/test_render_agent_loop_board.py` — 배너 테스트 3종 + docstring/import

## 3. 리스크

렌더러만 수정 — `agent_loop.py`(active-loop 운영 영역) 무관이라 동시 세션 충돌 0. 배너는 ledger 의 이미 계산된 enum(`heartbeat_state`/`status`)만 집계, `now()` 재계산 없음 → 결정적. ADR 0005: 숫자(count)/enum label 만 노출, free-text(stdout/prompt/command/guidance/plan) 0. 가능한 깨짐 = 집계 오류 → mutation 으로 배제(§4).

## 4. 테스트

3종 추가 (worktree pytest 10 passed):
- `test_staleness_banner_aggregates_session_lease_counts` — fixture(2세션·1 stale·1 lease) 기준 `sessions 2`/`hb-stale 1/2`/`status-stale 1`/`leases 1` 검증
- `test_staleness_banner_healthy_when_no_stale` — all-fresh → `✓ HEALTHY`, warn chip 없음
- `test_staleness_banner_empty_when_no_data` — 빈 입력 → 빈 문자열

**Mutation 검증**: 배너의 `heartbeat_state=="stale"` 집계를 깨면 `..._aggregates` 가 정확히 FAIL(`hb-stale 1/2` 부재), 복원 시 10 passed — non-vacuous.

## 5. Eval 영향

All `·` — load-bearing path 미변경(렌더러는 LOAD_BEARING_PATHS 외), RAG/eval 무관. real-data 영향 없음.

## 6. 하위 호환

`render()` 시그니처 무변경. `body_sections` 에 섹션 하나 추가만 — 기존 섹션/출력 구조 보존. board HTML 출력은 gitignored(ADR 0005). 답변 계약(ADR 0003) 무관.

## 7. 범위 외

- lease 동적 만료(now 기반 `expires_at < now` 판정) 미구현 — ledger 의 `status` enum 신뢰 (Non-goal)
- orphan worktree 정리 — SessionStart hygiene 훅 위임
- `agent_loop.py` 의 staleness 계산 로직 변경 없음