### PR TITLE
docs: clarify orphan worktree warning handling

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -82,6 +82,15 @@ python3 scripts/agent_loop.py overlap-preflight \
 예상 변경 파일이 다른 세션의 dirty/diff 파일과 겹치지 않는다는 근거를 남긴 뒤
 진행한다. 근거를 만들 수 없으면 다른 issue를 고른다.
 
+### Orphan Worktree Warnings
+
+pre-push hygiene가 “branch already merged into main, but the worktree was never removed”를 보고해도,
+현재 PR과 무관한 다른 세션의 worktree를 opportunistic cleanup하지 않는다. 경고는 push를 막지 않는
+soft warning이며, 정리는 전용 경로(`make worktree-cleanup-dry-run` → `make worktree-cleanup`)나
+SessionStart hygiene([ADR 0096](../adr/0096-auto-worktree-branch-cleanup.md))에 맡긴다.
+즉시 정리해야 한다면 self-skip/clean/merged-confirmed 조건을 확인하고, 원격 branch
+삭제는 stacked dependent 확인 없이는 하지 않는다.
+
 ## Classification Contract
 
 Planner는 open PR을 선택 후보 목록으로 다루지 않는다. PR의 CI, draft 여부,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1875

pre-push orphan worktree 경고가 unrelated PR shipment 중 반복 노출될 때, agent가 다른 세션 worktree를 임의로 정리하지 않도록 운영 문서에 처리 기준을 추가했습니다. 경고는 soft warning이며 전용 cleanup 경로와 SessionStart hygiene에 맡기도록 명시합니다.

## 2. 영향 파일

- `docs/operations/ai-codex-workflow.md` — orphan worktree warning 처리 기준 추가

## 3. 리스크

- 리스크: cleanup 경로/ADR 링크가 깨지거나 기존 hook 계약과 어긋나는 문구가 들어갈 수 있음.
- 배제: 기존 Make target과 ADR 0096 링크만 인용했고 doc link check를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md`
- `git diff --check`
- `make check-branch`

테스트 미추가 사유: docs-only 운영 문구 변경이며 hook 동작 변경이 없습니다.

## 5. Eval 영향

All `N/A` — RAG/eval/load-bearing 코드 변경 없음. private/public eval 산출물 및 metric surface 변경 없음.

## 6. 하위 호환

하위 호환 영향 없음. CLI flag, schema, answer contract 변경 없음.

## 7. 범위 외

- orphan worktree 실제 삭제/branch 삭제 없음.
- pre-push/SessionStart hook 구현 변경 없음.
- 원격 branch 삭제 없음.