### PR TITLE
Clarify ingestion mode vs loader fallback wording

### DIFF
--- a/docs/real-data/real-data-ingestion.md
+++ b/docs/real-data/real-data-ingestion.md
@@ -83,8 +83,9 @@ required input 이며, 새 환경에서는 `eval/real_config.local.example.yaml`
 optional profile을 사용할 때도 index schema는 동일하며, 기본 경로만 `data/index/real100/`로 분리한다.
 
 ## v1 / v2 비교
-- v1 기본값은 `--ingestion_mode csv-text`이며, CSV의 `텍스트` 컬럼을 본문으로 사용한다.
+- v1 기본값은 `--ingestion_mode csv-text`이며, 이는 metadata-CSV v1 ingestion 경로를 선택한다는 뜻이다. HWP/PDF body extraction 또는 loader fallback 값인 `csv_text`와 다른 표면이다.
 - v2는 `--ingestion_mode visual`을 명시했을 때만 활성화된다.
+- HWP/PDF parser 선택은 별도 flag인 `--hwp_loader` / `--pdf_loader`가 담당한다. 예를 들어 `ingestion_mode=csv-text`이면서 `hwp_loader=pdf_pymupdf4llm`이면 metadata-CSV v1 경로를 쓰되 HWP 본문은 PyMuPDF4LLM page chunks로 만든다.
 - v2에서 PDF/image는 visual parser artifact를 만들고, HWP는 native visual parsing 대신 CSV 텍스트 fallback을 사용한다.
 - HWP fallback 문서는 metadata에 `visual_fallback_reason: visual_fallback_hwp`, `text_source: data_list_csv_text`를 유지한다.
 - 두 모드 모두 기본 산출물 경로는 `data/index/index.json`과 `data/index/ingestion_report.json`이다. v2는 추가로 `data/index/visual_artifacts/*.visual.json`을 생성한다.

--- a/rag_provenance.py
+++ b/rag_provenance.py
@@ -141,7 +141,12 @@ def build_index_rows(args: Any) -> list[Row]:
         ))
         if hwp == "kordoc" or pdf == "kordoc":
             rows.append(("kordoc_cache", _resolve_kordoc_cache(getattr(args, "files_dir", None)), INFO, None))
-        rows.append(("ingestion_mode", str(getattr(args, "ingestion_mode", "csv-text")), OK, None))
+        mode = str(getattr(args, "ingestion_mode", "csv-text"))
+        if mode == "csv-text":
+            mode_value = "csv-text (metadata CSV v1 path; does not force loader fallback csv_text)"
+        else:
+            mode_value = f"{mode} (metadata CSV visual path)"
+        rows.append(("ingestion_mode", mode_value, OK, None))
 
     rows.append(("chunking", str(getattr(args, "chunking_strategy", "fixed")), OK, None))
     if _env("BIDMATE_INGEST_REDACT_PII").lower() in _TRUTHY:

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -53,7 +53,13 @@ def parse_args() -> argparse.Namespace:
         "--ingestion_mode",
         default="csv-text",
         choices=["csv-text", "visual"],
-        help="Use CSV text v1 or visual parsing v2 when --metadata_csv is provided.",
+        help=(
+            "Select the metadata-CSV ingestion path when --metadata_csv is "
+            "provided: 'csv-text' selects the metadata-CSV v1 path, while "
+            "'visual' uses visual parsing v2. This flag does not force the "
+            "HWP/PDF loader fallback value 'csv_text'; body extraction is "
+            "controlled separately by --hwp_loader/--pdf_loader."
+        ),
     )
     parser.add_argument(
         "--visual_artifact_dir",

--- a/tests/test_provenance_banner.py
+++ b/tests/test_provenance_banner.py
@@ -115,6 +115,16 @@ class IngestionLoaderTest(unittest.TestCase):
         self.assertNotIn("hwp_loader", labels)
         self.assertIn("embedding", labels)
 
+    def test_ingestion_mode_value_distinguishes_loader_fallback(self):
+        rows = p.build_index_rows(_Args(ingestion_mode="csv-text", hwp_loader="pdf_pymupdf4llm"))
+        mode = [r for r in rows if r[0] == "ingestion_mode"][0]
+        hwp = [r for r in rows if r[0] == "hwp_loader"][0]
+        self.assertEqual(mode[2], p.OK)
+        self.assertIn("metadata CSV v1 path", mode[1])
+        self.assertIn("does not force loader fallback csv_text", mode[1])
+        self.assertEqual(hwp[1], "pdf_pymupdf4llm")
+        self.assertEqual(hwp[2], p.OK)
+
 
 class EvalTextSourceTest(unittest.TestCase):
     def _write_report(self, tmp: Path, counts: dict) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`ingestion_mode=csv-text`가 HWP/PDF loader fallback 값 `csv_text`처럼 보이는 혼동을 줄이기 위해 CLI help, provenance banner, real-data ingestion 문서의 wording을 명확히 했다. `csv-text`는 metadata-CSV v1 ingestion path 선택이고, body extraction은 `--hwp_loader` / `--pdf_loader`가 담당한다는 점을 명시했다.

Closes #1574

## 2. 영향 파일

- `scripts/build_index.py` — load-bearing: `--ingestion_mode` help wording 명확화
- `rag_provenance.py` — provenance banner의 기존 `ingestion_mode` row label은 유지하고 value에 loader fallback과의 차이를 명시
- `tests/test_provenance_banner.py` — `ingestion_mode` value가 loader fallback과 구분되는지 regression 추가
- `docs/real-data/real-data-ingestion.md` — v1/v2 ingestion mode와 loader flag 차이 설명

## 3. 리스크

가장 큰 리스크는 log/provenance consumer가 `ingestion_mode` label 변경으로 깨지는 것이다. Pre-commit adversarial review의 정보성 지적을 반영해 label은 기존 `ingestion_mode` 그대로 유지하고 value만 명확히 했다.

## 4. 테스트

- `python3 -m pytest -q tests/test_provenance_banner.py`
- `python3 -m py_compile scripts/build_index.py rag_provenance.py tests/test_provenance_banner.py`
- `python3 scripts/build_index.py --help | grep -A7 -- '--ingestion_mode'`
- provenance banner smoke via `rag_provenance.emit_build_banner(...)`
- `python3 scripts/check_doc_links.py --check-all --paths docs/real-data/real-data-ingestion.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변화 없음. `scripts/build_index.py`는 load-bearing path지만 이번 변경은 CLI help text만 수정한다. `rag_provenance.py`도 banner wording만 바꾸며 retrieval/indexing/eval pipeline logic은 변경하지 않는다. real-eval은 미실행: wording/provenance-only 변경이라 private aggregate claim이 없다.

## 6. 하위 호환

기존 CLI flag/value(`--ingestion_mode`, `csv-text`, `visual`)는 유지한다. 기존 provenance row label `ingestion_mode`도 유지해 log consumer 호환성을 보존한다. Answer-contract/schema 변경 없음.

## 7. 범위 외

`--ingestion_mode` flag 또는 `csv-text` value rename은 범위 외로 남겼다. 이름 변경은 CLI compatibility 영향을 주므로 별도 migration/alias 설계가 필요하다.
