### PR TITLE
docs: clarify cross-session overlap preflight

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -65,7 +65,10 @@ HTML 자체가 아니라 source aggregate artifact, 실행 command, diff, ADR/so
 
 Codex가 파일을 편집하기 전에 같은 issue/branch/PR/worktree가 이미 진행 중인지
 확인한다. 이 check는 report-only이며 branch switch, push, PR 생성/머지/닫기,
-issue close, branch delete를 실행하지 않는다.
+issue close, branch delete를 실행하지 않는다. Coordination surface는 Codex와
+Claude Code를 분리하지 않는다. 루트 checkout, `.codex/worktrees/*`,
+`.claude/worktrees/*`, 그리고 `git worktree list`에 잡히는 외부 worktree는
+모두 같은 “다른 세션” 후보로 취급한다.
 
 ```bash
 python3 scripts/agent_loop.py overlap-preflight \
@@ -75,8 +78,9 @@ python3 scripts/agent_loop.py overlap-preflight \
 
 `blocked`이면 현재 작업을 시작하지 않는다. 예: 같은 issue의 open PR이 있거나,
 다른 worktree가 같은 issue branch를 소유하거나, 현재 checkout이 detached/stale인
-경우다. `warn`이면 branch/PR history를 사람이 볼 수 있는 report로 확인한 뒤
-진행한다.
+경우다. `warn`이면 branch/PR history를 사람이 볼 수 있는 report로 확인하고,
+예상 변경 파일이 다른 세션의 dirty/diff 파일과 겹치지 않는다는 근거를 남긴 뒤
+진행한다. 근거를 만들 수 없으면 다른 issue를 고른다.
 
 ## Classification Contract
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -31,8 +31,11 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 2. `Ready Order`에서 status가 `ready`인 첫 task를 고른다.
 3. task의 `Scope`, `Non-Goals`, `Evidence Required`, `Failure Conditions`를 먼저 읽는다.
 4. 파일을 편집하기 전에 `python3 scripts/agent_loop.py overlap-preflight --issue <N> --branch <type>/issue-<N>-<slug>`로 같은 issue/branch/PR/worktree가 이미 진행 중인지 확인한다.
-5. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
-6. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
+   이때 Codex, Claude Code, 루트 checkout, `.codex/worktrees/*`, `.claude/worktrees/*`, 그리고 `git worktree list`에 잡히는 외부 worktree를 모두 같은 coordination surface로 본다.
+5. preflight가 `blocked`이면 그 task를 시작하지 말고 다른 issue를 고른다.
+   `warn`이면 branch/PR history 경고를 기록하고, 파일 겹침이 없는지 확인한 뒤 진행한다.
+6. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
+7. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
 
 `backlog` task는 missing decision이나 validation이 남아 있다는 뜻이다. agent는
 `backlog`를 임의로 실행하지 말고 ready 조건을 먼저 채운다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1867

Codex/Claude Code 병행 세션이 같은 issue나 worktree surface를 집어드는 사고를 줄이기 위해, 기존 `overlap-preflight` 운영 문서에 “Codex와 Claude Code worktree를 같은 coordination surface로 본다”는 규칙을 명시했습니다. 구현은 바꾸지 않고 operator 문서만 고정합니다.

## 2. 영향 파일

- `docs/operations/ai-codex-workflow.md` — overlap preflight의 cross-session 해석과 `warn` 처리 기준 보강
- `tasks/README.md` — task 시작 절차에 Codex/Claude/root/external worktree를 같은 surface로 보는 규칙 추가

## 3. 리스크

- 리스크: 문서 링크/프래그먼트 깨짐 또는 운영 문구가 기존 `overlap-preflight` 동작과 어긋남.
- 배제: 기존 명령 이름/링크만 사용했고, `check_doc_links`와 branch gate를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths tasks/README.md docs/operations/ai-codex-workflow.md`
- `git diff --check`
- `make check-branch`
- `python3 scripts/agent_loop.py overlap-preflight --issue 1867 --branch docs/issue-1867-cross-session-overlap-preflight`

테스트 미추가 사유: docs-only 운영 문구 변경이며 코드 동작 변경이 없습니다.

## 5. Eval 영향

All `N/A` — RAG/eval/load-bearing 코드 변경 없음. private/public eval 산출물 및 metric surface 변경 없음.

## 6. 하위 호환

하위 호환 영향 없음. CLI flag, schema, answer contract, doc link 계약 변경 없음.

## 7. 범위 외

- `scripts/agent_loop.py overlap-preflight` 구현 변경 없음.
- orphan/stale worktree 정리는 다른 세션 산물이라 건드리지 않음.
- merge 후 원격 브랜치 삭제는 별도 stacked-dependency 확인 없이는 하지 않음.