### PR TITLE
docs: add overlap preflight to staging self-ship runbook

### DIFF
--- a/docs/operations/staging-self-ship.md
+++ b/docs/operations/staging-self-ship.md
@@ -175,6 +175,11 @@ Gate 3 check 1은 protection이 실제임을 검증한다. Check 2는 P2.2로 �
 
 ## lane 실행
 
+Codex/Claude 병행 세션에서 이 lane을 시작할 때는 먼저
+[`overlap-preflight`](ai-codex-workflow.md#overlap-preflight)를 실행하고, 결과와
+evidence sink를 plan/PR에 남긴다. `blocked`면 시작하지 말고, `warn`이면 예상 변경
+파일이 기존 worktree와 겹치지 않는다는 근거를 남긴 뒤 진행한다.
+
 ```bash
 # fail-closed (blocked-on-user, exit 2) — 올바른 D-minus 동작:
 make 시작-ship


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/staging-self-ship.md`의 lane 실행 절차 앞에 Codex/Claude 병행 세션에서 `overlap-preflight`를 먼저 실행하고 결과/evidence sink를 남기라는 runbook 단계를 추가했습니다. self-ship 계열 자동화가 별도 worktree 작업과 겹치지 않았다는 증거를 남기기 위함입니다.

Closes #1919

## 2. 영향 파일

- `docs/operations/staging-self-ship.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: runbook 링크 fragment가 깨지거나 기존 D-minus 실행 의미를 바꾼 것처럼 읽힐 수 있음.
- 배제: lane 실행 전 증거 단계만 추가했고, `make 시작-ship` 동작/권한/guard 설명은 변경하지 않았습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1919 --branch docs/issue-1919-staging-self-ship-overlap-preflight` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/staging-self-ship.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. RAG/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing staging self-ship commands are unchanged.

## 7. 범위 외

- No `make 시작-ship` runtime execution.
- No branch protection, CODEOWNERS, or staging guard changes.
- No worktree cleanup despite orphan-worktree warnings.
