### PR TITLE
docs: mark real-data failure taxonomy archive-only

### DIFF
--- a/docs/real-data/real-data-failure-taxonomy.md
+++ b/docs/real-data/real-data-failure-taxonomy.md
@@ -2,6 +2,8 @@
 
 이슈 [#47](https://github.com/hskim-solv/BidMate-DocAgent/issues/47)의 결과물. real100 평가셋에서 발견된 실패 모드를 6 카테고리로 분류하고, 후속 작업의 우선순위를 정한다. 본 문서는 평가 산출물(`reports/real100/eval_summary.json`)을 기반으로 작성하며, 원본 RFP 문서, 발주 기관/사업명, 질의 원문은 포함하지 않는다.
 
+> **Historical archive note.** 이 문서의 `real100`, `reports/real100/*`, `data/index/real100` 기반 실패 분류는 issue #47 시점의 v1 snapshot 보존용이다. 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2` 표면만 사용하며, 아래 재현 명령과 카테고리 수치를 새 eval 근거로 재사용하지 않는다.
+
 ## 배경
 
 저장소에는 이미 공개 fixture smoke baseline, private hard-case 스캐폴딩, 재현 가능한 smoke harness, 리뷰어용 문서가 정비되어 있다. 다음 단계의 고가치 작업은 (a) 실데이터에서 어디가 실제로 깨지는지 검증하고, (b) 그 실패를 코드 경로에 매핑한 뒤, (c) impact·effort로 정렬된 백로그를 만드는 것이다. 본 문서는 그 결과물이며, 실제 fix 구현은 후속 이슈로 분리한다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/real-data/real-data-failure-taxonomy.md` 상단에 historical archive note를 추가했다. issue #47 시점의 legacy `real100`/`reports/real100/*`/`data/index/real100` 기반 실패 분류는 v1 snapshot 보존용이며, 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2`만 사용한다는 경계를 명시한다.

Closes #1892

## 2. 영향 파일

- `docs/real-data/real-data-failure-taxonomy.md` — 상단 archive-only note 1개 추가

## 3. 리스크

낮음. 기존 실패 분류, 재현 명령, 카테고리 표를 바꾸지 않고 해석 경계만 추가했다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/real-data/real-data-failure-taxonomy.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변경 없음. docs-only 변경이며 eval/config/rag 경로와 aggregate artifact를 수정하지 않았다. real-eval 미실행(불필요).

## 6. 하위 호환

영향 없음. 기존 v1 taxonomy 기록을 그대로 보존한다.

## 7. 범위 외

- 실패 taxonomy를 `real100_v2` 기준으로 재측정하지 않음
- private eval artifact 재생성 없음
- 다른 audit/plan 문서의 legacy 표기 sweep 없음
