### PR TITLE
docs: add overlap evidence to plan template

### DIFF
--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -4,6 +4,7 @@
 - Owner role: <Planner | Implementer | Evaluator | Reviewer | other role>
 - Related task: `tasks/queue.md::<task-id>` | N/A
 - Related issue / PR: <links or N/A>
+- Overlap preflight: clear | warn | blocked | N/A; evidence: <path or command output>
 - Related ADR: <links or "N/A - no decision-level change">
 - Created: YYYY-MM-DD
 - Last updated: YYYY-MM-DD
@@ -118,6 +119,7 @@ Update this section at every session boundary or context compaction.
 
 - Role:
 - Branch / worktree:
+- Overlap preflight:
 - Issue / PR:
 - Task:
 - Current status:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Plan docs and session handoffs now have explicit overlap-preflight fields, so long-running or multi-session work can preserve the cross-session non-overlap result and evidence path instead of only recording branch/worktree/issue metadata.

Closes #1906

## 2. 영향 파일

- `docs/plans/TEMPLATE.md` — plan metadata and handoff template fields only.

## 3. 리스크

- Risk: plan authors may treat the field as required for one-shot solo work.
- Mitigation: metadata allows `N/A`, while multi-session work can record `clear/warn/blocked` and evidence.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1906 --branch docs/issue-1906-plan-overlap-evidence`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/TEMPLATE.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only plan template change.

## 5. Eval 영향

All `N/A`: docs-only plan template guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, CI, task queue, or answer-contract changes. Existing plans remain readable; new fields are additive.

## 7. 범위 외

- No changes to overlap-preflight implementation.
- No queue, CI, hook, or worktree cleanup changes.
