### PR TITLE
docs: mark real-data ingestion real100 paths archive-only

### DIFF
--- a/docs/real-data/real-data-ingestion.md
+++ b/docs/real-data/real-data-ingestion.md
@@ -2,6 +2,8 @@
 
 이 문서는 비공개 PDF/HWP 원본과 `data_list.csv`를 로컬에서 인덱싱하는 v1 경로를 설명한다. 공개 baseline인 `eval/fixtures/smoke_rfp/raw` public fixture RFP 실행 흐름은 그대로 유지한다. 원본 PDF/image를 직접 파싱하는 v2 경로는 [`visual-ingestion-v2.md`](../vision/visual-ingestion-v2.md)에 별도로 정리한다.
 
+> **Historical archive note.** 이 문서의 v1 optional profile `data/index/real100`, `outputs/real100`, `reports/real100/*` 경로와 관련 명령은 pre-`real100_v2` private-eval ingestion 기록 보존용이다. 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2` 표면만 사용하며, 아래 v1 경로를 새 eval 근거로 재사용하지 않는다.
+
 ## 입력
 - `data/data_list.csv`: `공고 번호`, `공고 차수`, `사업명`, `사업 금액`, `발주 기관`, 날짜 필드, `사업 요약`, `파일형식`, `파일명`, `텍스트` 컬럼을 사용한다. 컬럼 audits는 [pre-flight 검증](#pre-flight-검증-issue-51)으로 분리해 본다.
 - `data/files/`: CSV의 `파일명`이 가리키는 PDF/HWP 파일 디렉터리다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/real-data/real-data-ingestion.md` 상단에 historical archive note를 추가했다. 문서의 v1 optional profile `data/index/real100`, `outputs/real100`, `reports/real100/*` 경로와 관련 명령은 pre-`real100_v2` ingestion 기록 보존용이며, 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2`만 사용한다는 경계를 명시한다.

Closes #1887

## 2. 영향 파일

- `docs/real-data/real-data-ingestion.md` — 상단 archive-only note 1개 추가

## 3. 리스크

낮음. 기존 v1 경로 설명과 명령을 바꾸지 않고 해석 경계만 추가했다. HWP/PDF ingestion 동작, loader 기본값, eval artifact는 변경하지 않는다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/real-data/real-data-ingestion.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변경 없음. docs-only 변경이며 eval/config/rag/ingestion 코드와 aggregate artifact를 수정하지 않았다. real-eval 미실행(불필요).

## 6. 하위 호환

영향 없음. 기존 v1 기록을 그대로 보존한다.

## 7. 범위 외

- v1 optional profile 명령을 `real100_v2`로 재작성하지 않음
- private eval artifact 재생성 없음
- 다른 real-data 문서의 legacy 표기 sweep 없음
