### PR TITLE
feat(self-review): narrative claim ↔ git ground-truth gap raw signal

### DIFF
--- a/docs/self-review/narrative-claims.json
+++ b/docs/self-review/narrative-claims.json
@@ -1,0 +1,4 @@
+{
+  "_schema": "Narrative-gap registry (issue #1088). Each entry juxtaposes a memory self-claim with a git ground-truth signal as a RAW SIGNAL — no verdict. Fields: signal (one of commits | load_bearing_touches | prs_merged_count | adr_changes_count), claim_value (number), source_memory (memory filename the claim came from), window (Qx-YYYY the claim refers to; compared against the report quarter via window_match), note (optional free text). Memory body text is never parsed — claims are registered explicitly here (privacy contract + parse-noise avoidance). The arithmetic gap is a raw signal; the in-/out-of-tolerance judgment stays with the LLM (SKILL.md, ADR 0064).",
+  "claims": []
+}

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -334,6 +334,113 @@ def collect_git(repo: str, start: str, end: str) -> dict[str, Any]:
     }
 
 
+# --- Narrative gap signals (issue #1088) -----------------------------------
+# Memory narrative accumulates numeric self-claims ("N PRs merged", "dogfood
+# N times"). git is the only externally-verifiable record of actual behavior;
+# when the two diverge the memory side risks being self-rationalization. We
+# place claim_value next to the git ground-truth value as a RAW SIGNAL — never
+# a verdict. The ✓/△/✗ judgment stays with the LLM (SKILL.md, ADR 0064); this
+# collector only juxtaposes the two numbers so a drifting claim can later be
+# surfaced as "needs verification".
+#
+# Deliberately OUT OF SCOPE (the discarded first attempt, stash-dropped):
+# word-count ratios, semantic similarity matching, and auto-grading. Claims
+# come from an explicit repo-internal registry, NOT from parsing memory body
+# text — the body is never read (privacy contract + parse noise).
+
+# Maps a registry ``signal`` name to a function extracting the comparable
+# scalar from ``collect_git()`` output. A signal absent from this map yields
+# ``git_value=None`` (gap stays None) so the registry may name a claim we
+# cannot yet ground without raising.
+NARRATIVE_GIT_SIGNALS: dict[str, Any] = {
+    "commits": lambda g: g.get("commits"),
+    "load_bearing_touches": lambda g: g.get("load_bearing_touches"),
+    "prs_merged_count": lambda g: len(g.get("prs_merged", [])),
+    "adr_changes_count": lambda g: len(g.get("adr_changes", [])),
+}
+
+
+def load_narrative_claims(path: str) -> list[dict[str, Any]]:
+    """Load the narrative-claims registry. Fail-soft to an empty list.
+
+    Registry shape::
+
+        {"claims": [{"signal", "claim_value", "source_memory",
+                     "window"?, "note"?}, ...]}
+
+    A missing file, malformed JSON, a non-dict root, or a non-list ``claims``
+    value all degrade to ``[]`` — the collector still runs, the gap section
+    just stays empty. Non-dict entries inside ``claims`` are skipped. Mirrors
+    the fail-soft import in ``load_load_bearing_paths``.
+    """
+    expanded = os.path.expanduser(path)
+    try:
+        with open(expanded, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    claims = data.get("claims")
+    if not isinstance(claims, list):
+        return []
+    return [c for c in claims if isinstance(c, dict)]
+
+
+def compute_narrative_gaps(
+    claims: list[dict[str, Any]], git_data: dict[str, Any], quarter: str
+) -> list[dict[str, Any]]:
+    """Juxtapose each claim_value with its git ground-truth value.
+
+    Returns one dict per claim carrying both numbers and their gap. This is a
+    RAW SIGNAL, not a verdict: ``gap`` is the plain arithmetic difference
+    (claim_value - git_value) and no threshold/grade is applied here — that is
+    the LLM's job in SKILL.md (ADR 0064). ``window_match`` flags whether the
+    claim's window equals the report quarter; since ``git_data`` is already
+    filtered to the quarter window, a mismatch means git_value is not a
+    like-for-like comparison and the gap should be read with caution.
+    """
+    signals: list[dict[str, Any]] = []
+    for claim in claims:
+        signal = claim.get("signal")
+        claim_value = claim.get("claim_value")
+        extractor = (
+            NARRATIVE_GIT_SIGNALS.get(signal) if isinstance(signal, str) else None
+        )
+        git_value = extractor(git_data) if extractor else None
+        if isinstance(claim_value, (int, float)) and isinstance(
+            git_value, (int, float)
+        ):
+            gap = claim_value - git_value
+        else:
+            gap = None
+        window = claim.get("window")
+        signals.append({
+            "signal": signal,
+            "claim_value": claim_value,
+            "git_value": git_value,
+            "gap": gap,
+            "window": window,
+            "window_match": (window == quarter) if window is not None else None,
+            "source_memory": claim.get("source_memory", ""),
+            "grounded": git_value is not None,
+        })
+    return signals
+
+
+def _narrative_gap_summary(signals: list[dict[str, Any]]) -> str:
+    """One-line registry summary for the report skeleton (no verdict)."""
+    if not signals:
+        return "0 registered"
+    grounded = [s for s in signals if s.get("grounded")]
+    gaps = [abs(s["gap"]) for s in grounded if isinstance(s.get("gap"), (int, float))]
+    max_gap = max(gaps) if gaps else None
+    return (
+        f"{len(signals)} registered, {len(grounded)} grounded, "
+        f"max|gap|={max_gap}"
+    )
+
+
 def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
     """Return ADR proposed→accepted lag for ADRs accepted within the quarter.
 
@@ -786,7 +893,8 @@ def compute_evidence_age_days(
 
 
 def assemble_stats(
-    quarter: str, transcripts_glob: str, memory_dir: str, repo: str
+    quarter: str, transcripts_glob: str, memory_dir: str, repo: str,
+    narrative_claims_path: str | None = None,
 ) -> dict[str, Any]:
     start, end = parse_quarter(quarter)
     sessions = collect_sessions(transcripts_glob, start, end)
@@ -806,6 +914,10 @@ def assemble_stats(
         "content_freshness": compute_axis_5_memory_hygiene(memory_data, start),
     }
     git_data = collect_git(repo, start, end)
+    claims_path = narrative_claims_path or os.path.join(
+        repo, "docs", "self-review", "narrative-claims.json"
+    )
+    narrative_claims = load_narrative_claims(claims_path)
     stats: dict[str, Any] = {
         "quarter": quarter,
         "date_range": [start, end],
@@ -817,6 +929,9 @@ def assemble_stats(
         "axis_2_plan_subagent_skip_rate": axis_2,
         "axis_4_cycle_time": axis_4,
         "axis_5_memory_hygiene": axis_5,
+        "narrative_gap_signals": compute_narrative_gaps(
+            narrative_claims, git_data, quarter
+        ),
     }
     stats["evidence_age_days"] = compute_evidence_age_days(stats)
     return stats
@@ -836,6 +951,10 @@ def emit_report(stats: dict[str, Any]) -> str:
         f"- Load-bearing touches: {stats['git'].get('load_bearing_touches', 0)}",
         f"- ADR changes: {len(stats['git'].get('adr_changes', []))}",
         f"- PRs merged: {len(stats['git'].get('prs_merged', []))}",
+        (
+            f"- Narrative-gap claims (issue #1088): "
+            f"{_narrative_gap_summary(stats.get('narrative_gap_signals', []))}"
+        ),
         (
             f"- Axis #2 Plan-subagent skip rate: "
             f"{stats['axis_2_plan_subagent_skip_rate'].get('skip_rate')} "
@@ -898,6 +1017,9 @@ def main() -> int:
     p.add_argument("--transcripts-glob", default=DEFAULT_TRANSCRIPTS_GLOB)
     p.add_argument("--memory-dir", default=DEFAULT_MEMORY_DIR)
     p.add_argument("--repo", default=os.getcwd())
+    p.add_argument("--narrative-claims", default=None,
+                   help="narrative-claims registry JSON (default "
+                        "<repo>/docs/self-review/narrative-claims.json)")
     p.add_argument("--emit-stats", action="store_true",
                    help="emit stats.json to stdout (quarter mode)")
     p.add_argument("--emit-report", action="store_true",
@@ -932,7 +1054,8 @@ def main() -> int:
 
     try:
         stats = assemble_stats(
-            args.quarter, args.transcripts_glob, args.memory_dir, args.repo
+            args.quarter, args.transcripts_glob, args.memory_dir, args.repo,
+            narrative_claims_path=args.narrative_claims,
         )
     except ValueError as e:
         sys.stderr.write(f"self-review: {e}\n")

--- a/tests/test_self_review_narrative_gap_regression.py
+++ b/tests/test_self_review_narrative_gap_regression.py
@@ -1,0 +1,142 @@
+"""Regression: narrative-gap raw signals (issue #1088).
+
+Locks the RAW-SIGNAL contract — the collector juxtaposes a memory self-claim
+with the git ground-truth value and emits the arithmetic gap, never a verdict.
+Out of scope (asserted absent): word-count ratios, semantic matching, and
+auto-grading (the discarded first attempt, stash-dropped).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts" / "claude-hooks" / "_self_review.py"
+)
+_spec = importlib.util.spec_from_file_location("_self_review_nb", _MOD_PATH)
+assert _spec is not None and _spec.loader is not None  # _MOD_PATH is a real file
+sr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sr)
+
+
+GIT_FIXTURE = {
+    "commits": 42,
+    "load_bearing_touches": 5,
+    "prs_merged": [{"number": n} for n in range(1, 16)],  # 15
+    "adr_changes": [{"id": "0099"}, {"id": "0100"}],       # 2
+}
+
+
+def test_gap_is_arithmetic_difference():
+    claims = [{"signal": "prs_merged_count", "claim_value": 20,
+               "source_memory": "x.md", "window": "Q2-2026"}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    assert s["claim_value"] == 20
+    assert s["git_value"] == 15
+    assert s["gap"] == 5
+    assert s["grounded"] is True
+    assert s["window_match"] is True
+    assert s["source_memory"] == "x.md"
+
+
+def test_commits_signal_grounded_negative_gap():
+    claims = [{"signal": "commits", "claim_value": 40}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    assert s["git_value"] == 42
+    assert s["gap"] == -2
+    assert s["window"] is None
+    assert s["window_match"] is None
+
+
+def test_unknown_signal_ungrounded_not_error():
+    claims = [{"signal": "plan_calls", "claim_value": 3}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    assert s["git_value"] is None
+    assert s["gap"] is None
+    assert s["grounded"] is False
+
+
+def test_window_mismatch_flagged_gap_still_raw():
+    claims = [{"signal": "commits", "claim_value": 1, "window": "Q1-2026"}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    assert s["window_match"] is False
+    assert s["gap"] == 1 - 42  # raw difference regardless of window mismatch
+
+
+def test_non_numeric_claim_value_gap_none():
+    claims = [{"signal": "commits", "claim_value": "lots"}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    assert s["gap"] is None
+    assert s["git_value"] == 42  # git side still grounded
+
+
+def test_no_verdict_keys_emitted():
+    """RAW SIGNAL contract: no ✓/△/✗ / verdict / grade fields leak in."""
+    claims = [{"signal": "commits", "claim_value": 40}]
+    s = sr.compute_narrative_gaps(claims, GIT_FIXTURE, "Q2-2026")[0]
+    forbidden = {"verdict", "grade", "status", "pass", "rating", "band", "score"}
+    assert forbidden.isdisjoint(s.keys())
+
+
+def test_empty_claims_empty_signals():
+    assert sr.compute_narrative_gaps([], GIT_FIXTURE, "Q2-2026") == []
+
+
+def test_load_registry_missing_file_empty(tmp_path):
+    assert sr.load_narrative_claims(str(tmp_path / "nope.json")) == []
+
+
+def test_load_registry_malformed_empty(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    assert sr.load_narrative_claims(str(p)) == []
+
+
+def test_load_registry_non_dict_claims_empty(tmp_path):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"claims": "oops"}))
+    assert sr.load_narrative_claims(str(p)) == []
+
+
+def test_load_registry_filters_non_dict_entries(tmp_path):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"claims": [
+        {"signal": "commits", "claim_value": 10},
+        "not-a-dict",
+        {"signal": "prs_merged_count", "claim_value": 3},
+    ]}))
+    out = sr.load_narrative_claims(str(p))
+    assert len(out) == 2  # non-dict entry filtered
+    assert out[0]["signal"] == "commits"
+
+
+def test_committed_registry_loads_and_is_list():
+    """The repo-committed registry must parse (even with claims empty)."""
+    repo_root = _MOD_PATH.parent.parent.parent
+    reg = repo_root / "docs" / "self-review" / "narrative-claims.json"
+    assert isinstance(sr.load_narrative_claims(str(reg)), list)
+
+
+def test_assemble_stats_wires_narrative_gap_signals(tmp_path):
+    """Wire check (#1828 dead-param lesson): signal reaches assembled stats."""
+    reg = tmp_path / "narrative-claims.json"
+    reg.write_text(json.dumps({"claims": [
+        {"signal": "adr_changes_count", "claim_value": 9, "window": "Q2-2026"}
+    ]}))
+    repo_root = _MOD_PATH.parent.parent.parent  # real git worktree
+    stats = sr.assemble_stats(
+        "Q2-2026",
+        transcripts_glob=str(tmp_path / "none*.jsonl"),
+        memory_dir=str(tmp_path / "no-memory"),
+        repo=str(repo_root),
+        narrative_claims_path=str(reg),
+    )
+    assert "narrative_gap_signals" in stats
+    sigs = stats["narrative_gap_signals"]
+    assert len(sigs) == 1
+    assert sigs[0]["signal"] == "adr_changes_count"
+    assert sigs[0]["claim_value"] == 9
+    assert isinstance(sigs[0]["git_value"], int)  # grounded against real git
+    assert sigs[0]["grounded"] is True

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -199,6 +199,7 @@ class AssembleStatsStructuralTest(unittest.TestCase):
             "axis_4_cycle_time",
             "axis_5_memory_hygiene",
             "evidence_age_days",
