### PR TITLE
docs: add overlap preflight to auto-ship start

### DIFF
--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -38,7 +38,16 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 3. 제목 또는 `SLUG` 로 `<type>/issue-<N>-<slug>` 브랜치를 만든다.
 4. `origin/main` 을 fetch 한 뒤 새 브랜치로 switch 한다.
 
-그 다음 파일을 수정하고 focused test 를 실행한 뒤 `make ship-arm` 한다.
+그 다음 파일을 수정하고 focused test 를 실행한 뒤 `make ship-arm` 한다. 편집이나
+arming 전에 동일 issue/branch/PR 이 다른 Codex, Claude Code, 또는 외부
+worktree 에서 이미 진행 중인지
+[`overlap-preflight`](./ai-codex-workflow.md#overlap-preflight)로 기록한다:
+
+```bash
+python3 scripts/agent_loop.py overlap-preflight \
+  --issue <N> \
+  --branch <type>/issue-<N>-<slug>
+```
 
 ## Arming: `make ship-arm`
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Auto-ship startup guidance now records the same cross-session overlap preflight used by direct Codex and long-session workflows before edits or arming, so Codex, Claude Code, and external worktrees do not ship the same issue/branch/PR concurrently.

Closes #1890

## 2. 영향 파일

- `docs/operations/auto-ship.md` — auto-ship start guidance only.

## 3. 리스크

- Risk: operators might treat overlap preflight as an automation behavior change rather than a documented pre-arm check.
- Mitigation: wording explicitly says behavior is unchanged and places the command after issue/branch creation, before edits/arming.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1890 --branch docs/issue-1890-auto-ship-overlap-preflight`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/auto-ship.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only workflow guidance change.

## 5. Eval 영향

All `N/A`: docs-only operations workflow guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, Makefile, or answer-contract changes. Existing auto-ship commands remain unchanged.

## 7. 범위 외

- No changes to `make ship-start`, `make ship-arm`, or Stop-hook implementation.
- No branch deletion behavior changes.
- No orphan worktree cleanup.
- No agent-loop implementation changes.
