### PR TITLE
docs: fix off-by-one relative links to repo-root Makefile / notebooks

### DIFF
--- a/docs/eval/embedding-finetune.md
+++ b/docs/eval/embedding-finetune.md
@@ -6,7 +6,7 @@
 > 에이전트(agent)가 초안을 작성하게 두지 말고 본인의 프레이밍으로 직접 작성하라.
 
 - **Related**: issue [#179](https://github.com/hskim-solv/BidMate-DocAgent/issues/179), [ADR 0027](../adr/0027-lora-finetuned-embedding-additive.md), [ADR 0019](../adr/0019-embedding-default-stays-minilm.md), [ADR 0021](../adr/0021-bge-m3-completes-phase-1-3.md).
-- **Notebook**: [`notebooks/embedding_finetune.ipynb`](../notebooks/embedding_finetune.ipynb) — Colab T4 에서 end-to-end 실행 가능.
+- **Notebook**: [`notebooks/embedding_finetune.ipynb`](../../notebooks/embedding_finetune.ipynb) — Colab T4 에서 end-to-end 실행 가능.
 - **Adapter**: Hugging Face Hub 의 `bidmate/embedding-lora-kure-rfp-ko-v1` *(#179 에서 업로드; SHA 는 [`eval/config.yaml`](../../eval/config.yaml) 에 고정)*.
 
 ## TL;DR

--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -42,7 +42,7 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 
 ## Arming: `make ship-arm`
 
-이 Makefile 타깃은 [`.claude/.ship-armed`](../Makefile)(JSON
+이 Makefile 타깃은 [`.claude/.ship-armed`](../../Makefile)(JSON
 상태 파일)를 쓰고 종료한다; 실제 파이프라인은 다음 Claude Stop
 이벤트에서 실행된다. 노브(env-var override):
 
@@ -58,14 +58,14 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 
 `make ship-disarm` 은 arm 파일과 pid 파일을 제거한다. `make ship-status`
 는 사람이 읽을 수 있는 요약을 출력한다.
-[`Makefile:289-339`](../Makefile) 와
+[`Makefile:289-339`](../../Makefile) 와
 [`scripts/claude-hooks/_ship_arm.py`](../../scripts/claude-hooks/_ship_arm.py) 참조.
 
 ## Direct run: `make ship-run`
 
 Codex Desktop 처럼 Claude Stop-hook 이 자연스럽게 발화하지 않는 세션에서는
 `make ship-run` 을 쓴다. 이 타깃은 먼저 `_ship_arm.py` 로 같은
-[`.claude/.ship-armed`](../Makefile) 상태 파일을 만든 다음,
+[`.claude/.ship-armed`](../../Makefile) 상태 파일을 만든 다음,
 [`stop-ship.sh`](../../scripts/claude-hooks/stop-ship.sh)를 stdin EOF 와 함께
 즉시 1회 호출한다. 정책 우회가 아니라 같은 Gate 0 / Stage 1-5 dispatcher 를
 직접 호출하는 wrapper 다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1866

docs 내부 상대경로 링크 2건이 off-by-one(`../` 한 단계 부족)으로 repo-root 참조 404 → `../../` 로 수정.

## 2. 영향 파일

- `docs/operations/auto-ship.md` — `](../Makefile)` ×3 → `](../../Makefile)`
- `docs/eval/embedding-finetune.md` — `](../notebooks/...)` → `](../../notebooks/...)`

둘 다 **비-load-bearing, docs-only**.

## 3. 리스크

docs 텍스트 링크 경로만. 코드/동작/Jekyll permalink 무관. 같은 파일의 기존 `../../scripts/`·`../../eval/` 링크와 정합 확인.

## 4. 테스트

내부 링크 스캔 재실행 → 두 링크 모두 `resolve OK` (기계 검증). 잔존 old-link 0.

## 5. Eval 영향

All `·` — docs-only, load-bearing path 미변경.

## 6. 하위 호환

링크 경로 문자열만 변경. 답변 계약/동작 무관.

## 7. 범위 외

- `docs/blog/*`, `docs/index.md` 의 `../adr/NNNN-.../` Jekyll permalink — 의도된 표기, 비대상
- `docs/investigations/*`, `docs/adr/*` 의 `rag_*.py:line` 코드 line-ref — 별도 fragility 이슈, 범위 분리