### PR TITLE
docs: remind PR authors to include overlap evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,8 @@ ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.p
 하는 테스트 최소 1개 필수. 출시된 버그용 regression 은 tests/test_*_regression.py
 (pattern: tests/test_retrieval_loop_regression.py).
 테스트 미추가 시 사유 명시.
+multi-session 또는 parallel worktree PR 이면 overlap-preflight result/evidence path를
+여기에 포함.
 -->
 
 ## 5. Eval 영향


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The PR template now nudges authors of multi-session or parallel-worktree PRs to include overlap-preflight result and evidence path in the test/evidence section, so reviewer handoffs surface the same coordination evidence preserved in plans and task handoffs.

Closes #1910

## 2. 영향 파일

- `.github/pull_request_template.md` — hidden author guidance comment only.

## 3. 리스크

- Risk: the template could become noisy or add a new visible requirement.
- Mitigation: this is a hidden comment under the existing test/evidence section and preserves the visible §1–§7 structure.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1910 --branch docs/issue-1910-pr-template-overlap-evidence`
- `python3 scripts/check_doc_links.py --check-all --paths .github/pull_request_template.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only PR template comment change.

## 5. Eval 영향

All `N/A`: docs-only PR template guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, CI, task queue, or answer-contract changes. Visible template sections remain unchanged.

## 7. 범위 외

- No changes to overlap-preflight implementation.
- No CI/review automation changes.
- No worktree cleanup or branch deletion changes.
