### PR TITLE
Stabilize existing blog post frontmatter

### DIFF
--- a/docs/blog/2026-05-goodhart-closed-loop.md
+++ b/docs/blog/2026-05-goodhart-closed-loop.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: 측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop
+permalink: /blog/2026-05-goodhart-closed-loop/
+---
+
 # 측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop
 
 > 이 글은 5 PR / 3 ADR / 2 audit 의 closed measurement loop 를 문서화한다.

--- a/docs/blog/hyde-measurement-saturation.md
+++ b/docs/blog/hyde-measurement-saturation.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: 0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호
+permalink: /blog/hyde-measurement-saturation/
+---
+
 # 0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호
 
 > This post documents the measurement-surface diagnosis that led to [ADR


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/blog/index.md`에서 링크하는 기존 public blog 글 2개가 YAML frontmatter 없이 plain markdown으로 남아 있었다. 다른 blog 글과 동일하게 `layout`, `title`, `permalink`를 추가해 GitHub Pages 렌더링/내비게이션 surface를 안정화한다.

Closes #1870

## 2. 영향 파일

- `docs/blog/2026-05-goodhart-closed-loop.md` — page frontmatter 추가
- `docs/blog/hyde-measurement-saturation.md` — page frontmatter 추가

## 3. 리스크

가장 큰 리스크는 글 본문을 의도치 않게 바꾸는 것이다. 이번 변경은 각 파일 선두에 YAML frontmatter만 추가하고 본문 텍스트는 유지했다.

## 4. 테스트

- `python3` frontmatter check for `docs/blog/*.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/blog/2026-05-goodhart-closed-loop.md docs/blog/hyde-measurement-saturation.md docs/blog/index.md docs/index.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only 변경이다. RAG/retrieval/eval pipeline 코드와 config를 건드리지 않았고, private real-eval claim도 없다.

## 6. 하위 호환

기존 파일 경로와 본문 링크는 유지한다. permalink만 명시해 Pages URL을 안정화한다.

## 7. 범위 외

GitHub Pages 배포 후 실제 URL 확인, blog 내용 rewrite, 새 blog post 작성은 범위 밖이다.
