### PR TITLE
Mark legacy Goodhart eval references archive-only

### DIFF
--- a/docs/blog/2026-05-goodhart-closed-loop.md
+++ b/docs/blog/2026-05-goodhart-closed-loop.md
@@ -17,6 +17,8 @@ permalink: /blog/2026-05-goodhart-closed-loop/
 > [`hyde-measurement-saturation.md`](./hyde-measurement-saturation.md),
 > [`2026-05-extractive-baseline.md`](./2026-05-extractive-baseline.md).
 
+> **Historical snapshot note.** 이 글의 `real100`, `n=221`, `reports/real100/*` 언급은 2026-05 측정 루프를 설명하기 위한 archive-only 맥락이다. 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2` 표면만 사용한다.
+
 이 closed loop 의 가장 큰 lesson 은 — *측정 도구의 첫 측정 결과를 신뢰하지 않는 것* 이다. 직관에 반하는 결과 (random baseline 이 default 보다 *높은* score) 가 나왔을 때, "시스템이 random 보다 못한가?" 가 아니라 "metric 정의 자체가 깨졌나?" 로 시작하는 것. 본 글의 5 step 은 그 한 질문에서 파생된 cascade 다.
 
 ## Step 1 — 측정 도구 도입 (PR #946)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Goodhart closed-loop blog post는 2026-05 historical measurement narrative라 legacy `real100`/`n=221`/`reports/real100/*`를 언급한다. 현재 새 작업과 PR claim의 private eval evidence는 `real100_v2`만 사용해야 하므로, 독자가 과거 artifact를 현재 근거로 오해하지 않도록 archive-only snapshot note를 추가했다.

Closes #1878

## 2. 영향 파일

- `docs/blog/2026-05-goodhart-closed-loop.md` — historical/archive-only note 추가

## 3. 리스크

가장 큰 리스크는 historical post의 측정 서사를 현재 수치로 덮어쓰는 것이다. 이번 변경은 본문 측정/링크를 바꾸지 않고, 상단에 현재 정책 경계만 명시한다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/blog/2026-05-goodhart-closed-loop.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only 변경이다. Historical note만 추가했고 eval/report/script를 변경하지 않았다. 새 private eval claim도 없다.

## 6. 하위 호환

기존 post URL, title, historical links는 유지한다. 새 note는 legacy artifact의 현재 사용 경계만 명시한다.

## 7. 범위 외

real100_v2 재측정, historical metric rewrite, reports 변경은 범위 밖이다.
