### PR TITLE
docs: add overlap question to AI operating system

### DIFF
--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -95,6 +95,7 @@
 | 질문 | 답하는 문서 |
 |---|---|
 | What should I work on next? | [`tasks/queue.md`](../../tasks/queue.md)의 `Ready Order` 또는 `python3 scripts/agent_loop.py continue-loop` |
+| How do I avoid overlapping another AI session? | [`overlap-preflight`](./ai-codex-workflow.md#overlap-preflight) for Codex, Claude Code, and external worktrees |
 | What role am I acting as? | 이 문서의 [Agent Role Model](#agent-role-model) |
 | What plan should I follow? | task의 plan link 또는 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md) |
 | What evidence must I produce? | task의 `Evidence Required`와 plan의 `Validation Strategy` |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The AI Engineering Operating System now directly answers how an agent avoids overlapping another Codex, Claude Code, or external worktree session by pointing to the canonical `overlap-preflight` guidance from the Operating Questions table.

Closes #1901

## 2. 영향 파일

- `docs/operations/ai-engineering-operating-system.md` — Operating Questions guidance only.

## 3. 리스크

- Risk: the operating-system page could duplicate lower-level coordination policy.
- Mitigation: this PR adds only one pointer row and keeps the canonical details in `ai-codex-workflow.md#overlap-preflight`.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1901 --branch docs/issue-1901-ai-os-overlap-question`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-engineering-operating-system.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only operating guidance change.

## 5. Eval 영향

All `N/A`: docs-only operating guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, Makefile, task queue, or answer-contract changes.

## 7. 범위 외

- No changes to overlap-preflight implementation.
- No queue, plan, eval, hook, or worktree cleanup changes.
