### PR TITLE
docs: mark SPLADE ColBERT real100 sizing anchor historical

### DIFF
--- a/docs/investigations/152-splade-colbert-feasibility.md
+++ b/docs/investigations/152-splade-colbert-feasibility.md
@@ -96,7 +96,12 @@ private 100-doc / 21-case real-data 에서만 실행. raw 결과는 `artifacts/b
 | dtype | float32 | `np.load(...).dtype` |
 | backend | local-hashing-bow | `idx["embedding"]["model"]` |
 
-Private real100 의 N 은 gitignored — `docs/real-data/real-data-failure-taxonomy.md` 의 100 docs × 30–50 chunks/doc 추정으로 **3,000–5,000 chunks 범위** 로 둔다. 정확한 수는 본 노트에 commit 하지 않는다.
+Private `real100` 의 N 은 gitignored 이며, 여기서는
+`docs/real-data/real-data-failure-taxonomy.md` 의 100 docs × 30–50 chunks/doc 추정을
+**historical v1 archive-only scale proxy** 로만 둔다. 이 **3,000–5,000 chunks 범위** 는
+ColBERT 저장비를 대략 산정하기 위한 과거 배경값이며 현재 private eval 근거가
+아니다. 새 작업·PR·claim 에서 정확한 현재 sizing 을 주장하려면 별도
+`real100_v2` manifest/index 검증을 먼저 추가해야 한다.
 
 ### 4.2 chunk 당 저장 공식(per-chunk storage formula)
 


### PR DESCRIPTION
## §1 Summary
- Mark the SPLADE/ColBERT storage-sizing `real100` chunk estimate as historical v1 archive-only context.
- State that current sizing claims require fresh `real100_v2` manifest/index validation.

Closes #1916

## §2 Changes
- Qualified the `3,000–5,000 chunks` estimate in `docs/investigations/152-splade-colbert-feasibility.md` as a legacy scale proxy, not current private eval evidence.

## §3 Verification
- `python3 scripts/check_doc_links.py --check-all --paths docs/investigations/152-splade-colbert-feasibility.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §4 Risk / Rollback
- Risk: low; docs-only qualifier.
- Rollback: revert this PR.

## §5 Eval Impact
- Documentation-only; no eval/runtime behavior changed.
- Prevents a legacy v1 `real100` sizing estimate from being read as current `real100_v2` evidence.

## §6 Screenshots / Artifacts
N/A — markdown-only docs update.

## §7 Follow-ups
N/A.

Constraint: Current private eval evidence for new work must use real100_v2, while this feasibility note only needed a rough storage-sizing proxy.
Rejected: Recompute ColBERT sizing from private artifacts | unnecessary for a docs-only qualifier and would expand into private eval work.
Confidence: high
Scope-risk: narrow
Directive: Investigation notes may use legacy real100 only as archive-only scale context unless fresh real100_v2 validation is attached.
Tested: python3 scripts/check_doc_links.py --check-all --paths docs/investigations/152-splade-colbert-feasibility.md; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
Not-tested: GitHub Pages render after merge.
