### PR TITLE
docs: mark private100 real100 history archive-only

### DIFF
--- a/docs/real-data/private-100-doc-experiments.md
+++ b/docs/real-data/private-100-doc-experiments.md
@@ -2,6 +2,8 @@
 
 이 문서는 private 100-doc RFP 평가 결과를 포트폴리오용 근거로 남기되, 원문이나 개별 예측이 커밋되지 않도록 하는 aggregate-only 운영 기준이다. 실제 private 원문과 per-example output은 로컬 `artifacts/benchmarks/` 아래에만 둔다.
 
+> **Historical archive note.** 이 문서의 `real100`, `reports/real100/*`, `data/index/real100`, `n=221` 기록은 2026-05 private100/v1 측정 기록 보존용 archive-only snapshot 이다. 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2` 표면만 사용하며, 아래 v1 명령·표를 새 근거로 재사용하지 않는다.
+
 ## 명명(Naming)
 
 - Run ID: `private100_<profile>_<YYYYMMDDTHHMMSSZ>`


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/real-data/private-100-doc-experiments.md` 상단에 historical archive note를 추가했다. 문서 안의 legacy `real100`/`reports/real100/*`/`data/index/real100`/`n=221` 기록은 2026-05 private100/v1 측정 로그 보존용이며, 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2`만 사용한다는 경계를 명시한다.

Closes #1883

## 2. 영향 파일

- `docs/real-data/private-100-doc-experiments.md` — 상단 archive-only note 1개 추가

## 3. 리스크

낮음. 기존 표/명령/자동 생성 history는 변경하지 않고 해석 경계만 추가했다. 가장 큰 리스크는 역사적 문서 문구가 현재 정책처럼 오해되는 것이며, 이번 note가 그 리스크를 줄인다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/real-data/private-100-doc-experiments.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변경 없음. docs-only 변경이며 eval/config/rag 경로와 aggregate artifact를 수정하지 않았다. real-eval 미실행(불필요).

## 6. 하위 호환

영향 없음. 기존 문서 기록과 generated history marker를 보존한다.

## 7. 범위 외

- legacy `real100` 표/명령을 `real100_v2`로 재작성하지 않음
- private eval artifact 재생성 없음
- 다른 real-data 문서의 legacy 표기 sweep 없음