+            "narrative_gap_signals",
         }
         self.assertEqual(set(stats.keys()), expected_keys)
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1088

메모리 narrative 에 누적되는 수치 **자기주장(claim)** 을 git **ground-truth** 와 병치해 `gap = claim_value − git_value` 를 **raw signal** 로 emit 한다. 자기보고(메모리)와 외부 검증 가능한 행동 기록(git)이 갈라지면 메모리가 self-rationalization 일 위험을 표면화한다. **판정(✓/△/✗)은 하지 않는다** — 등급은 SKILL.md LLM 절차(ADR 0064)에 남기고, 이 collector 는 두 수치를 병치만 한다.

폐기된 1차 시도(`compute_narrative_drift()` 단어카운트 ratio, stash-drop)와 달리 **단어카운트/semantic 매칭/자동 등급은 out-of-scope**. claim 은 메모리 body 파싱(privacy contract 위반 + noise)이 아니라 **repo-internal registry 에 명시 등록**한다.

## 2. 영향 파일

- `scripts/claude-hooks/_self_review.py` — `load_narrative_claims()` + `compute_narrative_gaps()` + `NARRATIVE_GIT_SIGNALS` 추가, `assemble_stats()` 병합 wire, `--narrative-claims` CLI flag, `emit_report()` surface. **load-bearing 아님** (`_governance.py` LOAD_BEARING_PATHS 목록 외)
- `docs/self-review/narrative-claims.json` — 신규 registry (claims 빈 list 로 시작)
- `tests/test_self_review_narrative_gap_regression.py` — 회귀 13종

