### PR TITLE
chore(eval): smoke headline metric 어휘 정직화 + abstention/page-metadata surface

### DIFF
--- a/scripts/run_naive_baseline_eval.py
+++ b/scripts/run_naive_baseline_eval.py
@@ -34,9 +34,9 @@ RETRIEVAL_LABELS = {
     "nDCG@5": "chunk_ndcg_at_5",
 }
 ANSWER_LABELS = {
-    "Faithfulness": "groundedness",
-    "Answer relevancy": "accuracy",
-    "Citation accuracy": "citation_precision",
+    "rule_based_groundedness": "groundedness",
+    "term_coverage_accuracy": "accuracy",
+    "citation_chunk_accuracy": "citation_precision",
 }
 REQUIRED_FAILURE_BUCKETS = {
     "retrieval_failures": (
@@ -228,6 +228,43 @@ def _failure_rate(summary: dict[str, Any], key: str) -> float | None:
     return count / total
 
 
+def _failed_abstention_rate(summary: dict[str, Any]) -> float | None:
+    """Share of unanswerable cases that failed to abstain (abstention != 1.0).
+
+    Read-only aggregate over existing per-case ``answerable``/``abstention``
+    fields. Ranking and answer logic are untouched; this only relabels and
+    surfaces a diagnostic already implied by the eval summary.
+    """
+    unanswerable = [
+        case
+        for case in summary.get("case_results") or []
+        if case.get("answerable") is False
+    ]
+    if not unanswerable:
+        return None
+    failures = sum(1 for case in unanswerable if case.get("abstention") != 1.0)
+    return failures / len(unanswerable)
+
+
+def _page_metadata_coverage(summary: dict[str, Any]) -> float | None:
+    """Index-level page metadata coverage derived from chunks_total.
+
+    Uses the existing ``index_citation_metadata_coverage`` block (page-span
+    coverage over ``chunks_total``). Read-only; no retrieval/answer change.
+    """
+    coverage = summary.get("index_citation_metadata_coverage") or {}
+    total = coverage.get("chunks_total")
+    if not isinstance(total, int) or total <= 0:
+        return None
+    page_coverage = coverage.get("page_span_coverage")
+    if isinstance(page_coverage, (int, float)):
+        return float(page_coverage)
+    with_page_span = coverage.get("chunks_with_page_span")
+    if isinstance(with_page_span, int):
+        return with_page_span / total
+    return 0.0
+
+
 def _total_latency_ms(summary: dict[str, Any]) -> float | None:
     values = [
         float(case["latency_ms"])
@@ -267,12 +304,14 @@ def build_metrics_json(
             label: _metric(summary, key) for label, key in RETRIEVAL_LABELS.items()
         },
         "Answer/evidence metrics": {
-            "Faithfulness": _metric(summary, "groundedness"),
-            "Answer relevancy": _metric(summary, "accuracy"),
-            "Citation accuracy": _metric(summary, "citation_precision"),
+            "rule_based_groundedness": _metric(summary, "groundedness"),
+            "term_coverage_accuracy": _metric(summary, "accuracy"),
+            "citation_chunk_accuracy": _metric(summary, "citation_precision"),
             "Hallucination rate": _failure_rate(summary, "answer_synthesis_issue"),
             "Hallucination count": answer_synthesis_count,
             "Unanswerable detection rate": _metric(summary, "abstention"),
+            "failed_abstention_rate": _failed_abstention_rate(summary),
+            "page_metadata_coverage": _page_metadata_coverage(summary),
             "Unanswerable outcomes": summary.get("abstention_outcomes"),
         },
         "Operational metrics": {
@@ -304,11 +343,13 @@ def validate_metrics(metrics: dict[str, Any]) -> None:
     required = {
         "Retrieval metrics": ("Recall@5", "Recall@10", "MRR@5", "nDCG@5"),
         "Answer/evidence metrics": (
-            "Faithfulness",
-            "Answer relevancy",
-            "Citation accuracy",
+            "rule_based_groundedness",
+            "term_coverage_accuracy",
+            "citation_chunk_accuracy",
             "Hallucination rate",
             "Unanswerable detection rate",
+            "failed_abstention_rate",
+            "page_metadata_coverage",
         ),
         "Operational metrics": (
             "total latency ms",
@@ -670,7 +711,7 @@ def render_summary_md(
         "",
         "## Experiment Summary",
         "",
-        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Acc. | Faithfulness | Hallucination | P95 Latency |",
+        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Chunk Acc. | Rule-based Groundedness | Hallucination | P95 Latency |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
         (
             "| Naive Dense RAG | "
@@ -678,8 +719,8 @@ def render_summary_md(
             f"{_fmt_number(retrieval['Recall@10'])} | "
             f"{_fmt_number(retrieval['MRR@5'])} | "
             f"{_fmt_number(retrieval['nDCG@5'])} | "
-            f"{_fmt_number(answer['Citation accuracy'])} | "
-            f"{_fmt_number(answer['Faithfulness'])} | "
+            f"{_fmt_number(answer['citation_chunk_accuracy'])} | "
+            f"{_fmt_number(answer['rule_based_groundedness'])} | "
             f"{_fmt_number(answer['Hallucination rate'])} | "
             f"{_fmt_ms(ops['P95 latency ms'])} |"
         ),
@@ -729,7 +770,7 @@ def render_report(
         "",
         "## Metric Summary",
         "",
-        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Acc. | Faithfulness | Hallucination | P95 Latency |",
+        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Chunk Acc. | Rule-based Groundedness | Hallucination | P95 Latency |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
         (
             "| Naive Dense RAG | "
@@ -737,8 +778,8 @@ def render_report(
             f"{_fmt_number(retrieval['Recall@10'])} | "
             f"{_fmt_number(retrieval['MRR@5'])} | "
             f"{_fmt_number(retrieval['nDCG@5'])} | "
-            f"{_fmt_number(answer['Citation accuracy'])} | "
-            f"{_fmt_number(answer['Faithfulness'])} | "
+            f"{_fmt_number(answer['citation_chunk_accuracy'])} | "
+            f"{_fmt_number(answer['rule_based_groundedness'])} | "
             f"{_fmt_number(answer['Hallucination rate'])} | "
             f"{_fmt_ms(ops['P95 latency ms'])} |"
         ),
@@ -785,8 +826,8 @@ def render_report(
         good.append("Dense top-k retrieval found all derived gold chunks in the public fixture smoke set.")
     if answer["Unanswerable detection rate"] == 1.0:
         good.append("The unanswerable smoke case was detected as insufficient.")
-    if answer["Answer relevancy"] == 1.0 and answer["Faithfulness"] == 1.0:
-        good.append("Answerable fixture cases scored as relevant and faithful under the current rule-based scorer.")
+    if answer["term_coverage_accuracy"] == 1.0 and answer["rule_based_groundedness"] == 1.0:
+        good.append("Answerable fixture cases passed term-coverage and rule-based groundedness under the current rule-based scorer.")
     if not good:
         good.append("The run is reproducible and emits separated retrieval, answer/evidence, citation, failure, and latency artifacts.")
     lines.append("## What The Naive Baseline Does Reasonably Well")
@@ -797,10 +838,10 @@ def render_report(
     weak = []
     if retrieval["Recall@5"] != 1.0:
         weak.append("Dense-only retrieval has observable recall/ranking gaps before any answer logic is considered.")
-    if answer["Citation accuracy"] != 1.0:
-        weak.append("Citation accuracy is below perfect, so answers are not always tied to sufficient evidence.")
-    if answer["Faithfulness"] != 1.0:
-        weak.append("Faithfulness is below perfect, showing unsupported or partial evidence use.")
+    if answer["citation_chunk_accuracy"] != 1.0:
+        weak.append("Citation chunk accuracy is below perfect, so answers are not always tied to sufficient evidence.")
+    if answer["rule_based_groundedness"] != 1.0:
+        weak.append("Rule-based groundedness is below perfect, showing unsupported or partial evidence use.")
     if answer["Unanswerable detection rate"] != 1.0:
         weak.append("The baseline failed to abstain on at least one unanswerable case and answered with weak evidence.")
     if analysis["totals"].get("parsing_failures", 0):

--- a/scripts/run_naive_baseline_eval.py
+++ b/scripts/run_naive_baseline_eval.py
@@ -359,6 +359,11 @@ def validate_metrics(metrics: dict[str, Any]) -> None:
             "P95 latency ms",
         ),
     }
+    # failed_abstention_rate / page_metadata_coverage legitimately return None
+    # when not applicable (no unanswerable cases; no index page-metadata block).
+    # The key must be present, but a None value is a valid "not applicable"
+    # state — not a missing-key error.
+    nullable_keys = {"failed_abstention_rate", "page_metadata_coverage"}
     missing: list[str] = []
     for group, keys in required.items():
         block = metrics.get(group)
@@ -366,7 +371,7 @@ def validate_metrics(metrics: dict[str, Any]) -> None:
             missing.append(group)
             continue
         for key in keys:
-            if key not in block or block[key] is None:
+            if key not in block or (block[key] is None and key not in nullable_keys):
                 missing.append(f"{group}.{key}")
     if missing:
         raise ValueError("metrics.json missing required keys: " + ", ".join(sorted(missing)))
@@ -619,7 +624,7 @@ def recommend_issues(analysis: dict[str, Any], metrics: dict[str, Any]) -> list[
                 "title": "Audit citation support gaps in naive baseline answers",
                 "problem": "Observed citations are incomplete, vague, or not aligned with the generated claims.",
                 "why_it_matters": "RFP review needs claim-to-evidence traceability even when the textual answer is mostly correct.",
-                "expected_metric_impact": "Citation accuracy and claim-citation alignment should become explainable before verifier work starts.",
+                "expected_metric_impact": "Citation chunk accuracy and claim-citation alignment should become explainable before verifier work starts.",
                 "files_likely_to_change": "eval/scorers/citation.py, eval/scorers/alignment.py, docs/evaluation/naive_rag_baseline_report.md",
                 "acceptance_criteria": "Each citation failure case has a deterministic reason code and a representative example.",
                 "parallel_ai_assisted": "Yes",
@@ -643,7 +648,7 @@ def recommend_issues(analysis: dict[str, Any], metrics: dict[str, Any]) -> list[
                 "title": "Catalog naive answer failure modes without prompt tuning",
                 "problem": "The baseline produced an answer-policy failure on observed cases, including failed abstention when evidence was insufficient.",
                 "why_it_matters": "Answer failures must be separated from retrieval misses before prompt or verifier experiments.",
-                "expected_metric_impact": "Faithfulness, answer relevancy, hallucination, and abstention error rates get cleaner attribution.",
+                "expected_metric_impact": "Rule-based groundedness, term-coverage accuracy, hallucination, and abstention error rates get cleaner attribution.",
                 "files_likely_to_change": "docs/evaluation/naive_rag_baseline_report.md, eval/scorers/case.py",
                 "acceptance_criteria": "Failure cases distinguish partial answer, weak evidence, wrong synthesis, and failed abstention.",
                 "parallel_ai_assisted": "Yes",

--- a/tests/test_run_naive_baseline_eval.py
+++ b/tests/test_run_naive_baseline_eval.py
@@ -161,11 +161,13 @@ class NaiveBaselineEvalWrapperTest(unittest.TestCase):
                 "nDCG@5": 1.0,
             },
             "Answer/evidence metrics": {
-                "Faithfulness": 1.0,
-                "Answer relevancy": 1.0,
-                "Citation accuracy": 1.0,
+                "rule_based_groundedness": 1.0,
+                "term_coverage_accuracy": 1.0,
+                "citation_chunk_accuracy": 1.0,
                 "Hallucination rate": 0.0,
                 "Unanswerable detection rate": 1.0,
+                "failed_abstention_rate": 0.0,
+                "page_metadata_coverage": 1.0,
             },
             "Operational metrics": {
                 "total latency ms": 10.0,
@@ -217,7 +219,12 @@ class NaiveBaselineEvalWrapperTest(unittest.TestCase):
                     "count": 2,
                 },
             },
-            "index_citation_metadata_coverage": {"coverage_reason": "ok"},
+            "index_citation_metadata_coverage": {
+                "coverage_reason": "ok",
+                "chunks_total": 4,
+                "chunks_with_page_span": 4,
+                "page_span_coverage": 1.0,
+            },
             "case_results": [
                 {
                     "id": "c1",

--- a/tests/test_smoke_metric_semantics_regression.py
+++ b/tests/test_smoke_metric_semantics_regression.py
@@ -1,0 +1,206 @@
+"""Regression guard for naive-baseline smoke headline metric honesty (#1424).
+
+The smoke wrapper (``scripts/run_naive_baseline_eval.py``) must surface
+rule-based headline metric names, not semantic-judge vocabulary
+(``Faithfulness`` / ``Answer relevancy`` / ``Citation accuracy``), and must
+expose the ``failed_abstention_rate`` and ``page_metadata_coverage``
+diagnostics as headline keys. This is a name-only honesty change: ADR 0001
+ranking/answer computation is untouched (values still come from
+``groundedness`` / ``accuracy`` / ``citation_precision`` / ``abstention`` /
+``index_citation_metadata_coverage``), only the surfaced labels changed.
+"""
+import copy
+import unittest
+
+from scripts import run_naive_baseline_eval as nb
+
+
+def _summary_with_abstention(abstention_value: float) -> dict:
+    """One answerable case + one unanswerable case with a tunable abstention."""
+    return {
+        "config": "eval/config.yaml",
+        "index_dir": "data/index",
+        "num_predictions": 2,
+        "chunk_recall_at_5": 1.0,
+        "chunk_recall_at_10": 1.0,
+        "chunk_mrr_at_5": 1.0,
+        "chunk_ndcg_at_5": 1.0,
+        "groundedness": 0.5,
+        "accuracy": 0.5,
+        "citation_precision": 0.5,
+        "claim_citation_alignment": 0.5,
+        "abstention": abstention_value,
+        "abstention_outcomes": {
+            "correct_refusal": 1,
+            "incorrect_answer": 0,
+            "boundary_partial": 0,
+        },
+        "failure_category_counts": {"answer_synthesis_issue": 0},
+        "latency": {"p50": 10.0, "p95": 20.0, "mean": 15.0},
+        "stage_latency": {
+            "retrieve_ms": {"p50": 2.0, "p95": 3.0, "mean": 2.5, "count": 2},
+            "answer_generation_ms": {"p50": 4.0, "p95": 5.0, "mean": 4.5, "count": 2},
+        },
+        "index_citation_metadata_coverage": {
+            "coverage_reason": "ok",
+            "chunks_total": 4,
+            "chunks_with_page_span": 4,
+            "page_span_coverage": 1.0,
+        },
+        "case_results": [
+            {
+                "id": "c1",
+                "query": "기관 A의 보안 요구사항은?",
+                "query_type": "single_doc",
+                "answerable": True,
+                "chunk_recall_at_5": 1.0,
+                "chunk_recall_at_10": 1.0,
+                "chunk_mrr_at_5": 1.0,
+                "chunk_ndcg_at_5": 1.0,
+                "accuracy": 0.5,
+                "groundedness": 0.5,
+                "citation_precision": 0.5,
+                "claim_citation_alignment": 0.5,
+                "abstention": None,
+                "answer": "answer",
+                "citation": [],
+                "failure_category": None,
+                "latency_ms": 10.0,
+            },
+            {
+                "id": "c2",
+                "query": "없는 요구사항은?",
+                "query_type": "abstention",
+                "answerable": False,
+                "chunk_recall_at_5": None,
+                "chunk_recall_at_10": None,
+                "chunk_mrr_at_5": None,
+                "chunk_ndcg_at_5": None,
+                "accuracy": None,
+                "groundedness": None,
+                "citation_precision": None,
+                "claim_citation_alignment": None,
+                "abstention": abstention_value,
+                "answer": "",
+                "citation": [],
+                "failure_category": None,
+                "latency_ms": 20.0,
+            },
+        ],
+    }
+
+
+def _config() -> dict:
+    return {
+        "cases": [
+            {
+                "id": "c1",
+                "answerable": True,
+                "expected_doc_ids": ["doc-a"],
+                "expected_terms": ["보안"],
+            },
+            {"id": "c2", "answerable": False},
+        ]
+    }
+
+
+def _metrics(summary: dict) -> dict:
+    return nb.build_metrics_json(
+        summary,
+        _config(),
+        run_id="reg",
+        command=["python3", "eval/run_eval.py"],
+        artifact_paths={},
+    )
+
+
+class SmokeMetricSemanticsRegressionTest(unittest.TestCase):
+    def test_smoke_headline_uses_rule_based_metric_names(self) -> None:
+        block = _metrics(_summary_with_abstention(1.0))["Answer/evidence metrics"]
+
+        self.assertIn("rule_based_groundedness", block)
+        self.assertIn("term_coverage_accuracy", block)
+        self.assertIn("citation_chunk_accuracy", block)
+        self.assertNotIn("Faithfulness", block)
+        self.assertNotIn("Answer relevancy", block)
+        self.assertNotIn("Citation accuracy", block)
+
+    def test_smoke_surfaces_failed_abstention_rate(self) -> None:
+        # answerable=False case with abstention != 1.0 = a failed abstention.
+        block = _metrics(_summary_with_abstention(0.0))["Answer/evidence metrics"]
+
+        self.assertIn("failed_abstention_rate", block)
+        self.assertGreater(block["failed_abstention_rate"], 0.0)
+
+    def test_smoke_surfaces_page_metadata_coverage(self) -> None:
+        summary = _summary_with_abstention(1.0)
+        summary["index_citation_metadata_coverage"] = {
+            "coverage_reason": "ok",
+            "chunks_total": 5,
+            "chunks_with_page_span": 4,
+            "page_span_coverage": 0.8,
+        }
+
+        block = _metrics(summary)["Answer/evidence metrics"]
+
+        self.assertIn("page_metadata_coverage", block)
+        self.assertEqual(0.8, block["page_metadata_coverage"])
+
+    def test_validate_metrics_requires_new_keys(self) -> None:
+        metrics = {
+            "Retrieval metrics": {
+                "Recall@5": 1.0,
+                "Recall@10": 1.0,
+                "MRR@5": 1.0,
+                "nDCG@5": 1.0,
+            },
+            "Answer/evidence metrics": {
+                "rule_based_groundedness": 1.0,
+                "term_coverage_accuracy": 1.0,
+                "citation_chunk_accuracy": 1.0,
+                "Hallucination rate": 0.0,
+                "Unanswerable detection rate": 1.0,
+                # failed_abstention_rate + page_metadata_coverage intentionally omitted
+            },
+            "Operational metrics": {
+                "total latency ms": 10.0,
+                "retrieval latency mean ms": 2.0,
+                "generation latency mean ms": 4.0,
+                "P50 latency ms": 10.0,
+                "P95 latency ms": 20.0,
+            },
+        }
+
+        with self.assertRaisesRegex(ValueError, "metrics.json missing required keys"):
+            nb.validate_metrics(metrics)
+
+        # The error names the two newly-required diagnostic keys.
+        try:
+            nb.validate_metrics(copy.deepcopy(metrics))
+        except ValueError as exc:
+            message = str(exc)
+            self.assertIn("failed_abstention_rate", message)
+            self.assertIn("page_metadata_coverage", message)
+
+    def test_naive_baseline_preset_name_unchanged(self) -> None:
+        # ADR 0001 lock: the wrapper still selects the naive_baseline preset.
+        source = {
+            "primary_run": "full",
+            "ablation_runs": [
+                {"name": "naive_baseline", "pipeline": "naive_baseline"},
+                {"name": "full", "pipeline": "agentic_full"},
+            ],
+            "cases": [{"id": "c1", "query": "q"}],
+        }
+
+        filtered = nb.select_naive_config(source)
+
+        self.assertEqual("naive_baseline", filtered["primary_run"])
+        self.assertEqual(
+            [{"name": "naive_baseline", "pipeline": "naive_baseline"}],
+            filtered["ablation_runs"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smoke_metric_semantics_regression.py
+++ b/tests/test_smoke_metric_semantics_regression.py
@@ -201,6 +201,49 @@ class SmokeMetricSemanticsRegressionTest(unittest.TestCase):
             filtered["ablation_runs"],
         )
 
+    def test_validate_metrics_allows_none_for_diagnostic_keys(self) -> None:
+        # HIGH fix (#1424): failed_abstention_rate / page_metadata_coverage
+        # return None when not applicable (no unanswerable case; no index
+        # page-metadata block). validate_metrics must treat a present key with
+        # a None value as valid, not a missing-key error (else export_artifacts
+        # crashes on otherwise-fine runs).
+        metrics = {
+            "Retrieval metrics": {
+                "Recall@5": 1.0, "Recall@10": 1.0, "MRR@5": 1.0, "nDCG@5": 1.0,
+            },
+            "Answer/evidence metrics": {
+                "rule_based_groundedness": 1.0,
+                "term_coverage_accuracy": 1.0,
+                "citation_chunk_accuracy": 1.0,
+                "Hallucination rate": 0.0,
+                "Unanswerable detection rate": 1.0,
+                "failed_abstention_rate": None,
+                "page_metadata_coverage": None,
+            },
+            "Operational metrics": {
+                "total latency ms": 10.0,
+                "retrieval latency mean ms": 2.0,
+                "generation latency mean ms": 4.0,
+                "P50 latency ms": 10.0,
+                "P95 latency ms": 20.0,
+            },
+        }
+
+        # Must NOT raise: present key + None value == not-applicable.
+        nb.validate_metrics(metrics)
+
+    def test_build_metrics_json_handles_none_diagnostic(self) -> None:
+        # End-to-end: a summary with no index page-metadata block yields
+        # page_metadata_coverage None and must not crash build_metrics_json
+        # (which validates the required key set).
+        summary = _summary_with_abstention(1.0)
+        summary.pop("index_citation_metadata_coverage", None)
+
+        block = _metrics(summary)["Answer/evidence metrics"]
+
+        self.assertIn("page_metadata_coverage", block)
+        self.assertIsNone(block["page_metadata_coverage"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1424

#1424(smoke eval ↔ naive RAG benchmark 분리)의 의도 산출물 대부분은 이미 main 에 landing 됨 (#1419→#1428→#1435→#1488→#1491, 65 tests green; 원래 시도 PR #1430 은 closed-not-merged). **잔여 gap 은 단 하나** — smoke wrapper `scripts/run_naive_baseline_eval.py` 의 headline 이 아직 `Faithfulness`/`Answer relevancy`/`Citation accuracy` 같은 **semantic 어휘**를 노출(surface-map "smoke 는 semantic metric 처럼 보이면 안 됨" 원칙 위반)하고, `failed_abstention_rate`/`page_metadata_coverage` 진단 metric 을 headline 으로 surface 하지 않음(AC4 smoke-side 미충족). 본 PR 이 이 잔여를 닫는다 — **이름만 정직화**(값 산출 path 무변경).

## 2. 영향 파일

- `scripts/run_naive_baseline_eval.py` (수정) — headline 어휘 rule-based rename + 진단 metric 2종 headline + `validate_metrics` required-key + `render_report`/`render_summary_md` 라벨 동기화
- `tests/test_run_naive_baseline_eval.py` (갱신) — `_valid_metrics()`/`_summary_fixture` 키 교체
- `tests/test_smoke_metric_semantics_regression.py` (신규, 5 tests)

rename 매핑: `Faithfulness`→`rule_based_groundedness`, `Answer relevancy`→`term_coverage_accuracy`, `Citation accuracy`→`citation_chunk_accuracy` (`eval/naive_rag/metrics.py` 어휘와 일치). `scripts/claude-hooks/` 류 load-bearing 외 — `scripts/run_naive_baseline_eval.py` 는 LOAD_BEARING_PATHS 비포함.

## 3. 리스크

- 가장 가능성: (a) `metrics.json` headline 키 rename 으로 downstream consumer 깨짐, (b) ADR 0001 baseline 동작 변경 오인.
- 배제: (a) `render_report` 가 생성하는 `naive_rag_baseline_report.md` 는 generated view(정적 커밋 아님) — 다음 run 시 자동 재생성. `raw_eval_summary_keys` 원본 키(`groundedness`/`citation_precision`) 보존. (b) 값 산출 로직 무변경(`_metric` 호출 그대로), `test_naive_baseline_ranking_invariance.py` green(byte-identity).

## 4. 테스트

- 신규+갱신: **11 passed** (`test_smoke_metric_semantics_regression` 5 + `test_run_naive_baseline_eval` 6)
- 불변 가드: **59 passed** (`benchmark_v1` + `eval_contract` + `synthetic_benchmark`)
- ADR 0001: `test_naive_baseline_ranking_invariance` **1 passed + 4 subtests**

## 5. Eval 영향

Public fixture smoke 표면 한정. **이름만 정직화** — ranking/answer 계산 path 무변경(invariance 테스트 green = byte-identity). real-data 델타 없음. benchmark/private real-eval 표면 무변경.

## 6. 하위 호환

- `metrics.json` headline 키: semantic→rule-based rename = **의도적 표면 정직화**(surface-map 정합). `raw_eval_summary_keys` 원본 진단 데이터 보존.
- ADR 0001 `naive_baseline` preset 이름/ranking 불변(`test_naive_baseline_preset_name_unchanged` lock).
- 새 측정 표면 ADR: **불요** — 기존 ADR 0005 + surface-map 원칙에 smoke wrapper 를 사후 정합시킬 뿐, reviewer 가 의존할 새 계약 고정 없음.

## 7. 범위 외

- benchmark 표면(이미 #1419~1491 landing), `recommend_issues` follow-up 추천 산문, eval 재실행(`make smoke` 는 CI 에서).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
