### PR TITLE
chore(eval): keep naive private eval off legacy real100

### DIFF
--- a/eval/naive_rag/private_real_eval.py
+++ b/eval/naive_rag/private_real_eval.py
@@ -81,6 +81,8 @@ PREFERRED_SEMANTIC_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM
 ENV_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
 SAFE_FAILURE_COUNT_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 SAFE_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
+SAFE_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_REDACTED_SUMMARY_PATH_RE = re.compile(r"^reports/[A-Za-z0-9._-]+\.redacted\.json$")
 SAFE_COMPARISON_ROW_KEYS = {
     "workflow",
     "embedding_backend",
@@ -105,6 +107,10 @@ PRIVATE_PATH_MARKERS = (
     "data/index/real",
     "experiments/private_runs/",
     "reports/real",
+)
+LEGACY_REAL100_RESULT_PATH_RE = re.compile(
+    r"(?:^|/)(?:data/index|reports|outputs)/real100(?!_v2)(?:[^/]*)?(?:/|$)",
+    re.IGNORECASE,
 )
 
 
@@ -139,6 +145,133 @@ def rel_or_abs(path: Path, root: Path = ROOT_DIR) -> str:
         return str(path.resolve().relative_to(root.resolve()))
     except ValueError:
         return str(path)
+
+
+def unresolved_rel_or_abs(path: Path, root: Path = ROOT_DIR) -> str:
+    """Repo-relative path spelling without resolving symlinks."""
+    raw_path = Path(os.path.abspath(str(path))) if path.is_absolute() else path
+    raw_root = Path(os.path.abspath(str(root)))
+    try:
+        return raw_path.relative_to(raw_root).as_posix()
+    except ValueError:
+        return raw_path.as_posix()
+
+
+def resolved_rel_or_abs(path: Path, root: Path = ROOT_DIR) -> str:
+    """Resolved spelling for validation, preserving outside-root targets."""
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def is_legacy_real100_result_path(path: Path, root: Path = ROOT_DIR) -> bool:
+    """Return true for stale v1 real100 result/index surfaces, not real100_v2."""
+    unresolved = os.path.normpath(unresolved_rel_or_abs(path, root)).replace("\\", "/")
+    resolved = os.path.normpath(resolved_rel_or_abs(path, root)).replace("\\", "/")
+    return bool(
+        LEGACY_REAL100_RESULT_PATH_RE.search(unresolved)
+        or LEGACY_REAL100_RESULT_PATH_RE.search(resolved)
+    )
+
+
+def canonical_guarded_result_path(path: Path) -> Path:
+    """Resolve guard-sensitive result paths once before downstream writes."""
+    return path.resolve(strict=False)
+
+
+def _legacy_real100_error(label: str) -> PrivateRealEvalError:
+    return PrivateRealEvalError(f"legacy_real100_path: {label}")
+
+
+def assert_guarded_result_path_current(
+    path: Path,
+    *,
+    label: str,
+    root: Path = ROOT_DIR,
+) -> Path:
+    """Return the current canonical path after legacy real100 checks."""
+    if is_legacy_real100_result_path(path, root):
+        raise _legacy_real100_error(label)
+    canonical = canonical_guarded_result_path(path)
+    if is_legacy_real100_result_path(canonical, root):
+        raise _legacy_real100_error(label)
+    return canonical
+
+
+def assert_private_result_path_current(
+    path: Path,
+    *,
+    label: str,
+    root: Path = ROOT_DIR,
+) -> Path:
+    """Return the current canonical private write target after all path checks."""
+    canonical = assert_guarded_result_path_current(path, label=label, root=root)
+    if not git_ignores_path(canonical, root):
+        raise PrivateRealEvalError(f"private_path_not_gitignored: {label}")
+    return canonical
+
+
+def prepare_guarded_result_dir(path: Path, *, label: str, root: Path = ROOT_DIR) -> Path:
+    """Materialize a guarded directory, then pin and revalidate its target."""
+    if is_legacy_real100_result_path(path, root):
+        raise _legacy_real100_error(label)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise PrivateRealEvalError(f"invalid_guarded_path: {label}") from exc
+    return assert_guarded_result_path_current(path, label=label, root=root)
+
+
+def prepare_private_result_dir(path: Path, *, label: str, root: Path = ROOT_DIR) -> Path:
+    """Materialize a private result directory, then pin and revalidate its target."""
+    prepare_guarded_result_dir(path, label=label, root=root)
+    return assert_private_result_path_current(path, label=label, root=root)
+
+
+def validate_redacted_summary_path(
+    path: Path,
+    root: Path = ROOT_DIR,
+    *,
+    prepare: bool = False,
+) -> Path:
+    if is_legacy_real100_result_path(path, root):
+        raise _legacy_real100_error("redacted_summary_path")
+    if prepare:
+        prepare_guarded_result_dir(path.parent, label="redacted_summary_path", root=root)
+    canonical = assert_guarded_result_path_current(
+        path, label="redacted_summary_path", root=root
+    )
+    if git_ignores_path(canonical, root):
+        return canonical
+    normalized = os.path.normpath(unresolved_rel_or_abs(canonical, root)).replace("\\", "/")
+    if SAFE_REDACTED_SUMMARY_PATH_RE.fullmatch(normalized):
+        return canonical
+    raise PrivateRealEvalError("redacted_summary_path_not_allowed")
+
+
+def resolve_redacted_summary_path(
+    configured_path: str | None,
+    *,
+    output_dir: Path,
+    run_id: str,
+) -> Path:
+    return repo_path(configured_path) if configured_path else output_dir / run_id / "redacted_summary.json"
+
+
+def validate_run_id(value: str) -> str:
+    run_id = value.strip()
+    if (
+        not run_id
+        or run_id in {".", ".."}
+        or "/" in run_id
+        or "\\" in run_id
+        or Path(run_id).is_absolute()
+        or not SAFE_RUN_ID_RE.fullmatch(run_id)
+    ):
+        raise PrivateRealEvalError("invalid_run_id")
+    return run_id
 
 
 def load_private_config(path: Path) -> dict[str, Any]:
@@ -442,6 +575,8 @@ def validate_private_inputs(
     questions_path = repo_path(str(config.get("questions_path") or gold_evidence_path), root)
     index_dir = repo_path(str(config["index_dir"]), root)
     output_dir = repo_path(str(config["output_dir"]), root)
+    pinned_index_dir = canonical_guarded_result_path(index_dir)
+    pinned_output_dir = canonical_guarded_result_path(output_dir)
     index_build = (
         config.get("index_build") if isinstance(config.get("index_build"), Mapping) else {}
     )
@@ -470,7 +605,18 @@ def validate_private_inputs(
         errors.append("private_path_not_gitignored: output_dir")
     if not git_ignores_path(index_dir, root):
         errors.append("private_path_not_gitignored: index_dir")
-    if not (index_dir / "index.json").is_file() and not can_build_index:
+    if is_legacy_real100_result_path(output_dir, root):
+        errors.append("legacy_real100_path: output_dir")
+    if is_legacy_real100_result_path(index_dir, root):
+        errors.append("legacy_real100_path: index_dir")
+    hwp_pdf_artifact_dir_value = str(index_build.get("hwp_pdf_artifact_dir") or "").strip()
+    if hwp_pdf_artifact_dir_value:
+        hwp_pdf_artifact_dir = repo_path(hwp_pdf_artifact_dir_value, root)
+        if not git_ignores_path(hwp_pdf_artifact_dir, root):
+            errors.append("private_path_not_gitignored: hwp_pdf_artifact_dir")
+        if is_legacy_real100_result_path(hwp_pdf_artifact_dir, root):
+            errors.append("legacy_real100_path: hwp_pdf_artifact_dir")
+    if not (pinned_index_dir / "index.json").is_file() and not can_build_index:
         errors.append(f"missing_private_index: index_dir mode={build_mode}")
 
     document_count = _count_documents(documents_dir)
@@ -551,7 +697,7 @@ def validate_private_inputs(
                     f"questions count={len(unanswerable_with_gold)}"
                 )
 
-    index_docs, index_chunks = _index_counts(index_dir)
+    index_docs, index_chunks = _index_counts(pinned_index_dir)
     if errors:
         raise PrivateRealEvalError("Private real-eval validation failed:\n- " + "\n- ".join(errors))
     return {
@@ -559,23 +705,41 @@ def validate_private_inputs(
         "data_list_path": data_list_path,
         "questions_path": questions_path,
         "gold_evidence_path": gold_evidence_path,
-        "index_dir": index_dir,
-        "output_dir": output_dir,
+        "index_dir": pinned_index_dir,
+        "output_dir": pinned_output_dir,
         "document_count": document_count,
         "question_count": len(questions),
         "answerable_count": sum(1 for q in questions if q.get("answerable", True)),
         "unanswerable_count": sum(1 for q in questions if not q.get("answerable", True)),
-        "index_exists": (index_dir / "index.json").is_file(),
+        "index_exists": (pinned_index_dir / "index.json").is_file(),
         "index_document_count": index_docs,
         "index_chunk_count": index_chunks,
         "build_mode": build_mode,
     }
 
 
+def prepare_private_write_paths(
+    validation: Mapping[str, Any],
+    *,
+    root: Path = ROOT_DIR,
+) -> dict[str, Any]:
+    """Materialize and pin private output/index directories before any writes."""
+    prepared = dict(validation)
+    prepared["index_dir"] = prepare_private_result_dir(
+        Path(validation["index_dir"]), label="index_dir", root=root
+    )
+    prepared["output_dir"] = prepare_private_result_dir(
+        Path(validation["output_dir"]), label="output_dir", root=root
+    )
+    return prepared
+
+
 def build_index_command(
     config: Mapping[str, Any], validation: Mapping[str, Any]
 ) -> list[str] | None:
-    index_dir = Path(validation["index_dir"])
+    index_dir = assert_private_result_path_current(
+        Path(validation["index_dir"]), label="index_dir"
+    )
     index_build = (
         config.get("index_build") if isinstance(config.get("index_build"), Mapping) else {}
     )
@@ -609,6 +773,12 @@ def build_index_command(
     ):
         value = str(index_build.get(key) or "").strip()
         if value:
+            if key == "hwp_pdf_artifact_dir":
+                artifact_dir = prepare_private_result_dir(
+                    repo_path(value), label="hwp_pdf_artifact_dir"
+                )
+                command.extend([flag, rel_or_abs(artifact_dir)])
+                continue
             command.extend([flag, value])
     return command
 
@@ -645,9 +815,10 @@ def write_contract_config(
     *,
     run_id: str,
 ) -> Path:
-    output_dir = Path(validation["output_dir"])
-    run_dir = output_dir / run_id
-    run_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = assert_private_result_path_current(
+        Path(validation["output_dir"]), label="output_dir"
+    )
+    run_dir = prepare_private_result_dir(output_dir / run_id, label="run_dir")
     questions_path = _private_questions_path(config, validation, run_dir)
     pipeline = config.get("pipeline") if isinstance(config.get("pipeline"), Mapping) else {}
     top_k = int(config["top_k"])
@@ -1074,12 +1245,28 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"({validation['answerable_count']} answerable, "
             f"{validation['unanswerable_count']} unanswerable)"
         )
+        run_id = validate_run_id(
+            args.run_id or str(config.get("run_id") or "").strip() or default_run_id()
+        )
         if args.validate_only:
+            summary_path = resolve_redacted_summary_path(
+                args.redacted_summary_path,
+                output_dir=Path(validation["output_dir"]),
+                run_id=run_id,
+            )
+            validate_redacted_summary_path(summary_path)
             return 0
+        validation = prepare_private_write_paths(validation)
+        summary_path = resolve_redacted_summary_path(
+            args.redacted_summary_path,
+            output_dir=Path(validation["output_dir"]),
+            run_id=run_id,
+        )
+        summary_path = validate_redacted_summary_path(summary_path, prepare=True)
         build_command = build_or_load_private_index(config, validation)
-        run_id = args.run_id or str(config.get("run_id") or "").strip() or default_run_id()
         contract_path = write_contract_config(config, validation, run_id=run_id)
         started = time.perf_counter()
+        assert_private_result_path_current(Path(validation["output_dir"]), label="output_dir")
         run_dir = run_from_config(
             contract_path,
             output_root_override=Path(validation["output_dir"]),
@@ -1088,14 +1275,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         metrics_path = run_dir / "metrics.json"
         metrics_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+        assert_private_result_path_current(run_dir, label="run_dir")
         write_private_run_metadata(
             run_dir, validation, build_command=build_command, elapsed_ms=elapsed_ms
         )
-        summary_path = (
-            repo_path(args.redacted_summary_path)
-            if args.redacted_summary_path
-            else run_dir / "redacted_summary.json"
-        )
+        summary_path = validate_redacted_summary_path(summary_path, prepare=True)
         comparison_summary = load_existing_redacted_summary(summary_path)
         redacted_summary = build_redacted_summary(
             metrics_payload,
@@ -1104,6 +1288,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             elapsed_ms=elapsed_ms,
             comparison_summary=comparison_summary,
         )
+        summary_path = validate_redacted_summary_path(summary_path, prepare=True)
         write_json(summary_path, redacted_summary)
     except Exception as exc:
         print(f"[ERROR] Private real-eval failed: {exc}", file=sys.stderr)

--- a/tests/test_private_real_eval_workflow.py
+++ b/tests/test_private_real_eval_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -51,6 +52,70 @@ def _is_ignored(path: str) -> bool:
         if parent.is_symlink():
             return _is_ignored(str(rel))
     return False
+
+
+def _write_min_private_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    docs_dir = tmp_path / "files"
+    docs_dir.mkdir()
+    for index in range(50):
+        (docs_dir / f"private-{index:02d}.pdf").write_text("placeholder", encoding="utf-8")
+    data_list = tmp_path / "data_list.csv"
+    data_list.write_text("placeholder\n", encoding="utf-8")
+    gold = tmp_path / "gold_evidence.jsonl"
+    gold.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "question_id": f"q{index}",
+                    "question": "private question",
+                    "answerable": index < 10,
+                    "gold_evidence": [{"chunk_id": f"c{index}"}] if index < 10 else [],
+                },
+                ensure_ascii=False,
+            )
+            for index in range(13)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return docs_dir, data_list, gold
+
+
+def _write_private_eval_config(
+    path: Path,
+    *,
+    docs_dir: Path,
+    data_list: Path,
+    gold: Path,
+    index_dir: Path,
+    output_dir: Path,
+) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "benchmark_type": "private_real_eval",
+                "not_ci_smoke": True,
+                "is_private_data": True,
+                "documents_dir": str(docs_dir),
+                "data_list_path": str(data_list),
+                "gold_evidence_path": str(gold),
+                "questions_path": str(gold),
+                "index_dir": str(index_dir),
+                "output_dir": str(output_dir),
+                "top_k": 10,
+                "metrics": {
+                    "retrieval": ["recall_at_5"],
+                    "citation": ["citation_accuracy"],
+                    "answer_control": ["unanswerable_detection_flag"],
+                },
+                "latency_scope": "private_runner_wall_clock",
+                "answer_metric_mode": "deterministic_contract_v1",
+                "redaction_policy": {"summary_only": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_private_local_configs_and_data_paths_are_gitignored() -> None:
@@ -171,6 +236,432 @@ def test_private_runner_requires_private_inputs_to_be_gitignored() -> None:
     assert "private_path_not_gitignored: gold_evidence_path" in message
     assert "private_path_not_gitignored: questions_path" in message
     assert str(REPO_ROOT) not in message
+
+
+def test_private_runner_rejects_legacy_real100_result_surfaces(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "files"
+    docs_dir.mkdir()
+    for index in range(50):
+        (docs_dir / f"private-{index:02d}.pdf").write_text("placeholder", encoding="utf-8")
+    data_list = tmp_path / "data_list.csv"
+    data_list.write_text("placeholder\n", encoding="utf-8")
+    gold = tmp_path / "gold_evidence.jsonl"
+    gold.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "question_id": f"q{index}",
+                    "question": "private question",
+                    "answerable": index < 10,
+                    "gold_evidence": [{"chunk_id": f"c{index}"}] if index < 10 else [],
+                },
+                ensure_ascii=False,
+            )
+            for index in range(13)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = {
+        "benchmark_type": "private_real_eval",
+        "not_ci_smoke": True,
+        "is_private_data": True,
+        "documents_dir": str(docs_dir),
+        "data_list_path": str(data_list),
+        "gold_evidence_path": str(gold),
+        "questions_path": str(gold),
+        "index_dir": "data/index/real100",
+        "output_dir": "reports/real100",
+        "top_k": 10,
+        "metrics": {
+            "retrieval": ["recall_at_5"],
+            "citation": ["citation_accuracy"],
+            "answer_control": ["unanswerable_detection_flag"],
+        },
+        "latency_scope": "private_runner_wall_clock",
+        "answer_metric_mode": "deterministic_contract_v1",
+        "redaction_policy": {"summary_only": True},
+        "minimums": {
+            "min_documents": 1,
+            "min_questions": 1,
+            "min_answerable_questions": 1,
+            "min_unanswerable_questions": 0,
+        },
+    }
+
+    with pytest.raises(pre.PrivateRealEvalError) as exc_info:
+        pre.validate_private_inputs(config)
+
+    message = str(exc_info.value)
+    assert "legacy_real100_path: index_dir" in message
+    assert "legacy_real100_path: output_dir" in message
+    assert "data/index/real100" not in message
+    assert "reports/real100" not in message
+    for legacy_path in (
+        "data/index/Real100",
+        "data/index/real100_minilm",
+        "reports/REAL100",
+        "reports/real100_m3",
+        "outputs/real100_kordoc",
+    ):
+        assert pre.is_legacy_real100_result_path(Path(legacy_path))
+    for current_path in (
+        "data/index/REAL100_V2",
+        "data/index/real100_v2",
+        "reports/real100_v2_chroma",
+        "outputs/real100_v2_check",
+    ):
+        assert not pre.is_legacy_real100_result_path(Path(current_path))
+
+
+def test_redacted_summary_path_rejects_legacy_real100_surfaces(tmp_path: Path) -> None:
+    with pytest.raises(pre.PrivateRealEvalError) as exc_info:
+        pre.validate_redacted_summary_path(Path("reports/real100/summary.json"))
+
+    assert str(exc_info.value) == "legacy_real100_path: redacted_summary_path"
+    pre.validate_redacted_summary_path(Path("reports/real100_v2_chroma/summary.json"))
+    redacted_aggregate = tmp_path / "reports" / "private_real_eval_candidate.redacted.json"
+    assert not pre.git_ignores_path(redacted_aggregate, root=tmp_path)
+    pre.validate_redacted_summary_path(redacted_aggregate, root=tmp_path)
+    pre.validate_redacted_summary_path(Path("reports/private_real_eval_summary.redacted.json"))
+    with pytest.raises(pre.PrivateRealEvalError) as tracked_exc:
+        pre.validate_redacted_summary_path(Path("README.md"))
+    assert str(tracked_exc.value) == "redacted_summary_path_not_allowed"
+
+
+def test_private_runner_rejects_legacy_hwp_pdf_artifact_dir(tmp_path: Path) -> None:
+    docs_dir, data_list, gold = _write_min_private_inputs(tmp_path)
+    config = {
+        "benchmark_type": "private_real_eval",
+        "not_ci_smoke": True,
+        "is_private_data": True,
+        "documents_dir": str(docs_dir),
+        "data_list_path": str(data_list),
+        "gold_evidence_path": str(gold),
+        "questions_path": str(gold),
+        "index_dir": str(tmp_path / "index"),
+        "output_dir": str(tmp_path / "runs"),
+        "top_k": 10,
+        "metrics": {
+            "retrieval": ["recall_at_5"],
+            "citation": ["citation_accuracy"],
+            "answer_control": ["unanswerable_detection_flag"],
+        },
+        "latency_scope": "private_runner_wall_clock",
+        "answer_metric_mode": "deterministic_contract_v1",
+        "redaction_policy": {"summary_only": True},
+        "index_build": {"hwp_pdf_artifact_dir": "data/index/real100/hwp_pdf_artifacts"},
+    }
+
+    with pytest.raises(pre.PrivateRealEvalError) as exc_info:
+        pre.validate_private_inputs(config)
+
+    message = str(exc_info.value)
+    assert "legacy_real100_path: hwp_pdf_artifact_dir" in message
+    assert "data/index/real100/hwp_pdf_artifacts" not in message
+
+
+def test_legacy_path_match_uses_unresolved_symlink_spelling(tmp_path: Path) -> None:
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    current_target = tmp_path / "external" / "real100_v2_chroma"
+    current_target.mkdir(parents=True)
+    legacy_link = reports_dir / "real100"
+    legacy_link.symlink_to(current_target, target_is_directory=True)
+
+    assert legacy_link.resolve() == current_target
+    assert pre.is_legacy_real100_result_path(legacy_link, root=tmp_path)
+
+
+def test_legacy_path_match_uses_resolved_symlink_target(tmp_path: Path) -> None:
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    legacy_target = reports_dir / "real100"
+    legacy_target.mkdir()
+    current_link = reports_dir / "current"
+    current_link.symlink_to(legacy_target, target_is_directory=True)
+
+    assert current_link.resolve() == legacy_target
+    assert pre.is_legacy_real100_result_path(current_link, root=tmp_path)
+
+
+def test_legacy_path_match_preserves_external_resolved_target(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    reports_dir = repo_root / "reports"
+    reports_dir.mkdir(parents=True)
+    external_target = tmp_path / "external" / "reports" / "REAL100"
+    external_target.mkdir(parents=True)
+    current_link = reports_dir / "current"
+    current_link.symlink_to(external_target, target_is_directory=True)
+
+    assert current_link.resolve() == external_target
+    assert pre.is_legacy_real100_result_path(current_link, root=repo_root)
+
+
+def test_private_runner_pins_guarded_paths_before_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    docs_dir, data_list, gold = _write_min_private_inputs(tmp_path)
+    safe_output = tmp_path / "safe" / "reports" / "real100_v2_chroma"
+    safe_index = tmp_path / "safe" / "index" / "real100_v2"
+    safe_summary_dir = tmp_path / "safe" / "summaries" / "real100_v2"
+    legacy_output = tmp_path / "legacy" / "reports" / "real100"
+    legacy_index = tmp_path / "legacy" / "data" / "index" / "real100"
+    legacy_summary_dir = tmp_path / "legacy" / "summaries"
+    for path in (
+        safe_output,
+        safe_index,
+        safe_summary_dir,
+        legacy_output,
+        legacy_index,
+        legacy_summary_dir,
+    ):
+        path.mkdir(parents=True)
+    output_link = tmp_path / "output-current"
+    index_link = tmp_path / "index-current"
+    summary_link = tmp_path / "summary-current"
+    output_link.symlink_to(safe_output, target_is_directory=True)
+    index_link.symlink_to(safe_index, target_is_directory=True)
+    summary_link.symlink_to(safe_summary_dir, target_is_directory=True)
+    config_path = tmp_path / "private_real_eval.local.yaml"
+    _write_private_eval_config(
+        config_path,
+        docs_dir=docs_dir,
+        data_list=data_list,
+        gold=gold,
+        index_dir=index_link,
+        output_dir=output_link,
+    )
+
+    def fake_build_or_load(
+        _config: dict[str, object], validation: dict[str, object]
+    ) -> None:
+        assert Path(validation["output_dir"]) == safe_output.resolve()
+        assert Path(validation["index_dir"]) == safe_index.resolve()
+        output_link.unlink()
+        output_link.symlink_to(legacy_output, target_is_directory=True)
+        index_link.unlink()
+        index_link.symlink_to(legacy_index, target_is_directory=True)
+        summary_link.unlink()
+        summary_link.symlink_to(legacy_summary_dir, target_is_directory=True)
+        return None
+
+    def fake_run_from_config(
+        _contract_path: Path,
+        *,
+        output_root_override: Path,
+        run_id_override: str,
+    ) -> Path:
+        assert output_root_override == safe_output.resolve()
+        run_dir = output_root_override / run_id_override
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "metrics.json").write_text(
+            json.dumps(
+                {
+                    "dataset": {
+                        "num_questions": 13,
+                        "answerable_count": 10,
+                        "unanswerable_count": 3,
+                    },
+                    "retrieval_metrics": {"recall_at_5": {"mean": 1.0, "n": 13}},
+                    "answer_metrics": {"citation_accuracy": {"mean": 1.0, "n": 10}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return run_dir
+
+    monkeypatch.setattr(pre, "build_or_load_private_index", fake_build_or_load)
+    monkeypatch.setattr(pre, "run_from_config", fake_run_from_config)
+
+    result = pre.main(
+        [
+            "--config",
+            str(config_path),
+            "--run-id",
+            "stable-run",
+            "--redacted-summary-path",
+            str(summary_link / "summary.json"),
+        ]
+    )
+
+    assert result == 0
+    assert (safe_output / "stable-run" / "_inputs" / "contract.naive_baseline.generated.yaml").is_file()
+    assert (safe_output / "stable-run" / "metrics.json").is_file()
+    assert (safe_summary_dir / "summary.json").is_file()
+    assert not (legacy_output / "stable-run").exists()
+    assert not (legacy_summary_dir / "summary.json").exists()
+
+
+def test_private_runner_rechecks_absent_guarded_dir_before_first_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    docs_dir, data_list, gold = _write_min_private_inputs(tmp_path)
+    output_dir = tmp_path / "runs"
+    index_dir = tmp_path / "index"
+    legacy_output = tmp_path / "legacy" / "reports" / "real100"
+    legacy_output.mkdir(parents=True)
+    config_path = tmp_path / "private_real_eval.local.yaml"
+    _write_private_eval_config(
+        config_path,
+        docs_dir=docs_dir,
+        data_list=data_list,
+        gold=gold,
+        index_dir=index_dir,
+        output_dir=output_dir,
+    )
+
+    def fake_build_or_load(
+        _config: dict[str, object], _validation: dict[str, object]
+    ) -> None:
+        shutil.rmtree(output_dir)
+        output_dir.symlink_to(legacy_output, target_is_directory=True)
+        return None
+
+    def fail_run_from_config(*_args: object, **_kwargs: object) -> Path:
+        raise AssertionError("run_from_config must not run after output_dir retargeting")
+
+    monkeypatch.setattr(pre, "build_or_load_private_index", fake_build_or_load)
+    monkeypatch.setattr(pre, "run_from_config", fail_run_from_config)
+
+    result = pre.main(
+        [
+            "--config",
+            str(config_path),
+            "--run-id",
+            "stable-run",
+            "--redacted-summary-path",
+            str(tmp_path / "safe-summary" / "summary.json"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "legacy_real100_path: output_dir" in captured.err
+    assert not (legacy_output / "stable-run").exists()
+
+
+def test_private_runner_rejects_unsafe_run_id_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    docs_dir, data_list, gold = _write_min_private_inputs(tmp_path)
+    output_dir = tmp_path / "runs"
+    index_dir = tmp_path / "index"
+    config_path = tmp_path / "private_real_eval.local.yaml"
+    _write_private_eval_config(
+        config_path,
+        docs_dir=docs_dir,
+        data_list=data_list,
+        gold=gold,
+        index_dir=index_dir,
+        output_dir=output_dir,
+    )
+
+    def fail_build_or_load(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("build_or_load_private_index must not run for invalid run_id")
+
+    def fail_run_from_config(*_args: object, **_kwargs: object) -> Path:
+        raise AssertionError("run_from_config must not run for invalid run_id")
+
+    monkeypatch.setattr(pre, "build_or_load_private_index", fail_build_or_load)
+    monkeypatch.setattr(pre, "run_from_config", fail_run_from_config)
+
+    result = pre.main(
+        [
+            "--config",
+            str(config_path),
+            "--run-id",
+            "../real100",
+            "--redacted-summary-path",
+            str(tmp_path / "safe-summary" / "summary.json"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "invalid_run_id" in captured.err
+    assert not output_dir.exists()
+    assert not index_dir.exists()
+    assert not (tmp_path / "safe-summary").exists()
+
+
+def test_validate_only_rejects_legacy_redacted_summary_path_before_run(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "files"
+    docs_dir.mkdir()
+    for index in range(50):
+        (docs_dir / f"private-{index:02d}.pdf").write_text("placeholder", encoding="utf-8")
+    data_list = tmp_path / "data_list.csv"
+    data_list.write_text("placeholder\n", encoding="utf-8")
+    gold = tmp_path / "gold_evidence.jsonl"
+    gold.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "question_id": f"q{index}",
+                    "question": "private question",
+                    "answerable": index < 10,
+                    "gold_evidence": [{"chunk_id": f"c{index}"}] if index < 10 else [],
+                },
+                ensure_ascii=False,
+            )
+            for index in range(13)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "private_real_eval.local.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "benchmark_type": "private_real_eval",
+                "not_ci_smoke": True,
+                "is_private_data": True,
+                "documents_dir": str(docs_dir),
+                "data_list_path": str(data_list),
+                "gold_evidence_path": str(gold),
+                "questions_path": str(gold),
+                "index_dir": str(tmp_path / "index"),
+                "output_dir": str(tmp_path / "runs"),
+                "top_k": 10,
+                "metrics": {
+                    "retrieval": ["recall_at_5"],
+                    "citation": ["citation_accuracy"],
+                    "answer_control": ["unanswerable_detection_flag"],
+                },
+                "latency_scope": "private_runner_wall_clock",
+                "answer_metric_mode": "deterministic_contract_v1",
+                "redaction_policy": {"summary_only": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "eval.naive_rag.private_real_eval",
+            "--config",
+            str(config_path),
+            "--validate-only",
+            "--redacted-summary-path",
+            "reports/real100/summary.json",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "legacy_real100_path: redacted_summary_path" in result.stderr
+    assert "reports/real100/summary.json" not in result.stderr
+    assert not (tmp_path / "runs").exists()
 
 
 def test_private_runner_reports_label_gaps_without_private_ids(tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. Summary

Keep the local Naive RAG private-eval runner on current `real100_v2` evidence surfaces by failing closed when a config or CLI redacted-summary path points at legacy `real100*` result/index directories.

Closes #1425

## 2. Changes

- Reject legacy private-eval result/index surfaces under `data/index/real100*`, `reports/real100*`, and `outputs/real100*`, while preserving current `real100_v2*` paths.
- Validate `--redacted-summary-path` before `--validate-only` returns and before any build/run work can start.
- Add regression coverage for exact legacy `real100`, suffix lanes such as `real100_minilm` / `real100_m3`, current `real100_v2*` allow cases, and CLI validate-only behavior.

## 3. Validation

- `python3 -m py_compile eval/naive_rag/private_real_eval.py tests/test_private_real_eval_workflow.py`
- `python3 -m pytest -q tests/test_private_real_eval_workflow.py`
- `python3 -m pytest -q tests/test_real100_v2_guard.py tests/test_private_real_eval_workflow.py`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check`
- `make check-branch`
- local load-bearing pre-commit Codex adversarial review: pass, 0 blocking / 0 informational findings after amend

## 4. Risk / Rollback

Risk is narrow: this only rejects stale legacy private-eval output/index destinations and does not change retrieval, evaluation metrics, or public smoke/synthetic configs. Rollback is reverting the two-file patch.

## 5. Eval / Benchmark Impact

Private eval guardrail only. No new real-data aggregate claim and no live private run. This reinforces the current `real100_v2`-only policy and intentionally rejects archive-only legacy `real100*` surfaces.

## 6. Backwards Compatibility

Current `real100_v2*` local paths remain accepted. Legacy `real100*` paths are intentionally rejected unless the maintainer explicitly re-enables that surface.

## 7. Out of Scope

- Running a live private `real100_v2` eval
- Rewriting private-eval workflow docs/templates broadly
- Cleaning orphan worktrees reported by the push hook