## 3. 리스크

- **가장 가능성 높은 깨짐**: (a) stats schema 변경으로 기존 소비자 깨짐, (b) raw signal 에 판정이 새어듦, (c) privacy 위반(메모리 body 읽기).
- **배제 확인**: (a) `narrative_gap_signals` 는 **additive** 키 — 기존 키/구조 불변, `assemble_stats` 인자도 default 추가라 기존 호출 호환. (b) `test_no_verdict_keys_emitted` 가 verdict/grade/status/band/score 부재를 강제. (c) registry 만 읽고 메모리 body 는 건드리지 않음 — `collect_memory()` 의 frontmatter-only 계약 무변경.

## 4. 테스트

회귀 13종: gap 산술 차이, 음수 gap, unknown-signal graceful(git_value=None), 비숫자 claim graceful, window mismatch 플래그, **no-verdict-keys 계약**, 빈 claims, registry fail-soft(missing/malformed/non-dict/non-dict-entry filter), committed registry parse, **`assemble_stats` wire 검증(#1828 dead-param 교훈)**. 13 passed.

## 5. Eval 영향

N/A — self-review 협업 측정 도구. RAG 파이프라인(retrieval/answer/verifier) 무관, load-bearing path 아님. CI eval delta 없음 (All `·`).

## 6. 하위 호환

- stats JSON: `narrative_gap_signals` **additive** — 기존 키 불변, schema bump 불요.
- `assemble_stats(...)`: 신규 `narrative_claims_path` 인자 default `None` → 기존 호출부 호환. `--narrative-claims` CLI flag default `None`.
- 측정 표면: ADR 0060(self-review measurement surface) 연장, 판정 분리는 ADR 0064 유지. 새 ADR 은 reviewer 판단에 맡김 (raw signal additive 라 보류).

## 7. 범위 외

- 단어카운트 ratio / semantic 매칭 / 자동 4·5축 등급 (의도적 out-of-scope).
- 실제 claim 등록: registry 는 빈 list 로 시작 — 첫 claim 은 다음 self-review 때 등록(메커니즘 + 폐루프 준비). signal 4종 외 확장도 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
