### PR TITLE
docs: add overlap preflight to long-session handoff

### DIFF
--- a/docs/operations/long-session-workflow.md
+++ b/docs/operations/long-session-workflow.md
@@ -21,9 +21,11 @@ eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 
 3. [`docs/operations/ai-engineering-operating-system.md`](./ai-engineering-operating-system.md)에서
    role, evidence, review escalation을 확인한다.
 4. plan doc가 있으면 먼저 읽고, 없는데 필요한 범위면 구현 전에 만든다.
-5. `git status --short --branch`로 worktree 상태를 확인한다.
-6. 관련 ADR과 eval surface를 확인한다.
-7. 다음 safe command를 정하고 실행한다.
+5. `python3 scripts/agent_loop.py overlap-preflight --issue <N> --branch <type>/issue-<N>-<slug>`로
+   Codex/Claude Code/외부 worktree의 같은 issue·branch·PR 진행 여부를 확인한다.
+6. `git status --short --branch`로 worktree 상태를 확인한다.
+7. 관련 ADR과 eval surface를 확인한다.
+8. 다음 safe command를 정하고 실행한다.
 
 ## Context Preservation Rules
 
@@ -65,6 +67,7 @@ RAG 성능 개선 관련 long session은 handoff마다 8개 운영 원칙을 짧
 - Lifecycle stage:
 - Branch / worktree:
 - Base branch:
+- Overlap preflight: clear/warn/blocked + evidence path
 - Issue / PR:
 - Task:
 - Plan:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Long-session resume/handoff flow now records the cross-session overlap preflight before edits, so Codex and Claude Code lanes can prove they are not taking the same issue/branch/PR work.

Closes #1884

## 2. 영향 파일

- `docs/operations/long-session-workflow.md` — long-session start checklist and handoff template guidance only.

## 3. 리스크

- Risk: handoff authors could record an ambiguous preflight state or stale evidence path.
- Mitigation: the template now requires `clear/warn/blocked + evidence path`, and markdown link validation passed.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1884 --branch docs/issue-1884-long-session-overlap-preflight`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/long-session-workflow.md`
- `git diff --check origin/main...HEAD`
- `make check-branch`

No unit tests added: docs-only workflow guidance change.

## 5. Eval 영향

All `N/A`: docs-only operations workflow guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, answer-contract, or doc-link contract changes. Existing handoff template fields are preserved; one evidence field is added.

## 7. 범위 외

- No changes to `scripts/agent_loop.py` overlap-preflight behavior.
- No task queue edits.
- No hook changes.
- No orphan worktree cleanup or branch deletion.
