### PR TITLE
docs: mark HWP eval real100 corpus reference historical

### DIFF
--- a/docs/hwp/hwp-eval-closure.md
+++ b/docs/hwp/hwp-eval-closure.md
@@ -10,6 +10,10 @@ permalink: /hwp-eval-closure/
 corpus(96% HWP) 사이에서 식별된 네 가지 갭, 그리고 이를 해소한 PR 스택을
 기록한다.
 
+> **Historical archive note.** 이 문서의 `data/index/real100` private corpus
+> reference는 ADR 0039 / 2026-05 HWP gap closure 당시의 v1 snapshot 맥락이다.
+> 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2` 표면만 사용한다.
+
 ## 배경(Background)
 
 ADR 0036 (#641) 이 `HwpNativeLoader` 를 pyhwp-gated 기본값으로 출하한 후,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/hwp/hwp-eval-closure.md` 상단에 historical archive note를 추가했다. 문서의 `data/index/real100` private corpus reference는 ADR 0039 / 2026-05 HWP gap closure 당시의 v1 snapshot이며, 현재 새 작업·PR·claim의 private eval 근거는 `real100_v2`만 사용한다는 경계를 명시한다.

Closes #1898

## 2. 영향 파일

- `docs/hwp/hwp-eval-closure.md` — 상단 archive-only note 1개 추가

## 3. 리스크

낮음. HWP PR stack, gap 설명, public fixture smoke 설명은 변경하지 않고 corpus reference의 freshness 경계만 명시했다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/hwp/hwp-eval-closure.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

동작 변경 없음. docs-only 변경이며 eval/config/rag/ingestion 코드와 aggregate artifact를 수정하지 않았다. real-eval 미실행(불필요).

## 6. 하위 호환

영향 없음. 기존 HWP closure 기록을 그대로 보존한다.

## 7. 범위 외

- HWP eval closure 재측정 없음
- ADR 0039/0036 내용 변경 없음
- 다른 HWP/ingestion 문서 sweep 없음
