### PR TITLE
Expose public engineering blog index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # BidMate Agent 상세 문서
 
+- **[엔지니어링 블로그](./blog/index.md)** — 공개 기술 글 인덱스 / 30초 리뷰 경로
 - **[1-페이지 아키텍처 심층 분석](./architecture-deep-dive.md)** — 파이프라인 / ADR 매핑 / 측정 highlight 한 페이지 요약
 - [엔지니어링 거버넌스(워크플로 맵)](./engineering-governance.md)
 - [AI Engineering Operating System](operations/ai-engineering-operating-system.md) — 장기 AI-agent task / plan / review / eval evidence 운영 모델

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Engineering Blog
+permalink: /blog/
+---
+
+# Engineering Blog
+
+BidMate-DocAgent의 공개 기술 블로그 인덱스입니다. 각 글은 RFP 문서 RAG에서 반복적으로 재발한 설계 질문을 ADR, 측정 surface, 회귀 게이트와 연결해 설명합니다.
+
+## 추천 읽기 순서
+
+1. [Extractive를 1급 baseline로 유지하는 이유](./2026-05-extractive-baseline.md) — RFP 도메인에서 citation과 abstention을 generative fluency보다 우선한 이유.
+2. [0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호](./hyde-measurement-saturation.md) — HyDE 0pp 결과를 기능 실패가 아니라 measurement saturation으로 재해석한 과정.
+3. [측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop](./2026-05-goodhart-closed-loop.md) — metric Goodhart 함정을 찾고 scorer semantics를 보정한 closed-loop 사례.
+4. [Observability를 baseline 깨지 않고 추가하는 패턴](./2026-05-observability-fail-closed.md) — trace backend를 additive surface로 추가하는 fail-closed 패턴.
+5. [외부 시니어 리뷰 → 사실 정정 + ADR 매트릭스](./2026-05-external-review-followup.md) — 외부 리뷰 권고를 코드/ADR/CI evidence로 재검증한 decision matrix.
+
+## 30초 리뷰 경로
+
+- Baseline과 답변 정책: [Extractive baseline](./2026-05-extractive-baseline.md)
+- 측정 신뢰성: [HyDE saturation](./hyde-measurement-saturation.md) → [Goodhart closed loop](./2026-05-goodhart-closed-loop.md)
+- 운영성: [Observability fail-closed](./2026-05-observability-fail-closed.md)
+
+전체 프로젝트 개요는 [문서 홈](../index.md)과 [GitHub README](https://github.com/hskim-solv/BidMate-DocAgent)를 기준으로 확인합니다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

기존 공개 blog 글은 이미 존재하지만 `docs/_config.yml`의 `header_pages`가 가리키는 `blog/index.md`가 없어 `/blog/` 진입점이 안정적이지 않았다. 공개 engineering blog 인덱스를 추가하고 `docs/README.md`에서 30초 리뷰 경로로 연결해 #811의 public blog reachability 요구를 좁게 마무리한다.

Closes #811

## 2. 영향 파일

- `docs/blog/index.md` — 공개 engineering blog 인덱스 신규 추가
- `docs/README.md` — 상세 문서 인덱스에서 blog 진입 링크 추가

## 3. 리스크

가장 큰 리스크는 공개하면 안 되는 portfolio meta/private 문서를 blog index에 노출하는 것이다. 이번 인덱스는 이미 `docs/blog/` 아래 공개 글만 링크하고, private portfolio meta 문서는 링크하지 않는다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/README.md docs/blog/index.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only 변경이다. RAG/retrieval/eval pipeline 코드와 config를 건드리지 않았고, private real-eval claim도 없다.

## 6. 하위 호환

기존 문서 링크는 유지한다. `docs/_config.yml`의 기존 `header_pages: blog/index.md` 대상 파일을 추가하는 변경이라 Pages navigation compatibility를 개선한다.

## 7. 범위 외

새 long-form blog 작성, GitHub Pages 배포 후 실제 URL 확인, 외부 engineering repo 별도 publish는 범위 밖이다. 이번 PR은 현재 repo의 Pages blog index와 내부 진입 링크만 다룬다.
