### PR TITLE
docs: record overlap evidence for harness runs

### DIFF
--- a/docs/operations/harness.md
+++ b/docs/operations/harness.md
@@ -44,6 +44,11 @@ artifacts/runs/<run_id>/
 
 `artifacts/runs/`는 Git 추적 대상이 아니다. 공개 fixture smoke라도 raw prediction과 로그는 로컬 검증 산출물로 유지한다.
 
+병행 Codex/Claude worktree에서 harness를 실행해 PR 근거로 쓰는 경우, 실행 전
+[`overlap-preflight`](ai-codex-workflow.md#overlap-preflight) 결과를 함께 남긴다.
+`clear` 또는 정당화된 `warn` 결과가 있어야 해당 run artifact가 다른 세션의 변경과
+겹치지 않았음을 설명할 수 있다.
+
 ## 스키마
 
 `run_manifest.json`은 다음 필드를 포함한다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/harness.md`에 병행 Codex/Claude worktree에서 harness run artifact를 PR 근거로 사용할 때 `overlap-preflight` 결과를 같이 남기라는 문단을 추가했습니다. 재현 산출물이 다른 세션 변경과 겹치지 않았다는 provenance를 보존하기 위함입니다.

Closes #1923

## 2. 영향 파일

- `docs/operations/harness.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: harness artifact schema나 실행 절차가 변경된 것처럼 오해될 수 있음.
- 배제: artifact layout/schema/commands는 변경하지 않고, PR evidence에 붙일 overlap provenance 문단만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1923 --branch docs/issue-1923-harness-overlap-evidence` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/harness.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Harness/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing harness commands and artifact paths are unchanged.

## 7. 범위 외

- No harness runtime execution.
- No artifact schema changes.
- No worktree cleanup despite orphan-worktree warnings.
