### PR TITLE
test(scripts): cover idle / expired-lease chip branches in staleness banner

### DIFF
--- a/tests/test_render_agent_loop_board.py
+++ b/tests/test_render_agent_loop_board.py
@@ -16,7 +16,8 @@ Covers four behaviours the renderer must hold (tests assert the renderer's
    the rendered HTML; only structural metadata is exposed.
 4. the top staleness banner aggregates already-computed ledger enum fields
    (session ``heartbeat_state``/``status``, lease ``status``) into at-a-glance
-   counts, surfacing only counts and enum labels (ADR 0005).
+   counts — distinguishing idle sessions and expired leases from stale ones —
+   surfacing only counts and enum labels (ADR 0005).
 """
 from __future__ import annotations
 
@@ -522,3 +523,45 @@ def test_staleness_banner_healthy_when_no_stale() -> None:
 def test_staleness_banner_empty_when_no_data() -> None:
     # No sessions and no leases → banner renders nothing (empty string).
     assert render_staleness_banner({}, {}) == ""
+
+
+def test_staleness_banner_counts_idle_sessions() -> None:
+    # idle 은 정상 대기 상태(staleness 아님): neutral chip 으로 집계되되 has_stale
+    # 에는 기여하지 않아야 → ✓ HEALTHY 유지. idle 집계 회귀 방어 (PR #1855 LOW).
+    data = {
+        "sessions": [
+            {"role": "orchestrator", "session_id": "s1",
+             "status": "active", "heartbeat_state": "fresh"},
+            {"role": "planner", "session_id": "s2",
+             "status": "idle", "heartbeat_state": "fresh"},
+            {"role": "scout", "session_id": "s3",
+             "status": "idle", "heartbeat_state": "fresh"},
+        ],
+    }
+    banner = render_staleness_banner(data, {"leases": []})
+    assert ">idle 2<" in banner          # two idle sessions counted (exact chip span — collision-safe)
+    assert "HEALTHY" in banner           # idle is not staleness
+    assert "hb-stale" not in banner
+    assert "status-stale" not in banner
+
+
+def test_staleness_banner_flags_expired_leases() -> None:
+    # expired lease 는 warn chip + ⚠ STALENESS 헤드라인을 유발해야 (has_stale).
+    # 세션은 모두 fresh — staleness 의 유일 출처가 expired lease 임을 격리.
+    data = {
+        "sessions": [
+            {"role": "orchestrator", "session_id": "s1",
+             "status": "active", "heartbeat_state": "fresh"},
+        ],
+    }
+    leases = {"leases": [
+        {"task_id": "T-1", "status": "expired"},
+        {"task_id": "T-2", "status": "active"},
+    ]}
+    banner = render_staleness_banner(data, leases)
+    assert ">leases 2<" in banner
+    assert ">expired-lease 1<" in banner  # only the expired one (exact chip span — collision-safe)
+    assert "STALENESS" in banner         # expired lease alone drives has_stale
+    # ADR 0005: lease task_id (구조적이나 enum 아님) 은 배너에 노출되지 않음.
+    assert "T-1" not in banner
+    assert "T-2" not in banner


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1856

PR #1855 (staleness 배너) code-reviewer 리뷰에서 `render_staleness_banner` 의 `idle` chip 집계가 **어떤 테스트로도 보호되지 않음**을 LOW 로 지적 (mutation: idle 로직 제거해도 기존 테스트 통과). 추가 점검에서 `expired-lease` chip **존재** 분기도 미커버(healthy 테스트는 부재만 확인)임을 확인. 두 분기를 테스트로 고정해 회귀를 방어한다.

## 2. 영향 파일

- `tests/test_render_agent_loop_board.py` — 배너 테스트 2종 추가 + 모듈 docstring 항목 4 보강 (**비-load-bearing**, test-only)
- 배너 코드(`scripts/render_agent_loop_board.py`) **변경 없음**

## 3. 리스크

test-only — 프로덕션 동작 표면 0. 배너 코드 미변경이므로 기존 출력/계약 불변. 인라인 fabricated fixture(private ledger 미참조).

## 4. 테스트

2종 추가 (worktree pytest 12 passed = 기존 10 + 신규 2):
- `test_staleness_banner_counts_idle_sessions` — idle 세션 2개 → `idle 2` chip + ✓ HEALTHY(idle 은 staleness 아님) + hb-stale/status-stale 부재
- `test_staleness_banner_flags_expired_leases` — expired lease → `expired-lease 1` + `leases 2` + ⚠ STALENESS, 그리고 lease `task_id` 미노출(ADR 0005)

**Mutation 검증 (non-vacuous)**: `idle = 0` 변조 → idle 테스트 정확히 FAIL; `expired_leases = 0` 변조 → expired 테스트 정확히 FAIL; 둘 다 복원 시 12 passed.

## 5. Eval 영향

All `·` — load-bearing path 미변경, test-only, RAG/eval 무관.

## 6. 하위 호환

배너 코드·`render()` 시그니처·답변 계약(ADR 0003) 전부 무관 — 테스트만 추가.

## 7. 범위 외

- `lease` 동적 만료(now 기반) 판정 — #1855 와 동일하게 ledger `status` enum 신뢰 (Non-goal)
- 배너 신규 chip/기능 추가 없음 — 기존 분기 커버리지만 보강