### PR TITLE
docs: add overlap evidence to task handoff template

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -34,7 +34,8 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
    이때 Codex, Claude Code, 루트 checkout, `.codex/worktrees/*`, `.claude/worktrees/*`, 그리고 `git worktree list`에 잡히는 외부 worktree를 모두 같은 coordination surface로 본다.
 5. preflight가 `blocked`이면 그 task를 시작하지 말고 다른 issue를 고른다.
    `warn`이면 branch/PR history 경고를 기록하고, 파일 겹침이 없는지 확인한 뒤 진행한다.
-6. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
+6. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree,
+   overlap-preflight 결과/evidence path, 첫 명령을 남긴다.
 7. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
 
 `backlog` task는 missing decision이나 validation이 남아 있다는 뜻이다. agent는
@@ -57,6 +58,7 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 - `Evidence Required`
 - `Failure Conditions`
 - `Related Plan / Issue / PR Links`
+- `Overlap Preflight`
 - `Handoff Notes`
 
 ## Operating Rules
@@ -89,5 +91,6 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 - Evidence Required:
 - Failure Conditions:
 - Related Plan / Issue / PR Links:
+- Overlap Preflight: clear | warn | blocked | N/A; evidence: <path or command output>
 - Handoff Notes:
 ```


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Task queue handoff guidance now preserves overlap-preflight result and evidence path, so agents that follow the start preflight do not lose that cross-session coordination evidence in the durable task entry.

Closes #1908

## 2. 영향 파일

- `tasks/README.md` — task schema/minimal-entry handoff guidance only.

## 3. 리스크

- Risk: task authors could treat overlap-preflight as mandatory for every trivial solo task.
- Mitigation: the field allows `N/A` while preserving `clear/warn/blocked` evidence for multi-session work.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1908 --branch docs/issue-1908-task-handoff-overlap-evidence`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/README.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only task handoff guidance change.

## 5. Eval 영향

All `N/A`: docs-only task handoff guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, CI, active queue state, or answer-contract changes. New task entries can add the field; existing task records remain readable.

## 7. 범위 외

- No edits to `tasks/queue.md` active task state.
- No changes to overlap-preflight implementation.
- No CI, hook, or worktree cleanup changes.
