### PR TITLE
docs: mark failure-mode taxonomy link archive-only

### DIFF
--- a/docs/case-studies/failure-modes.md
+++ b/docs/case-studies/failure-modes.md
@@ -4,7 +4,7 @@
 
 본 문서는 요약이며, 정본(canonical) 데이터는 다음을 참조한다 (중복 서술하지 않음):
 
-- [`docs/real-data/real-data-failure-taxonomy.md`](../real-data/real-data-failure-taxonomy.md) — real100 기반 6-카테고리(C1–C6) 정본 분류
+- [`docs/real-data/real-data-failure-taxonomy.md`](../real-data/real-data-failure-taxonomy.md) — historical v1 `real100` 기반 6-카테고리(C1–C6) 정본 분류(archive-only snapshot)
 - [`docs/agentic/agent-failure-modes-analysis.md`](../agentic/agent-failure-modes-analysis.md) — LangGraph 오케스트레이션 실패 패턴
 - [`docs/operations/failure-mode-harden-process.md`](../operations/failure-mode-harden-process.md) — monotone-ratchet 하드닝 프로세스
 - [ADR 0059](../adr/0059-failure-mode-classifier-as-measurement-surface.md) (failure classifier) · [ADR 0062](../adr/0062-failure-rate-regression-contract.md) (회귀 ceiling 계약)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/case-studies/failure-modes.md`의 taxonomy 링크 설명을 `historical v1 real100` / `archive-only snapshot`으로 명확히 했다. target 문서(`docs/real-data/real-data-failure-taxonomy.md`)는 issue #47 시점의 v1 taxonomy 기록이고, 현재 새 private eval 근거는 `real100_v2`만 사용한다.

Closes #1895

## 2. 영향 파일

- `docs/case-studies/failure-modes.md` — taxonomy 링크 설명 1줄 수정

## 3. 리스크

낮음. case-study 본문과 failure-mode 대응 설명은 변경하지 않고 cross-link의 evidence freshness 경계만 명시했다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/case-studies/failure-modes.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변경 없음. docs-only 변경이며 eval/config/rag 경로와 aggregate artifact를 수정하지 않았다. real-eval 미실행(불필요).

## 6. 하위 호환

영향 없음. 기존 링크와 case-study 구조를 유지한다.

## 7. 범위 외

- taxonomy 재측정 없음
- case-study failure-mode 본문 재작성 없음
- 다른 docs legacy 표기 sweep 없음
