### PR TITLE
docs: connect ownership to overlap preflight

### DIFF
--- a/docs/multi-agent-ownership.md
+++ b/docs/multi-agent-ownership.md
@@ -17,10 +17,15 @@ RAG 파이프라인은 단계별 (ingestion → 검색 → 계획 → 검증 →
 
 ## 원칙
 
-1. **ADR 소유권.** agent 1명 = ADR 계약 1개 이상의 단독 저자. 해당 ADR 수정은 그 agent 의 PR 으로만
-2. **허브 lock holder.** `rag_core.py` 는 Pipeline Core owner 만 수정. 다른 owner 는 hook, callback, `run_rag_query` public surface 경유
-3. **Additive only.** 신규 기능은 분석 변형 또는 확장 preset (ADR 0001/0011). 추출형 기준선은 절대 교체 금지
-4. **Stacked PR.** 의존 작업은 상위 PR 위로 rebase, `gh pr create --base <upstream>`. 독립 작업은 `main` 으로 직접
+1. **Start gate.** 파일 소유권을 읽기 전에 먼저
+   [`overlap-preflight`](operations/ai-codex-workflow.md#overlap-preflight)를 실행한다.
+   Codex, Claude Code, 루트 checkout, `.codex/worktrees/*`, `.claude/worktrees/*`,
+   외부 `git worktree`는 모두 같은 coordination surface다. `blocked`면 시작하지 않고,
+   `warn`이면 예상 변경 파일이 다른 세션의 dirty/diff 파일과 겹치지 않는다는 근거를 남긴다.
+2. **ADR 소유권.** agent 1명 = ADR 계약 1개 이상의 단독 저자. 해당 ADR 수정은 그 agent 의 PR 으로만
+3. **허브 lock holder.** `rag_core.py` 는 Pipeline Core owner 만 수정. 다른 owner 는 hook, callback, `run_rag_query` public surface 경유
+4. **Additive only.** 신규 기능은 분석 변형 또는 확장 preset (ADR 0001/0011). 추출형 기준선은 절대 교체 금지
+5. **Stacked PR.** 의존 작업은 상위 PR 위로 rebase, `gh pr create --base <upstream>`. 독립 작업은 `main` 으로 직접
 
 ## 7개 소유권 역할
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1880

multi-agent 소유권 문서가 owner table만 설명하고 새 cross-session preflight 규칙과 연결되지 않아, Codex/Claude Code 병행 작업 시작 시점의 게이트를 원칙 1번으로 추가했습니다. 파일 소유권을 읽기 전에 overlap-preflight를 먼저 실행하고, `blocked`/`warn` 결과를 어떻게 다룰지 명시합니다.

## 2. 영향 파일

- `docs/multi-agent-ownership.md` — ownership 원칙에 Start gate 추가 및 기존 원칙 번호 조정

## 3. 리스크

- 리스크: 새 링크가 깨지거나 ownership 문서와 운영 문서가 서로 다른 시작 절차를 말할 수 있음.
- 배제: 기존 `docs/operations/ai-codex-workflow.md#overlap-preflight` 앵커만 링크했고 doc link check를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/multi-agent-ownership.md`
- `git diff --check`
- `make check-branch`

테스트 미추가 사유: docs-only 운영 문구 변경이며 코드 동작 변경이 없습니다.

## 5. Eval 영향

All `N/A` — RAG/eval/load-bearing 코드 변경 없음. private/public eval 산출물 및 metric surface 변경 없음.

## 6. 하위 호환

하위 호환 영향 없음. CLI flag, schema, answer contract 변경 없음.

## 7. 범위 외

- `scripts/agent_loop.py overlap-preflight` 구현 변경 없음.
- task queue 상태 변경 없음.
- worktree/branch cleanup 없음.