### PR TITLE
docs: add overlap evidence to governance review checklist

### DIFF
--- a/docs/reviews/ai-review-checklists.md
+++ b/docs/reviews/ai-review-checklists.md
@@ -58,6 +58,7 @@ AI-agent failure mode를 일부러 찾는다.
 
 - 새 문서가 기존 source of truth를 대체한다고 암시하지 않는가?
 - `CLAUDE.md`, `AGENTS.md`, `docs/engineering-governance.md`, ADR, README 사이에 drift가 생기지 않았는가?
+- multi-session 또는 parallel worktree PR이면 [`overlap-preflight`](../operations/ai-codex-workflow.md#overlap-preflight) 결과와 evidence path가 남아 있고 `clear/warn/blocked` 해석이 PR scope와 맞는가?
 - Links가 상대 경로 기준으로 유효한가? `make check-doc-links` 또는 `python scripts/check_doc_links.py --check-all`를 실행했는가?
 - 새 eval/benchmark 문서가 [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md)의 claim boundary를 따르는가?
 - 새 plan/task/review 문서가 실제로 다음 agent가 실행 가능한 수준인가?


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Documentation / Governance Review now asks reviewers to confirm overlap-preflight evidence for multi-session or parallel-worktree PRs, so the reviewer checklist matches the current Codex/Claude Code coordination workflow.

Closes #1904

## 2. 영향 파일

- `docs/reviews/ai-review-checklists.md` — Documentation / Governance Review checklist only.

## 3. 리스크

- Risk: reviewer checklist could become noisy if the bullet applies to every docs PR.
- Mitigation: wording scopes it only to multi-session or parallel worktree PRs and points to the canonical overlap-preflight doc.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1904 --branch docs/issue-1904-review-overlap-evidence`
- `python3 scripts/check_doc_links.py --check-all --paths docs/reviews/ai-review-checklists.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only review checklist change.

## 5. Eval 영향

All `N/A`: docs-only review checklist guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, CI, task queue, or answer-contract changes.

## 7. 범위 외

- No changes to overlap-preflight implementation.
- No CI/review automation changes.
- No worktree cleanup or branch deletion changes.
