### PR TITLE
Use Pages permalinks for blog navigation

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -10,16 +10,16 @@ BidMate-DocAgent의 공개 기술 블로그 인덱스입니다. 각 글은 RFP �
 
 ## 추천 읽기 순서
 
-1. [Extractive를 1급 baseline로 유지하는 이유](./2026-05-extractive-baseline.md) — RFP 도메인에서 citation과 abstention을 generative fluency보다 우선한 이유.
-2. [0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호](./hyde-measurement-saturation.md) — HyDE 0pp 결과를 기능 실패가 아니라 measurement saturation으로 재해석한 과정.
-3. [측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop](./2026-05-goodhart-closed-loop.md) — metric Goodhart 함정을 찾고 scorer semantics를 보정한 closed-loop 사례.
-4. [Observability를 baseline 깨지 않고 추가하는 패턴](./2026-05-observability-fail-closed.md) — trace backend를 additive surface로 추가하는 fail-closed 패턴.
-5. [외부 시니어 리뷰 → 사실 정정 + ADR 매트릭스](./2026-05-external-review-followup.md) — 외부 리뷰 권고를 코드/ADR/CI evidence로 재검증한 decision matrix.
+1. [Extractive를 1급 baseline로 유지하는 이유](./2026-05-extractive-baseline/) — RFP 도메인에서 citation과 abstention을 generative fluency보다 우선한 이유.
+2. [0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호](./hyde-measurement-saturation/) — HyDE 0pp 결과를 기능 실패가 아니라 measurement saturation으로 재해석한 과정.
+3. [측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop](./2026-05-goodhart-closed-loop/) — metric Goodhart 함정을 찾고 scorer semantics를 보정한 closed-loop 사례.
+4. [Observability를 baseline 깨지 않고 추가하는 패턴](./2026-05-observability-fail-closed/) — trace backend를 additive surface로 추가하는 fail-closed 패턴.
+5. [외부 시니어 리뷰 → 사실 정정 + ADR 매트릭스](./2026-05-external-review-followup/) — 외부 리뷰 권고를 코드/ADR/CI evidence로 재검증한 decision matrix.
 
 ## 30초 리뷰 경로
 
-- Baseline과 답변 정책: [Extractive baseline](./2026-05-extractive-baseline.md)
-- 측정 신뢰성: [HyDE saturation](./hyde-measurement-saturation.md) → [Goodhart closed loop](./2026-05-goodhart-closed-loop.md)
-- 운영성: [Observability fail-closed](./2026-05-observability-fail-closed.md)
+- Baseline과 답변 정책: [Extractive baseline](./2026-05-extractive-baseline/)
+- 측정 신뢰성: [HyDE saturation](./hyde-measurement-saturation/) → [Goodhart closed loop](./2026-05-goodhart-closed-loop/)
+- 운영성: [Observability fail-closed](./2026-05-observability-fail-closed/)
 
 전체 프로젝트 개요는 [문서 홈](../index.md)과 [GitHub README](https://github.com/hskim-solv/BidMate-DocAgent)를 기준으로 확인합니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ RFP/제안요청서 문서 이해를 위한 Agentic RAG 시스템 [BidMate-DocAg
 
 - **[엔지니어링 블로그](./blog/)** — 측정-주도 엔지니어링 회고
   - [Extractive를 1급 baseline로 유지하는 이유](./blog/2026-05-extractive-baseline/)
-  - [측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop](./blog/2026-05-goodhart-closed-loop.md)
-  - [0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호](./blog/hyde-measurement-saturation.md)
+  - [측정 도구가 자기 함정을 발견했을 때 — 5-step closed loop](./blog/2026-05-goodhart-closed-loop/)
+  - [0pp lift 가 가리킨 것 — 측정 surface 안의 진짜 신호](./blog/hyde-measurement-saturation/)
   - [Observability를 baseline 깨지 않고 추가하는 패턴](./blog/2026-05-observability-fail-closed/)
   - [외부 시니어 리뷰 → 사실 정정 + ADR 매트릭스](./blog/2026-05-external-review-followup/)
 - **[1-page Architecture deep-dive](./architecture-deep-dive/)** — 파이프라인 / ADR 매핑 / 측정 highlight 한 페이지 요약


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

공개 blog 글들이 stable `permalink`를 선언하므로 Pages-facing 인덱스(`docs/blog/index.md`, `docs/index.md`)가 source `.md` 경로 대신 렌더링된 pretty URL을 가리키도록 정리했다. 이로써 `/blog/`에서 각 글로 이동할 때 GitHub Pages URL 체계와 일치한다.

Closes #1874

## 2. 영향 파일

- `docs/blog/index.md` — blog 글 링크를 `./<slug>/` permalink로 변경
- `docs/index.md` — blog 글 링크를 `./blog/<slug>/` permalink로 변경

## 3. 리스크

Directory-style permalink는 일반 file-existence link checker가 존재성을 직접 확인하지 않는다. 이를 보완하기 위해 각 링크가 실제 blog frontmatter의 `permalink`와 매칭되는지 별도 Python check로 검증했다.

## 4. 테스트

- `python3` blog permalink resolver check
- `python3 scripts/check_doc_links.py --check-all --paths docs/blog/index.md docs/index.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only 변경이다. RAG/retrieval/eval pipeline 코드와 config를 건드리지 않았고, private real-eval claim도 없다.

## 6. 하위 호환

글 파일 경로와 frontmatter는 유지한다. Pages-facing index 링크만 rendered permalink로 정렬한다.

## 7. 범위 외

GitHub Pages 배포 후 실제 HTTP 확인, Jekyll workflow 변경, blog 본문 rewrite는 범위 밖이다.
