### PR TITLE
test(eval): lock real100_v2 benchmark tier contract

### DIFF
--- a/docs/evaluation/real100_v2-benchmark-tiers.md
+++ b/docs/evaluation/real100_v2-benchmark-tiers.md
@@ -1,0 +1,66 @@
+# real100_v2 Benchmark Tier Split
+
+Issue: [#1503](https://github.com/hskim-solv/BidMate-DocAgent/issues/1503)  
+Surface: private real-eval aggregate-only interpretation.
+
+## Purpose
+
+`reports/real100_v2/benchmark_tiers.aggregate.json` separates the private
+`real100_v2` aggregate into three interpretation tiers so reviewers can read a
+run as more than one headline average:
+
+- `easy_sanity` — answerable, single-doc / single-chunk checks with clear terms.
+- `standard_real` — normal RFP QA such as date, amount, score, schedule, or
+  requirement extraction with moderate distractors.
+- `hard_stress` — multi-chunk, multi-doc, table-heavy, similar-clause,
+  unanswerable, citation/page-dependent, or parser-stress cases.
+
+The split is for interpretation and regression analysis only. It is not a
+license to cherry-pick a winning tier while hiding the overall result or another
+regressing tier.
+
+## Renderer
+
+The aggregate is produced by:
+
+```bash
+python3 scripts/render_real100_v2_aggregates.py \
+  --eval-summary <private-local-real100_v2-eval-summary.json> \
+  --questions <private-local-real100_v2-questions.jsonl> \
+  --baseline-out reports/real100_v2/baseline.aggregate.json \
+  --tiers-out reports/real100_v2/benchmark_tiers.aggregate.json
+```
+
+Inputs may be private local files. Only allowlisted aggregate output may be
+committed.
+
+## Commit Boundary
+
+Committed tier artifacts must omit raw questions, answers, evidence text,
+filenames, local paths, `doc_id`, `chunk_id`, and per-case rows. The renderer
+emits only tier names, counts, aggregate metric means, missing counts,
+abstention outcome counts, and safe failure-category counts.
+
+## Claim Rules
+
+Allowed:
+
+- “The private `real100_v2` aggregate improved or regressed in tier X” when the
+  same report also names the overall result, every tier, config/index
+  provenance, and paired-delta context.
+- “Tier X is the dominant stress slice for this run” when stated as diagnostic
+  interpretation, not as a global quality claim.
+
+Disallowed:
+
+- Using one improved tier as a headline while another tier or the overall
+  aggregate regresses.
+- Mixing legacy `real100`/v1/221/kordoc evidence into a current `real100_v2`
+  tier claim.
+- Committing raw private case rows to explain a tier.
+
+## Regression Guard
+
+`tests/test_render_real100_v2_aggregates.py` locks the renderer contract with
+synthetic fixtures and checks that both generated and committed aggregate tier
+artifacts stay public-safe.

--- a/docs/evaluation/surface-map.md
+++ b/docs/evaluation/surface-map.md
@@ -118,6 +118,7 @@ Before accepting an eval/benchmark claim, verify:
 - [Eval Dataset Spec](../eval/eval-dataset-spec.md)
 - [Synthetic Naive RAG Benchmark v1 Design](./synthetic_benchmark_v1_design.md)
 - [Private Real-Eval Workflow](./private_real_eval_workflow.md)
+- [real100_v2 Benchmark Tier Split](./real100_v2-benchmark-tiers.md)
 - [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-loop.md)
 - [Pre-Improvement Readiness Checklist](./pre_improvement_readiness_checklist.md)
 - [RAG Performance Experiment Stack](./rag-performance-experiment-stack.md)

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -6,7 +6,7 @@ Allowed files:
 
 - `parse_inventory.aggregate.json`
 - `question_distribution.aggregate.json`
-- `benchmark_tiers.aggregate.json`
+- `benchmark_tiers.aggregate.json` — see [tier interpretation docs](../../docs/evaluation/real100_v2-benchmark-tiers.md)
 - `baseline.aggregate.json`
 - `latency_cost_budget.aggregate.json`
 - `reranker_candidate_budget.aggregate.json`

--- a/tests/test_render_real100_v2_aggregates.py
+++ b/tests/test_render_real100_v2_aggregates.py
@@ -1,0 +1,219 @@
+"""Regression guards for aggregate-only real100_v2 tier rendering."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.private_data_quality_audit_utils import assert_public_safe
+from scripts.render_real100_v2_aggregates import TIERS, main, render_tiers
+
+
+def _case(case_id: str, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": case_id,
+        "answerable": True,
+        "abstained": False,
+        "chunk_recall_at_5": 0.0,
+        "chunk_recall_at_10": 0.0,
+        "chunk_mrr_at_5": 0.0,
+        "chunk_ndcg_at_5": 0.0,
+        "citation_precision": 0.0,
+        "citation_grounding": 0.0,
+        "abstention": None,
+        "failure_category": "none",
+        # Input may contain private per-case fields; output must not.
+        "question": "PRIVATE QUESTION SENTINEL",
+        "answer": "PRIVATE ANSWER SENTINEL",
+        "doc_id": "PRIVATE_DOC",
+        "chunk_id": "PRIVATE_CHUNK",
+        "file_path": "/Users/example/private.rfp",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_render_tiers_groups_metrics_and_unknown_cases_without_private_leak() -> None:
+    summary = {
+        "case_results": [
+            _case(
+                "easy-1",
+                chunk_recall_at_5=1.0,
+                chunk_recall_at_10=1.0,
+                chunk_mrr_at_5=0.5,
+                chunk_ndcg_at_5=0.75,
+                citation_precision=0.25,
+                citation_grounding=1.0,
+            ),
+            _case(
+                "standard-1",
+                abstained=True,
+                chunk_recall_at_5=0.5,
+                chunk_recall_at_10=1.0,
+                failure_category="retrieval_miss",
+            ),
+            _case(
+                "hard-1",
+                answerable=False,
+                abstained=True,
+                abstention=1.0,
+                failure_category="new_private_failure_label",
+            ),
+            _case("unmapped-1", chunk_recall_at_5=1.0),
+        ]
+    }
+    question_tiers = {
+        "easy-1": "easy_sanity",
+        "standard-1": "standard_real",
+        "hard-1": "hard_stress",
+    }
+
+    aggregate = render_tiers(summary, question_tiers)
+
+    assert aggregate["profile_type"] == "private_real100_v2_benchmark_tiers"
+    assert set(aggregate["tiers"]) == set(TIERS)
+    assert aggregate["unknown_tier_case_count"] == 1
+    assert aggregate["tiers"]["easy_sanity"]["n"] == 1
+    assert aggregate["tiers"]["standard_real"]["n"] == 1
+    assert aggregate["tiers"]["hard_stress"]["n"] == 1
+    assert aggregate["tiers"]["easy_sanity"]["metrics"]["recall_at_5"] == {
+        "mean": 1.0,
+        "n": 1,
+        "missing": 0,
+    }
+    assert aggregate["tiers"]["standard_real"]["abstention_outcomes"] == {
+        "false_abstention": 1
+    }
+    assert aggregate["tiers"]["hard_stress"]["abstention_outcomes"] == {
+        "correct_abstention": 1
+    }
+    assert aggregate["tiers"]["hard_stress"]["failure_distribution"] == {
+        "unknown": 1
+    }
+
+    assert_public_safe(aggregate)
+    rendered = json.dumps(aggregate, ensure_ascii=False, sort_keys=True)
+    for forbidden in (
+        "PRIVATE QUESTION SENTINEL",
+        "PRIVATE ANSWER SENTINEL",
+        "PRIVATE_DOC",
+        "PRIVATE_CHUNK",
+        "/Users/example/private.rfp",
+        "case_results",
+    ):
+        assert forbidden not in rendered
+
+
+def test_cli_writes_baseline_and_tier_aggregates(tmp_path: Path) -> None:
+    summary_path = tmp_path / "eval_summary.json"
+    questions_path = tmp_path / "questions.jsonl"
+    baseline_out = tmp_path / "baseline.aggregate.json"
+    tiers_out = tmp_path / "benchmark_tiers.aggregate.json"
+
+    summary_path.write_text(
+        json.dumps(
+            {
+                "num_predictions": 2,
+                "accuracy": 0.5,
+                "groundedness": 0.25,
+                "citation_precision": 0.75,
+                "citation_grounding": 1.0,
+                "claim_citation_alignment": 0.5,
+                "answer_format_compliance": 1.0,
+                "abstention": None,
+                "retry": 0.0,
+                "case_results": [
+                    _case("easy-1", chunk_recall_at_5=1.0),
+                    _case(
+                        "hard-1",
+                        answerable=False,
+                        abstained=False,
+                        abstention=0.0,
+                    ),
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    questions_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "question_id": "easy-1",
+                        "difficulty_tier": "easy_sanity",
+                        "question": "PRIVATE QUESTION SENTINEL",
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "question_id": "hard-1",
+                        "difficulty_tier": "hard_stress",
+                        "support_text": "PRIVATE SUPPORT SENTINEL",
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--eval-summary",
+            str(summary_path),
+            "--questions",
+            str(questions_path),
+            "--baseline-out",
+            str(baseline_out),
+            "--tiers-out",
+            str(tiers_out),
+        ]
+    )
+
+    assert rc == 0
+    baseline = json.loads(baseline_out.read_text(encoding="utf-8"))
+    tiers = json.loads(tiers_out.read_text(encoding="utf-8"))
+    assert baseline["profile_type"] == "private_real100_v2_baseline"
+    assert baseline["metrics"]["recall_at_5"] is None
+    assert baseline["privacy"]["aggregate_only"] is True
+    assert tiers["profile_type"] == "private_real100_v2_benchmark_tiers"
+    assert tiers["tiers"]["easy_sanity"]["n"] == 1
+    assert tiers["tiers"]["hard_stress"]["abstention_outcomes"] == {
+        "missed_abstention": 1
+    }
+    assert_public_safe(baseline)
+    assert_public_safe(tiers)
+    rendered = json.dumps({"baseline": baseline, "tiers": tiers}, ensure_ascii=False)
+    assert "PRIVATE QUESTION SENTINEL" not in rendered
+    assert "PRIVATE SUPPORT SENTINEL" not in rendered
+
+
+def test_committed_benchmark_tiers_artifact_matches_public_contract() -> None:
+    path = Path("reports/real100_v2/benchmark_tiers.aggregate.json")
+    aggregate = json.loads(path.read_text(encoding="utf-8"))
+
+    assert aggregate["schema_version"] == 1
+    assert aggregate["profile_type"] == "private_real100_v2_benchmark_tiers"
+    assert set(aggregate["tiers"]) == set(TIERS)
+    assert aggregate["privacy"] == {
+        "aggregate_only": True,
+        "chunk_ids_omitted": True,
+        "doc_ids_omitted": True,
+        "filenames_omitted": True,
+        "paths_omitted": True,
+        "per_case_rows_omitted": True,
+        "raw_answers_omitted": True,
+        "raw_evidence_omitted": True,
+        "raw_questions_omitted": True,
+        "raw_text_omitted": True,
+    }
+    for tier in TIERS:
+        block = aggregate["tiers"][tier]
+        assert {"n", "metrics", "abstention_outcomes", "failure_distribution"} <= set(block)
+        assert {"recall_at_5", "recall_at_10", "mrr_at_5", "ndcg_at_5"} <= set(
+            block["metrics"]
+        )
+    assert_public_safe(aggregate)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`real100_v2` benchmark tier split은 이미 aggregate artifact와 renderer가 있었지만, renderer/privacy/schema 계약을 직접 잠그는 focused regression test와 reviewer-facing 해석 문서가 없었습니다. 이 PR은 tier split을 `easy_sanity` / `standard_real` / `hard_stress` aggregate-only interpretation surface로 문서화하고, raw private case content가 committable output으로 새지 않는 계약을 synthetic fixture로 잠급니다.

Closes #1503

## 2. 영향 파일

- `tests/test_render_real100_v2_aggregates.py` — renderer contract/privacy/schema regression tests 추가.
- `docs/evaluation/real100_v2-benchmark-tiers.md` — tier split 해석/claim/commit-boundary 문서 추가.
- `docs/evaluation/surface-map.md` — 관련 문서 링크 추가.
- `reports/real100_v2/README.md` — `benchmark_tiers.aggregate.json` 해석 문서 링크 추가.

## 3. 리스크

- 리스크: tier별 개선만 cherry-pick하는 claim wording이 생길 수 있음.
  - 배제/완화: 새 문서가 overall + every tier reporting을 요구하고, `claim-audit --from-git` 통과.
- 리스크: private raw question/evidence/id/path가 aggregate output에 새는 회귀.
  - 배제/완화: synthetic sentinel fixture와 committed artifact privacy test, `privacy-audit-output` 통과.

## 4. 테스트

- `python3 -m pytest -q tests/test_render_real100_v2_aggregates.py` — 3 passed.
- `python3 -m py_compile scripts/render_real100_v2_aggregates.py tests/test_render_real100_v2_aggregates.py` — passed.
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/real100_v2-benchmark-tiers.md docs/evaluation/surface-map.md reports/real100_v2/README.md` — passed.
- `python3 scripts/check_real100_v2_only.py` — passed.
- `python3 scripts/agent_loop.py privacy-audit-output` — passed, finding count 0.
- `python3 scripts/agent_loop.py claim-audit --from-git` — passed, findings none.
- `git diff --check` — passed.
- `make check-branch` — passed.

## 5. Eval 영향

Benchmark-reporting / documentation + regression-test change only. No RAG runtime, retrieval, answer, scoring, parser, index, or private aggregate regeneration. No new performance claim. `real100_v2`-only guard passed; legacy `real100`/v1/221/kordoc evidence is not used.

## 6. 하위 호환

No CLI flag, schema version, answer contract, or runtime behavior change. Existing `scripts/render_real100_v2_aggregates.py` output contract is preserved and now tested.

## 7. 범위 외

- Full private `real100_v2` benchmark regeneration: intentionally not run; this PR locks aggregate renderer/docs contract only.
- Any default retrieval/reranker/context-packing behavior change: out of scope.
