### PR TITLE
docs: link overlap preflight to evidence sinks

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -82,6 +82,11 @@ python3 scripts/agent_loop.py overlap-preflight \
 예상 변경 파일이 다른 세션의 dirty/diff 파일과 겹치지 않는다는 근거를 남긴 뒤
 진행한다. 근거를 만들 수 없으면 다른 issue를 고른다.
 
+결과와 evidence path는 장기 작업이면 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md)
+또는 [`tasks/README.md`](../../tasks/README.md)의 handoff 필드에 남기고,
+PR 에서는 [`.github/pull_request_template.md`](../../.github/pull_request_template.md)
+§4 테스트/근거 섹션에 요약한다.
+
 ### Orphan Worktree Warnings
 
 pre-push hygiene가 “branch already merged into main, but the worktree was never removed”를 보고해도,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The canonical overlap-preflight guidance now points to the durable evidence sinks where agents should preserve the result and evidence path: plan templates, task handoffs, and the PR test/evidence section.

Closes #1912

## 2. 영향 파일

- `docs/operations/ai-codex-workflow.md` — overlap-preflight guidance only.

## 3. 리스크

- Risk: canonical guidance could duplicate template details and drift.
- Mitigation: this PR links the evidence sinks without restating their full schemas.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1912 --branch docs/issue-1912-overlap-evidence-sinks`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md`
- `git diff --check`
- `make check-branch`

No unit tests added: docs-only workflow guidance change.

## 5. Eval 영향

All `N/A`: docs-only workflow guidance; no RAG/eval/load-bearing runtime behavior change and no private eval evidence claim.

## 6. 하위 호환

No CLI, schema, hook, CI, task queue state, or answer-contract changes.

## 7. 범위 외

- No changes to overlap-preflight implementation.
- No template field changes.
- No worktree cleanup or branch deletion changes.
