### PR TITLE
feat(agent-loop): X task-pool E3c — X>1 cycle-worktree artifact mirror + thread-safe warnings + lease-kwargs split (dark)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9,6 +9,7 @@ PRs, deletes branches, force-pushes, or calls external model APIs.
 from __future__ import annotations
 
 import argparse
+import copy
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 import contextlib
 from dataclasses import dataclass
@@ -989,6 +990,45 @@ def _repo_path(path: Path, repo_root: Path) -> str:
         return path.as_posix()
 
 
+# ADR 0095 PR-E3c MED-3: parent-relative posix prefix for the active coordination dir
+# (``reports/agent_loop/active``) and the X>1 per-task artifact mirror root
+# (``reports/agent_loop/active/tasks/<task_id>``). Recorded so a cycle's artifact paths survive the
+# per-task worktree teardown (the artifacts are COPIED to this parent-resolvable location).
+_ACTIVE_DIR_REL_POSIX = DEFAULT_ACTIVE_DIR.relative_to(ROOT_DIR).as_posix()  # "reports/agent_loop/active"
+_ACTIVE_TASKS_REL_POSIX = (DEFAULT_ACTIVE_DIR / "tasks").relative_to(ROOT_DIR).as_posix()
+
+
+def _task_artifact_mirror_dir(repo_root: Path, task_id: str) -> Path:
+    """The parent task-scoped directory the X>1 cycle's ``active`` artifacts are copied INTO before
+    the cycle worktree is torn down: ``<repo_root>/reports/agent_loop/active/tasks/<task_id>``."""
+    return DEFAULT_ACTIVE_DIR / "tasks" / task_id if repo_root == ROOT_DIR else repo_root / _ACTIVE_TASKS_REL_POSIX / task_id
+
+
+def _cycle_artifact_repo_path(
+    path: Path,
+    *,
+    effective_repo_root: Path,
+    repo_root: Path,
+    task_id: str,
+) -> str:
+    """Record a cycle artifact path so it is PARENT-resolvable (ADR 0095 PR-E3c MED-3).
+
+    At X==1 (``effective_repo_root == repo_root`` — no worktree) this is EXACTLY ``_repo_path(path,
+    repo_root)`` -> byte-identical (ADR 0001). At X>1 the artifact was written inside the cycle
+    worktree under ``reports/agent_loop/active/...``; that worktree is torn down at cycle end, so the
+    recorded path is re-pointed to the parent task-scoped mirror
+    ``reports/agent_loop/active/tasks/<task_id>/...`` (the copy that ``_run_cycle_in_task_worktree``
+    makes before teardown). The re-point only rewrites the ``reports/agent_loop/active/`` prefix; a
+    path that does not sit under the active dir (defensive) falls back to ``_repo_path`` unchanged."""
+    if effective_repo_root == repo_root:
+        return _repo_path(path, repo_root)
+    rel = _repo_path(path, effective_repo_root)  # worktree-relative, e.g. reports/agent_loop/active/codex_runner.md
+    prefix = _ACTIVE_DIR_REL_POSIX + "/"
+    if rel.startswith(prefix):
+        return f"{_ACTIVE_TASKS_REL_POSIX}/{task_id}/{rel[len(prefix):]}"
+    return rel
+
+
 def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -1064,6 +1104,26 @@ class LedgerState:
         with self._lock:
             self._cycles.append(cycle)   # BY REFERENCE — caller keeps mutating it
 
+    def upsert_cycle(self, task_id: str, cycle_snapshot: dict[str, object]) -> None:
+        """Register an immutable deep-copy of a cycle's current state (ADR 0095 PR-E3c HIGH-2).
+
+        Thread-safe: called from the owner thread before every ``write_cycle_checkpoint`` so
+        ``snapshot()`` always serializes a frozen copy, never a live-mutating dict.  The find-
+        and-replace (by ``task_id``) preserves list order so X==1 serial output is identical to
+        the old ``append_cycle`` by-ref path (same single entry per task, same order).
+
+        X==1 byte-identity argument: at X==1 there is exactly one writer thread; upsert is
+        called before every ``write_cycle_checkpoint`` (same points the old by-ref append was
+        already in effect at), and the deep-copy value equals the by-ref value at that instant
+        (no concurrent mutation).  ``snapshot()`` returns ``list(self._cycles)`` as before, but
+        now each element is an immutable copy -> the serialised JSON is byte-identical."""
+        with self._lock:
+            for i, existing in enumerate(self._cycles):
+                if existing.get("task_id") == task_id:
+                    self._cycles[i] = cycle_snapshot
+                    return
+            self._cycles.append(cycle_snapshot)
+
     def extend_blockers(self, messages: Sequence[str]) -> None:
         with self._lock:
             self._blockers.extend(messages)
@@ -1096,6 +1156,74 @@ class LedgerState:
                 path,
                 json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True) + "\n",
             )
+
+    def persist_checkpoint(self, path: Path, base_payload: dict[str, object]) -> None:
+        """Atomically snapshot the ledger fields INTO ``base_payload`` and persist (ADR 0095 PR-E3c
+        MED-1). ``base_payload`` carries every NON-ledger field the caller computed (schema_version,
+        decision, config, warnings, ...); this method injects the four ledger-derived fields
+        (completed_task_ids / deferred_task_ids / cycles / blockers) and writes the file ALL UNDER A
+        SINGLE ``_lock`` acquisition. The previous two-phase ``snapshot()`` then ``persist()`` took
+        the lock twice, so under X>1 a checkpoint thread could snapshot, a sibling could upsert +
+        persist a NEWER state, and then the first thread's persist would overwrite it with its stale
+        pre-sibling payload (lost update). Folding snapshot+merge+persist into one critical section
+        removes that window.
+
+        X==1 byte-identity: with a single writer thread there is no contention, the injected fields
+        equal the old ``snapshot()`` values, and the JSON is serialised with the same
+        ``indent=2, sort_keys=True`` -> byte-identical bytes + same single ``_atomic_write_text``
+        call shape (ADR 0001). Holding the lock across the disk write matches ``persist()`` (which
+        already wrote under the lock); the brief extra hold of the snapshot read is negligible and is
+        the price of correctness under concurrency."""
+        with self._lock:
+            payload = dict(base_payload)
+            payload["completed_task_ids"] = list(self._completed)
+            payload["deferred_task_ids"] = list(self._deferred)
+            payload["cycles"] = list(self._cycles)
+            payload["blockers"] = _dedupe_preserve_order(self._blockers)
+            _atomic_write_text(
+                path,
+                json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True) + "\n",
+            )
+
+
+class _ThreadSafeWarningList(list):
+    """A ``list`` whose mutating + snapshot operations are serialized behind one in-process lock
+    (ADR 0095 PR-E3c codex round-3 MED-1).
+
+    The X-task-pool driver (``write_active_auto_loop``) shares ONE ``warnings`` list across the
+    ThreadPoolExecutor worker threads: ``run_one_task`` / ``run_repair_apply`` call
+    ``warnings.append(...)`` and the driver passes ``append_warnings=warnings.extend`` into the
+    per-task worktree lifecycle (teardown / mirror / runner warnings). Meanwhile
+    ``write_cycle_checkpoint`` (also on a worker thread) and the final state serialization READ the
+    list via ``_dedupe_preserve_order(warnings.snapshot())``. CPython's ``list.append`` is
+    individually GIL-atomic, but ``_dedupe_preserve_order`` ITERATES the list, and a concurrent
+    ``append`` / ``extend`` during that iteration is a genuine data race ("list changed size during
+    iteration" / a torn read). Guarding ``append`` / ``extend`` and exposing an atomic ``snapshot()``
+    (a locked shallow copy the reader iterates instead of the live list) closes it.
+
+    X==1 byte-identity (ADR 0001): at the dark default the pool runs the serial
+    claim -> submit -> ``future.result()`` path on ONE thread, so the lock is ALWAYS uncontended and
+    every ``append`` / ``extend`` / ``snapshot`` happens in EXACTLY the pre-change call order against
+    a plain list -> identical ordering, identical bytes. The lock only changes WHEN two threads
+    contend, which never happens at X==1."""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+        self._lock = threading.Lock()
+
+    def append(self, item: object) -> None:  # type: ignore[override]
+        with self._lock:
+            super().append(item)
+
+    def extend(self, items: "Iterable[object]") -> None:  # type: ignore[override]
+        with self._lock:
+            super().extend(items)
+
+    def snapshot(self) -> list:
+        """Return a locked shallow copy so a reader can iterate a stable list while worker threads
+        keep appending. Readers MUST use this (not the live list) for ``_dedupe_preserve_order``."""
+        with self._lock:
+            return list(self)
 
 
 DEFAULT_GLOBAL_CONCURRENCY = 8
@@ -1210,15 +1338,6 @@ def _parallelism_kill_enabled() -> bool:
     Reuses the brick-C / ack resolver truthy判정 pattern ("1"/"true"/"yes"/"on",
     case-insensitive) so all parallelism knobs agree on what "on" means."""
     return os.environ.get(PARALLELISM_KILL_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _e2_task_pool_dark_clamp_enabled() -> bool:
-    """True while the E2-dark clamp is in place (PR-E3 removes this function and its call site).
-
-    Extracted as a module-level function so tests can monkeypatch it to False to reach
-    the X>1 branch of run_task_in_worktree and verify the E3-deferred RuntimeError fires.
-    In production this always returns True (E2 ships the X task-pool substrate dark)."""
-    return True
 
 
 # X task-pool size (ADR 0095 PR-E2). Default 1 == serial == byte-identical (ADR 0001 gate);
@@ -11190,28 +11309,25 @@ def write_active_auto_loop(
             "the lease flock is a no-op (no cross-process exclusion); X>1 is unsafe without it"
         )
         task_pool_size = 1
-    # ADR 0095 PR-E2 ships the X task-pool substrate DARK: the worktree-per-task isolation
-    # (run_task_in_worktree) + ThreadPoolExecutor driver + stop_event fail-closed land here, but
-    # the real X>1 fan-out (ledger/lease reconciliation across worktrees) is gated to PR-E3. So
-    # this PR clamps the EFFECTIVE pool to 1 internally regardless of the knob — the driver runs
-    # the serial claim -> submit -> future.result() path (byte-identical, ADR 0001). The resolved
-    # ``task_pool_size`` (knob value, post kill-switch / fcntl gating) is still surfaced below so a
-    # >1 request is visibly demoted; PR-E3 removes this clamp to enable real concurrency.
-    e2_dark_clamp_warning: str | None = None
+    # ADR 0095 PR-E3c enables the real X>1 fan-out: the resolved ``task_pool_size`` (knob value,
+    # post kill-switch / fcntl gating) is used directly as the effective pool. The worktree-per-task
+    # isolation (run_task_in_worktree -> _run_cycle_in_task_worktree) + ThreadPoolExecutor driver +
+    # stop_event fail-closed drive real concurrency at X>1; at X=1 the driver runs the serial claim
+    # -> submit -> future.result() path with NO worktree (byte-identical, ADR 0001). PR-E2 shipped
+    # this substrate DARK behind an effective-pool clamp; PR-E3c removes that clamp.
     effective_task_pool_size = task_pool_size
-    if effective_task_pool_size > 1 and _e2_task_pool_dark_clamp_enabled():
-        e2_dark_clamp_warning = (
-            f"task pool requested {effective_task_pool_size} but ADR 0095 PR-E2 ships the X "
-            "task-pool substrate dark; running serially (X=1). PR-E3 enables X>1 fan-out"
-        )
-        effective_task_pool_size = 1
     out_path = _active_path(out, repo_root=repo_root)
     state_path = _active_path(state, repo_root=repo_root)
-    prior_completed, prior_deferred, warnings = _load_active_auto_ledger(state_path)
+    prior_completed, prior_deferred, _prior_warnings = _load_active_auto_ledger(state_path)
+    # ADR 0095 PR-E3c codex round-3 MED-1: the X>1 ThreadPoolExecutor workers share THIS warnings
+    # list (run_one_task/run_repair_apply append; the worktree-lifecycle append_warnings extends),
+    # while write_cycle_checkpoint + the final serialization read it. Wrap it in a lock-guarded list
+    # (append/extend serialized, atomic snapshot for the readers) so a concurrent append during the
+    # reader's _dedupe_preserve_order iteration cannot tear/raise. At X==1 the single serial worker
+    # never contends the lock and the call order is unchanged -> byte-identical (ADR 0001).
+    warnings = _ThreadSafeWarningList(_prior_warnings)
     if fcntl_clamp_warning is not None:
         warnings.append(fcntl_clamp_warning)
-    if e2_dark_clamp_warning is not None:
-        warnings.append(e2_dark_clamp_warning)
     ledger = LedgerState(completed=prior_completed, deferred=prior_deferred)
     completed = ledger.completed
     deferred_task_ids = ledger.deferred
@@ -11222,6 +11338,22 @@ def write_active_auto_loop(
     # gates every autotune side effect below so off-mode stays byte-identical (AC1/R4).
     if lane_autotune_config is None:
         lane_autotune_config = _resolve_lane_autotune_config()
+    # ADR 0095 PR-E3c MED-2: lane-autotune is nondeterministic under X>1. Concurrent cycles read the
+    # SAME live `cycles` history and mutate the shared pending_effort_overrides / lane_autotune_cooldown
+    # / lane_autotune_recommendations with last-writer-wins timing, so the controller's output depends
+    # on the (undefined) order in which parallel tasks finish their runner work. A lock would remove the
+    # data race but NOT the nondeterminism (the read-order itself is timing-dependent). Since autotune is
+    # opt-in and there is no defined cross-task ordering, the lower-risk correct fix is to DISABLE it at
+    # X>1 with a one-time advisory, forcing lane_autotune_config=None so all four autotune gates (prior-
+    # stats load, runner compute/update, checkpoint emit, final emit) stay off. At X==1 this branch never
+    # runs (effective_task_pool_size == 1), so autotune executes EXACTLY as today -> byte-identical (ADR 0001).
+    if lane_autotune_config is not None and effective_task_pool_size > 1:
+        warnings.append(
+            "lane-autotune disabled for this run: the X task-pool (effective_task_pool_size="
+            f"{effective_task_pool_size}) has no deterministic cross-task ordering for the controller "
+            "history/effort-override state (ADR 0095 PR-E3c MED-2)"
+        )
+        lane_autotune_config = None
     # Cross-run lane-stats history (oldest first) seeds the controller window so fail_rate
     # spans prior runs, not just this run's iterations. Only read when autotune is ON.
     prior_lane_stats: list[list[dict[str, object]]] = []
@@ -11300,7 +11432,11 @@ def write_active_auto_loop(
     max_attempts = max(1, max_iterations, int(auto_max_iterations_cap))
 
     def write_cycle_checkpoint(decision: str) -> None:
-        snap = ledger.snapshot()
+        # ADR 0095 PR-E3c MED-1: build only the NON-ledger payload here; the four ledger-derived
+        # fields (completed_task_ids / deferred_task_ids / cycles / blockers) are injected by
+        # ledger.persist_checkpoint UNDER ONE LOCK together with the disk write, so a concurrent
+        # sibling upsert+persist cannot be clobbered by a stale snapshot (lost update). At X==1 the
+        # single writer makes this byte-identical to the old snapshot()+persist() path (ADR 0001).
         checkpoint_payload = {
             "schema_version": 1,
             "generated_at": _isoformat(datetime.now(timezone.utc)),
@@ -11315,19 +11451,18 @@ def write_active_auto_loop(
             "target_completed_count": target_completed_count,
             "max_attempts": max_attempts,
             "max_iterations_reason": limit_reason,
-            "completed_task_ids": snap["completed_task_ids"],
-            "deferred_task_ids": snap["deferred_task_ids"],
             "next_task_id": None,
-            "cycles": snap["cycles"],
-            "blockers": snap["blockers"],
-            "warnings": _dedupe_preserve_order(warnings),
+            # codex round-3 MED-1: read via the atomic locked snapshot — this checkpoint builder runs
+            # ON the worker threads (write_cycle_checkpoint is called inside run_one_task), so iterating
+            # the live shared list while a sibling appends would race. snapshot() iterates a stable copy.
+            "warnings": _dedupe_preserve_order(warnings.snapshot()),
         }
         # ADR 0092 (AC8/AC13): only emit the recommendations + cooldown_state keys when
         # autotune is ON, so the checkpoint payload is byte-identical to today when OFF.
         if lane_autotune_config is not None:
             checkpoint_payload["lane_autotune_recommendations"] = lane_autotune_recommendations
             checkpoint_payload["lane_autotune_cooldown"] = lane_autotune_cooldown
-        ledger.persist(state_path, checkpoint_payload)
+        ledger.persist_checkpoint(state_path, checkpoint_payload)
 
     # Infinite-mode safety state. ``consecutive_blockers`` is reset to zero on every
     # completion so a long-running drain is only aborted by an *unbroken* streak of
@@ -11398,6 +11533,7 @@ def write_active_auto_loop(
         completion_decision: str,
         coordination_root: Path | None = None,
         lease_id: str | None = None,
+        artifact_root: Path | None = None,
     ) -> bool:
         """Auto-repair apply lane (ADR 0095 PR-E2 Finding 1).
 
@@ -11405,18 +11541,30 @@ def write_active_auto_loop(
         ``complete_if_not_stopped`` so a sibling's stop_event blocks spurious promotion here too.
         ADR 0095 PR-E3a threads ``coordination_root`` into the patch lane (the lease-bearing
         ``write_active_codex_runner`` call); the apply lane (``write_active_apply``) + patch
-        artifact stay on ``repo_root`` (artifacts). ``coordination_root=None`` -> repo_root keeps
+        artifact stay on the ARTIFACT root. ``coordination_root=None`` -> repo_root keeps
         X==1 byte-identical (ADR 0001). ADR 0095 PR-E3b additionally threads this cycle's own
         ``lease_id`` into that patch lane so the repair write-lane borrows THIS cycle's lease, not
-        first-match; ``lease_id=None`` (X=1) keeps the first-match path -> byte-identical."""
+        first-match; ``lease_id=None`` (X=1) keeps the first-match path -> byte-identical.
+        ADR 0095 PR-E3c HIGH-1: ``artifact_root`` separates artifact writes (patch runner output,
+        write_active_apply, patch_artifact.json path) from the coordination root.
+        ``artifact_root=None`` -> ``repo_root`` keeps X==1 byte-identical."""
         repair_coord = coordination_root or repo_root
+        effective_artifact_root = artifact_root or repo_root
 
         def run_patch(agent_choice: str) -> ActiveCodexRunnerResult:
-            # ADR 0095 PR-E3a/E3b: only forward coordination_root + lease_id when the coord differs
-            # from repo_root (X>1) so the X==1 patch-lane call stays textually identical
-            # (byte-identical). lease_id is folded into the same X>1 gate.
+            # ADR 0095 PR-E3c HIGH-2: forward coordination_root + lease_id whenever the ARTIFACT root
+            # diverges from the COORD root (effective_artifact_root != repair_coord) OR an explicit
+            # artifact_root was passed (artifact_root is not None). After E3c the X>1 caller threads
+            # coordination_root=PARENT repo_root, so repair_coord == repo_root and the old
+            # ``repair_coord != repo_root`` gate was FALSE — leaving coordination_root/lease_id
+            # UN-forwarded while repo_root=worktree (effective_artifact_root) made lease reads resolve
+            # to the torn-down cycle worktree instead of the shared parent lease file. Both new
+            # conditions key off the artifact↔coord split, which is exactly the X>1 signal.
+            # X==1 byte-identity: artifact_root=None -> effective_artifact_root == repo_root AND
+            # coordination_root=None -> repair_coord == repo_root, so effective_artifact_root ==
+            # repair_coord AND artifact_root is None -> gate FALSE -> textually identical call (ADR 0001).
             patch_coord_kwargs: dict[str, object] = {}
-            if repair_coord != repo_root:
+            if effective_artifact_root != repair_coord or artifact_root is not None:
                 patch_coord_kwargs["coordination_root"] = repair_coord
                 if lease_id is not None:
                     patch_coord_kwargs["lease_id"] = lease_id
@@ -11429,7 +11577,7 @@ def write_active_auto_loop(
                 write_agent=agent_choice,
                 timeout_seconds=effective_subprocess_timeout(),
                 record_gate_heartbeats=False,
-                repo_root=repo_root,
+                repo_root=effective_artifact_root,
                 mode="patch",
                 task_id=task.task_id,
                 state=DEFAULT_ACTIVE_AUTO_REPAIR_STATE,
@@ -11453,17 +11601,20 @@ def write_active_auto_loop(
             repair = run_patch(fallback_agent)
             cycle["repair_fallback_agent"] = fallback_agent
         cycle["repair_decision"] = repair.decision
-        cycle["repair_report"] = _repo_path(repair.report_path, repo_root)
+        # ADR 0095 PR-E3c MED-3: re-point repair/apply artifact paths to the parent task mirror so
+        # they survive cycle-worktree teardown at X>1. At X==1 effective_artifact_root == repo_root
+        # -> _repo_path(..., repo_root) -> byte-identical (ADR 0001).
+        cycle["repair_report"] = _cycle_artifact_repo_path(repair.report_path, effective_repo_root=effective_artifact_root, repo_root=repo_root, task_id=task.task_id)
         cycle["repair_status"] = repair.decision
         cycle["completion_decision"] = completion_decision
         if repair.decision == "completed":
-            apply_result = write_active_apply(execute=True, repo_root=repo_root)
+            apply_result = write_active_apply(execute=True, repo_root=effective_artifact_root)
             cycle["apply_decision"] = apply_result.decision
-            cycle["apply_report"] = _repo_path(apply_result.report_path, repo_root)
+            cycle["apply_report"] = _cycle_artifact_repo_path(apply_result.report_path, effective_repo_root=effective_artifact_root, repo_root=repo_root, task_id=task.task_id)
             cycle["apply_integration_branch"] = apply_result.integration_branch
             cycle["apply_applied"] = apply_result.applied
             if apply_result.applied:
-                patch_path = repo_root / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+                patch_path = effective_artifact_root / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
                 if _patch_declares_blocked_handoff(patch_path):
                     cycle["completion_decision"] = "repair-applied-blocked-handoff"
                     cycle["completed"] = False
@@ -11471,6 +11622,7 @@ def write_active_auto_loop(
                     warnings.append(
                         f"{task.task_id}: repair patch only recorded a blocked handoff; deferred for another repair cycle"
                     )
+                    ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                     write_cycle_checkpoint("running")
                     return False
                 cycle["completion_decision"] = "repair-applied"
@@ -11478,9 +11630,20 @@ def write_active_auto_loop(
                 # is the THIRD terminal completion site; route through the helper so a sibling's
                 # stop_event prevents spurious promotion here too. At X==1 always returns True.
                 if not complete_if_not_stopped(task.task_id):
+                    # codex round-3 MED-2: completion was DENIED (a sibling set stop_event), but this
+                    # cycle has already mutated repair_decision/repair_report/repair_status/
+                    # completion_decision/apply_* in place. The early return skips the post-completion
+                    # upsert_cycle below, so without this snapshot the immutable ledger would keep the
+                    # STALE pre-repair copy. Persist the work-done (non-completed) cycle before
+                    # returning (run_repair_apply is defined ABOVE run_one_task, so _snapshot_cycle is
+                    # not in scope here — upsert directly, same shape as the success path below).
+                    # X==1: complete_if_not_stopped ALWAYS returns True (stop_event is never set
+                    # mid-cycle), so this branch is DEAD at X=1 -> byte-identical (ADR 0001).
+                    ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                     return False
                 cycle["completed"] = True
                 warnings.append(f"{task.task_id}: repair patch applied; recorded repair-applied completion")
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 return True
             if apply_result.blockers:
@@ -11737,7 +11900,14 @@ def write_active_auto_loop(
             "completed": False,
             "retry_deferred": retrying_deferred,
         }
-        ledger.append_cycle(cycle)
+        # ADR 0095 PR-E3c HIGH-2: define a helper that snapshots the CURRENT cycle state into
+        # the ledger. Called (a) once right now (initial registration so ALL exit paths see a
+        # cycle entry), and (b) before every write_cycle_checkpoint (mid-run X>1 safety). At X=1
+        # the value equals the by-ref mutable at every call point -> byte-identical (ADR 0001).
+        def _snapshot_cycle() -> None:
+            ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
+
+        _snapshot_cycle()  # initial registration
 
         start = write_active_start(
             mode=mode,
@@ -11767,14 +11937,30 @@ def write_active_auto_loop(
         # / coord). EMPTY at X=1 so the runner + ship calls stay textually the lease_id=None /
         # default-reject path -> first-match / unconditional-write -> byte-identical (ADR 0001).
         runner_lease_kwargs: dict[str, object] = {}
+        repair_lease_kwargs: dict[str, object] = {}
         ship_reject_kwargs: dict[str, object] = {}
         if effective_repo_root != repo_root:
             if cycle_lease_id is not None:
                 runner_lease_kwargs["lease_id"] = cycle_lease_id
+                repair_lease_kwargs["lease_id"] = cycle_lease_id
+            # ADR 0095 PR-E3c HIGH-1 (codex round-3 fix): artifact_root threads the cycle worktree
+            # so repair patch artifacts (run_patch output, write_active_apply, patch_artifact.json)
+            # land inside the per-task worktree, NOT the shared parent repo. It belongs ONLY to the
+            # repair lane (run_repair_apply has the param); write_active_codex_runner has NO
+            # artifact_root parameter, so the runner call must keep the lease_id-only dict — passing
+            # artifact_root there would TypeError at X>1. Hence two separate kwargs dicts. BOTH stay
+            # EMPTY at X=1 (gate false) -> runner+repair calls take the default path -> byte-identical.
+            repair_lease_kwargs["artifact_root"] = effective_repo_root
             ship_reject_kwargs["reject_on_overlap"] = True
         cycle["start_decision"] = start.decision
-        cycle["start_report"] = _repo_path(start.report_path, effective_repo_root)
+        # ADR 0095 PR-E3c MED-3: record artifact paths so they survive cycle-worktree teardown at X>1
+        # (re-pointed to the parent task mirror). At X==1 this == _repo_path(..., repo_root) -> byte-identical.
+        cycle["start_report"] = _cycle_artifact_repo_path(start.report_path, effective_repo_root=effective_repo_root, repo_root=repo_root, task_id=task.task_id)
         if start.blockers:
+            # codex round-3 HIGH-2: HEAD never set a completion_decision on the start-blocker path,
+            # so adding one breaks X=1 byte-identity (extra cycles[] key). Snapshot only the
+            # pre-existing start_decision/start_report fields (round-2 HIGH-1 fix) -> byte-identical.
+            _snapshot_cycle()
             if register_task_blocker(task, [f"{task.task_id}: {item}" for item in start.blockers]):
                 stop_event.set()
                 return
@@ -11783,11 +11969,12 @@ def write_active_auto_loop(
             cycle["gate_tier"] = "start-blocked"
             cycle["completion_decision"] = "start-blocked"
             if auto_repair:
-                applied = run_repair_apply(cycle, task, completion_decision="start-repair-needed", coordination_root=effective_coord_root, **runner_lease_kwargs)
+                applied = run_repair_apply(cycle, task, completion_decision="start-repair-needed", coordination_root=effective_coord_root, **repair_lease_kwargs)
                 warnings.append(
                     f"{task.task_id}: active-start/active-loop blocked without explicit blockers; routed to patch repair lane"
                     + (" and completed by repair apply" if applied else " and deferred")
                 )
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 if applied:
                     return
@@ -11799,6 +11986,7 @@ def write_active_auto_loop(
                     stop_event.set()
                     return
                 return
+            _snapshot_cycle()
             if register_task_blocker(task, [f"{task.task_id}: active-start/active-loop decision was blocked"]):
                 stop_event.set()
                 return
@@ -11828,7 +12016,7 @@ def write_active_auto_loop(
             **runner_lease_kwargs,
         )
         cycle["runner_decision"] = runner.decision
-        cycle["runner_report"] = _repo_path(runner.report_path, effective_repo_root)
+        cycle["runner_report"] = _cycle_artifact_repo_path(runner.report_path, effective_repo_root=effective_repo_root, repo_root=repo_root, task_id=task.task_id)
         # ADR 0092 (B2 wiring, AC3): capture per-lane timing/status from the runner so the
         # opt-in controller can sense within-agent bottlenecks on the NEXT iteration. Gated on
         # the autotune config so the auto_loop_state.json stays byte-identical when OFF.
@@ -11847,6 +12035,11 @@ def write_active_auto_loop(
             # this cycle) and the carried cooldown_state to the PURE controller. PR2 returns the
             # effort overrides to apply on the NEXT iteration's runner call + the decremented
             # cooldown_state, both threaded forward via the loop-level mutables below.
+            # ADR 0095 PR-E3c HIGH-2: the ledger now holds immutable deep-copies (upsert_cycle),
+            # so the current cycle's lane_stats is NOT yet registered (no upsert has run since
+            # the lane_stats write above). Append the current cycle's lane_stats explicitly so
+            # compute_lane_autotune sees the same history as the old by-ref path.
+            current_lane_stats = cycle.get("lane_stats")
             history = [
                 *prior_lane_stats,
                 *(
@@ -11854,6 +12047,7 @@ def write_active_auto_loop(
                     for prior_cycle in cycles
                     if isinstance(prior_cycle.get("lane_stats"), list)
                 ),
+                *(([list(current_lane_stats)] if isinstance(current_lane_stats, list) else [])),
             ]
             (
                 next_effort_overrides,
@@ -11880,11 +12074,12 @@ def write_active_auto_loop(
         if execute_runner and runner.decision != "completed":
             cycle["gate_tier"] = "runner-blocked"
             if auto_repair:
-                applied = run_repair_apply(cycle, task, completion_decision="runner-repair-needed", coordination_root=effective_coord_root, **runner_lease_kwargs)
+                applied = run_repair_apply(cycle, task, completion_decision="runner-repair-needed", coordination_root=effective_coord_root, **repair_lease_kwargs)
                 warnings.append(
                     f"{task.task_id}: runner did not complete ({runner.decision}); routed to patch repair lane"
                     + (" and completed by repair apply" if applied else " and deferred")
                 )
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 if applied:
                     return
@@ -11899,6 +12094,12 @@ def write_active_auto_loop(
             runner_messages = [f"{task.task_id}: runner {item}" for item in runner.blockers]
             if not runner.blockers:
                 runner_messages.append(f"{task.task_id}: runner decision was {runner.decision}, expected completed")
+            # ADR 0095 PR-E3c HIGH-1: publish the runner-blocked mutations (runner_decision /
+            # runner_report / gate_tier / lane_autotune) to the ledger BEFORE the terminal blocker,
+            # so the final snapshot()-backed cycles carry them. The old append_cycle by-ref path
+            # captured these automatically; with immutable upsert deep-copies they must be snapshotted
+            # explicitly. X==1 byte-identical: equals the by-ref value at this instant (ADR 0001).
+            _snapshot_cycle()
             if register_task_blocker(task, runner_messages):
                 stop_event.set()
                 return
@@ -11909,7 +12110,7 @@ def write_active_auto_loop(
             changed_files=context_files,
             repo_root=effective_repo_root,
         )
-        cycle["gate_evidence"] = _repo_path(evidence_path, effective_repo_root)
+        cycle["gate_evidence"] = _cycle_artifact_repo_path(evidence_path, effective_repo_root=effective_repo_root, repo_root=repo_root, task_id=task.task_id)
         cycle["gate_ready"] = bool(gate_summary.get("ready"))
         cycle["privacy_clean"] = bool(gate_summary.get("privacy_clean"))
         cycle["gate_tier"] = "ready" if cycle["gate_ready"] and cycle["privacy_clean"] else "repairable"
@@ -11929,9 +12130,16 @@ def write_active_auto_loop(
                 # stop_event is set (a sibling's blocker already stopped the run). At X==1 the
                 # event is never set mid-cycle -> helper always returns True -> byte-identical.
                 if not complete_if_not_stopped(task.task_id):
+                    # codex round-3 MED-2: completion DENIED (sibling stop_event). The cycle already
+                    # carries gate_evidence/gate_ready/privacy_clean/gate_tier + completion_decision;
+                    # the early return skips the success-path upsert_cycle below, so snapshot the
+                    # work-done (non-completed) cycle before returning. DEAD at X=1 (helper always
+                    # True) -> byte-identical (ADR 0001).
+                    _snapshot_cycle()
                     return
                 cycle["completed"] = True
                 warnings.append(f"{task.task_id}: ship execution disabled; recorded local gate completion")
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 return
             if (
@@ -11940,11 +12148,12 @@ def write_active_auto_loop(
                 and runner.decision == "completed"
                 and cycle["privacy_clean"]
             ):
-                applied = run_repair_apply(cycle, task, completion_decision="repair-needed", coordination_root=effective_coord_root, **runner_lease_kwargs)
+                applied = run_repair_apply(cycle, task, completion_decision="repair-needed", coordination_root=effective_coord_root, **repair_lease_kwargs)
                 warnings.append(
                     f"{task.task_id}: conservative gate not ready; routed to patch repair lane"
                     + (" and completed by repair apply" if applied else " and deferred")
                 )
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 if applied:
                     return
@@ -11957,6 +12166,7 @@ def write_active_auto_loop(
                     return
                 return
             warnings.append(f"{task.task_id}: ship execution disabled; not marking task completed")
+            _snapshot_cycle()
             if not infinite_mode:
                 stop_event.set()
                 return
@@ -11968,11 +12178,12 @@ def write_active_auto_loop(
             return
         if not cycle["gate_ready"]:
             if auto_repair and cycle["privacy_clean"]:
-                applied = run_repair_apply(cycle, task, completion_decision="repair-needed", coordination_root=effective_coord_root, **runner_lease_kwargs)
+                applied = run_repair_apply(cycle, task, completion_decision="repair-needed", coordination_root=effective_coord_root, **repair_lease_kwargs)
                 warnings.append(
                     f"{task.task_id}: conservative gate not ready; routed to patch repair lane"
                     + (" and completed by repair apply" if applied else " and deferred")
                 )
+                ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
                 write_cycle_checkpoint("running")
                 if applied:
                     return
@@ -11984,6 +12195,11 @@ def write_active_auto_loop(
                     stop_event.set()
                     return
                 return
+            # ADR 0095 PR-E3c HIGH-1: publish the gate-not-ready mutations (gate_evidence / gate_ready
+            # / privacy_clean / gate_tier) to the ledger BEFORE the terminal blocker so the final
+            # snapshot()-backed cycles carry them (the by-ref append used to capture them implicitly).
+            # X==1 byte-identical: equals the by-ref value at this instant (ADR 0001).
+            _snapshot_cycle()
             if register_task_blocker(task, [f"{task.task_id}: conservative gate is not ready"]):
                 stop_event.set()
                 return
@@ -12010,11 +12226,16 @@ def write_active_auto_loop(
             **ship_reject_kwargs,
         )
         cycle["ship_decision"] = ship.decision
-        cycle["ship_report"] = _repo_path(ship.report_path, effective_repo_root)
+        cycle["ship_report"] = _cycle_artifact_repo_path(ship.report_path, effective_repo_root=effective_repo_root, repo_root=repo_root, task_id=task.task_id)
         if ship.decision != "executed":
             ship_messages = [f"{task.task_id}: ship {item}" for item in ship.blockers]
             if not ship.blockers:
                 ship_messages.append(f"{task.task_id}: ship decision was {ship.decision}, expected executed")
+            # ADR 0095 PR-E3c HIGH-1: publish the ship-blocked mutations (ship_decision / ship_report)
+            # to the ledger BEFORE the terminal blocker so the final snapshot()-backed cycles carry
+            # them (the by-ref append used to capture them implicitly). X==1 byte-identical: equals the
+            # by-ref value at this instant (ADR 0001).
+            _snapshot_cycle()
             if register_task_blocker(task, ship_messages):
                 stop_event.set()
                 return
@@ -12023,45 +12244,67 @@ def write_active_auto_loop(
         # FAIL-CLOSED via complete_if_not_stopped (ADR 0095 PR-E2 Finding 1): route through the
         # shared helper so ALL three terminal completion sites share one guard. Invisible at X==1.
         if not complete_if_not_stopped(task.task_id):
+            # codex round-3 MED-2: completion DENIED (sibling stop_event). The cycle already carries
+            # ship_decision/ship_report (just written above); the early return skips the success-path
+            # upsert_cycle below, so snapshot the work-done (non-completed) cycle before returning.
+            # DEAD at X=1 (helper always True) -> byte-identical (ADR 0001).
+            _snapshot_cycle()
             return
         cycle["completed"] = True
+        ledger.upsert_cycle(task.task_id, copy.deepcopy(cycle))
         write_cycle_checkpoint("running")
 
     def run_task_in_worktree(task: "TaskEntry", iteration: int, retrying_deferred: bool) -> None:
-        """Run one task cycle (ADR 0095 PR-E2).
+        """Run one task cycle (ADR 0095 PR-E2 substrate, PR-E3c fan-out).
 
-        At ``effective_task_pool_size == 1`` (the E2 dark default): calls ``run_one_task`` directly.
+        At ``effective_task_pool_size == 1`` (the dark default): calls ``run_one_task`` directly.
         No worktree is created, ``repo_root`` is ROOT_DIR (the plain closure), byte-identical
         (ADR 0001).
 
-        At ``effective_task_pool_size > 1`` (PR-E3 scope): raises an explicit E3-deferred
-        ``RuntimeError`` documenting the work-list. The E2-dark clamp makes this branch unreachable
-        at runtime; the raise makes the boundary visible in code and is caught by a unit test.
-
-        NOTE: the worktree lifecycle primitive (_run_cycle_in_task_worktree / create / teardown) is
-        already unit-tested at the module level; PR-E3 will wire it here once leases coordination_root
-        (write+read+acquire+release), parent branch/issue inheritance for cycle worktrees, and
-        overlap-preflight root-awareness are also resolved."""
+        At ``effective_task_pool_size > 1`` (PR-E3c fan-out): delegates to
+        ``_run_cycle_in_task_worktree`` which isolates the cycle in a per-task ``agent/<task>/cycle``
+        worktree and runs ``run_cycle`` (a closure that calls ``run_one_task`` with the two-root
+        params: cycle_repo_root = the worktree, coordination_root = the PARENT ROOT_DIR for leases,
+        plus the captured parent branch/issue for cycle-worktree inheritance — E3a/E3b). The
+        global-concurrency permit for the worktree create is acquired INSIDE
+        ``_run_cycle_in_task_worktree`` (around the create only), so the driver must NOT acquire it
+        here (no double charge)."""
         if effective_task_pool_size <= 1:
             # X==1 dark default: plain cycle, no worktree, no rebinding — byte-identical (ADR 0001).
             run_one_task(task, iteration, retrying_deferred)
             return
 
-        # --- X>1 fan-out: explicitly deferred to PR-E3 ------------------------------------------
-        # E3 work-list (codex round-2 HIGH findings):
-        #   • leases coordination_root: write_active_loop/write_active_start AND
-        #     read (_load_active_leases), acquire_active_agent, release_active_agent — ALL must use
-        #     the parent root so cross-task lease overlap is visible.
-        #   • parent branch/issue inheritance: cycle worktrees created from main (origin/main),
-        #     NOT the current branch, to avoid branch-tied issue metadata leaking into sibling tasks.
-        #   • overlap-preflight root-awareness: build_overlap_preflight must query the parent root.
-        #   • two-root threading: cycle_repo_root (artifacts) + coordination_root (leases) explicitly
-        #     passed through run_one_task / run_repair_apply / write_active_start / write_active_loop.
-        #   • claim_disjoint REJECT: first-writer-wins rejection (currently REPORT-only).
-        raise RuntimeError(
-            "X>1 task-pool fan-out is not enabled in PR-E2; PR-E3 wires leases coordination_root "
-            "(write+read+acquire+release), parent branch/issue inheritance for cycle worktrees, and "
-            "overlap-preflight root-awareness"
+        # --- X>1 fan-out (PR-E3c): isolate this cycle in a per-task worktree -----------------------
+        # run_cycle threads the two roots + parent branch/issue (E3a/E3b) into run_one_task so the
+        # cycle's artifacts land in the worktree while leases/coordination stay on the PARENT root.
+        # HIGH-3 (ADR 0095 PR-E3c codex review): use the closure ``repo_root`` (write_active_auto_loop
+        # parameter) rather than the module-level ROOT_DIR constant so non-CLI callers that pass an
+        # alternate root (tests, integration harnesses) get the correct coordination + parent root.
+        # On the CLI path repo_root == ROOT_DIR, so production behavior is unchanged.
+        def run_cycle(cycle_path: "Path") -> None:
+            run_one_task(
+                task,
+                iteration,
+                retrying_deferred,
+                cycle_repo_root=cycle_path,
+                coordination_root=repo_root,
+                parent_branch=parent_branch,
+                parent_issue=parent_issue,
+            )
+
+        # register_blocker adapter: _run_cycle_in_task_worktree expects Callable[[list[str]], bool];
+        # register_task_blocker is (task, messages) -> bool, so bind the task. on_stop mirrors
+        # stop_event.set() (no args); append_warnings extends the driver's warnings list. The git
+        # subprocess runner is left at the production default (None -> real `git worktree` spawn),
+        # matching create_task_cycle_worktree's own default.
+        _run_cycle_in_task_worktree(
+            task.task_id,
+            parent_root=repo_root,
+            run_cycle=run_cycle,
+            register_blocker=lambda messages: register_task_blocker(task, messages),
+            on_stop=stop_event.set,
+            append_warnings=lambda ws: warnings.extend(ws),
+            git_runner=None,
         )
 
     # X task-pool driver (ADR 0095 PR-E2). ``ThreadPoolExecutor(max_workers=effective_task_pool_size)``.
@@ -12102,6 +12345,33 @@ def write_active_auto_loop(
                 break
             if wall_clock_guard_tripped():
                 break
+            # ADR 0095 PR-E3c HIGH-3: bounded-mode overrun guard. At X>1, in-flight futures MIGHT each
+            # complete one task; while ``completed + in_flight`` could still satisfy the target we
+            # PAUSE new claims so the pool never over-claims past the target. But an in-flight future
+            # may DEFER instead of completing (e.g. a failed repair), so we must NOT treat in-flight
+            # work as a GUARANTEED completion and exit with an unmet target: instead of an
+            # unconditional break we drain ONE in-flight future and re-loop. After the drain, either
+            # ``completed`` reached the target (the loop_should_continue() check at the top breaks
+            # cleanly) OR the drained future deferred and the guard relaxes (completed + in_flight <
+            # target) so the next ready task is claimed. Only break for good when there is genuinely
+            # no in-flight work left to wait on (then ``completed >= target`` already, since
+            # in_flight==0 makes the guard condition collapse to completed >= target — which
+            # loop_should_continue() caught at the top). At X==1 in_flight is ALWAYS empty when this
+            # runs (serial path waits on each future before the next claim) AND
+            # loop_should_continue() already broke at ``completed >= target`` BEFORE this guard, so the
+            # guard is fully dead -> byte-identical (ADR 0001). Applies only with an explicit target.
+            if (not infinite_mode or explicit_target_completed_count) and target_completed_count is not None:
+                if len(completed) + len(in_flight) >= target_completed_count:
+                    if in_flight:
+                        # Wait for at least one in-flight task, then re-evaluate the target with the
+                        # updated completed/in_flight counts (never abandons an unmet target).
+                        done, in_flight = wait(in_flight, return_when=FIRST_COMPLETED)
+                        for fut in done:
+                            fut.result()
+                            check_task_budget(fut)
+                        continue
+                    # No in-flight work: the target is genuinely met (completed >= target); exit.
+                    break
             claimed = claim_next_task()
             if claimed is None:
                 break
@@ -12226,7 +12496,9 @@ def write_active_auto_loop(
         "learning_capture_advisory": learning_advisory,
         "adr_lifecycle_advisory": adr_lifecycle_advisory,
         "blockers": snap["blockers"],
-        "warnings": _dedupe_preserve_order(warnings),
+        # codex round-3 MED-1: the pool has joined here (no concurrent appends), but read via the
+        # locked snapshot uniformly with the checkpoint reader. Uncontended at X==1 -> byte-identical.
+        "warnings": _dedupe_preserve_order(warnings.snapshot()),
     }
     # ADR 0092 (AC8/AC13): emit recommendations + cooldown_state on the terminal state write
     # too (this block, not write_cycle_checkpoint, is the final state file). The persisted
@@ -12250,7 +12522,8 @@ def write_active_auto_loop(
         completed_task_ids=completed,
         next_task=next_task,
         blockers=tuple(_dedupe_preserve_order(blockers)),
-        warnings=tuple(_dedupe_preserve_order(warnings)),
+        # codex round-3 MED-1: locked-snapshot read (uniform with the other readers; pool joined).
+        warnings=tuple(_dedupe_preserve_order(warnings.snapshot())),
         state_path=state_path,
         repo_root=repo_root,
     )
@@ -12282,7 +12555,8 @@ def write_active_auto_loop(
         completed_task_ids=tuple(completed),
         next_task_id=next_task.task_id if next_task else None,
         blockers=tuple(_dedupe_preserve_order(blockers)),
-        warnings=tuple(_dedupe_preserve_order(warnings)),
+        # codex round-3 MED-1: locked-snapshot read (uniform with the other readers; pool joined).
+        warnings=tuple(_dedupe_preserve_order(warnings.snapshot())),
     )
 
 
@@ -17852,6 +18126,116 @@ def teardown_task_cycle_worktree(
     return warnings
 
 
+def _mirror_cycle_artifacts_to_parent(
+    task_id: str, cycle_path: Path, parent_root: Path
+) -> tuple[bool, list[str]]:
+    """TRANSACTIONALLY copy the cycle worktree's ``reports/agent_loop/active`` tree into a parent
+    task-scoped mirror ``<parent>/reports/agent_loop/active/tasks/<task_id>`` BEFORE the worktree is
+    torn down (ADR 0095 PR-E3c MED-3 + codex round-3 HIGH-3). Without this the X>1 cycle dict records
+    artifact paths that only existed inside the now-deleted worktree (dead references in the parent
+    ``auto_loop_state.json``); the mirror makes those re-pointed ``…/active/tasks/<task_id>/…`` paths
+    actually resolve.
+
+    Promotion is staged + backup/rollback so the live ``dst`` is never left half-written or (when a prior
+    mirror existed) missing on failure:
+      1. copy the cycle tree into a sibling ``…/<task_id>.mirror-tmp`` staging dir (``dst`` untouched if
+         this fails -> no dangle);
+      2. if a prior mirror exists at ``dst`` (only ever a STALE leftover from a PRIOR run -- a task_id is
+         claimed at most once per run, so this is never a same-run concurrent write) move it ASIDE to
+         ``…/<task_id>.mirror-bak`` via atomic rename;
+      3. rename staging into ``dst`` (atomic); on failure RESTORE the prior to ``dst`` by ATOMIC RENAME
+         only (NOT a copytree fallback -- codex round-6 HIGH: a non-atomic copy can leave a partial dst
+         that masquerades as recovery and gets the clean backup deleted). ``dst`` is left missing ONLY
+         under catastrophic FS failure that also defeats the rename-back; that residual is SURFACED in the
+         returned warning (the prior copy stays at ``…/<task_id>.mirror-bak`` and the message names it for
+         manual recovery) -- NEVER silently swallowed (codex round-5 HIGH: the earlier ``except: pass``
+         could leave ``dst`` missing with no signal);
+      4. drop the backup only AFTER a successful promote (best-effort -- a stale backup left by a cleanup
+         hiccup is harmless and reclaimed next run; it must not fail an otherwise-successful promote).
+    The vacate->promote window is the irreducible cost of replacing a non-empty directory on POSIX without
+    ``RENAME_EXCHANGE`` (codex round-4 HIGH: the earlier ``rmtree(dst)`` then ``os.replace`` order lost the
+    prior mirror outright if the replace raised between them).
+
+    The nested ``tasks/`` subtree is excluded so the parent-mirror namespace is never recursively copied
+    into a child cycle's mirror. Never raises. Returns ``(ok, warnings)``: ``ok`` is True when the mirror
+    is fully promoted (safe to tear the worktree down) OR when there were no artifacts to mirror (nothing
+    to lose); False when promotion failed -- the caller then FAILS CLOSED (records a blocker + preserves
+    the worktree instead of tearing it down)."""
+    src = cycle_path / _ACTIVE_DIR_REL_POSIX
+    if not src.is_dir():
+        # No artifacts were produced in this cycle -> nothing to mirror, nothing to lose -> ok.
+        return True, []
+    dst = _task_artifact_mirror_dir(parent_root, task_id)
+    staging = dst.with_name(dst.name + ".mirror-tmp")
+    backup = dst.with_name(dst.name + ".mirror-bak")
+
+    def _rm(path: Path) -> None:
+        # Best-effort recursive remove; cleanup must never mask the original failure.
+        try:
+            if path.exists():
+                shutil.rmtree(path)
+        except OSError:
+            pass
+
+    # True only once the prior mirror has been moved dst -> backup (so a failed promote MUST restore it).
+    # Declared before the try so the except can read it on every path (incl. a staging-build failure).
+    vacated = False
+    try:
+        # Clean any leftover staging dir from a prior crashed attempt, then copy into staging.
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        # ignore the nested per-task mirror namespace ("tasks") so we never copy a parent mirror tree.
+        shutil.copytree(src, dst=staging, ignore=shutil.ignore_patterns("tasks"))
+        # Promote. Clean any stale leftover backup first, then vacate the (stale) prior mirror if present.
+        if backup.exists():
+            shutil.rmtree(backup)
+        if dst.exists():
+            os.replace(dst, backup)  # vacate the prior; backup now holds the only prior copy
+            vacated = True
+        try:
+            os.replace(staging, dst)  # promote the new mirror into place (atomic)
+        except OSError:
+            if vacated and not dst.exists():
+                os.replace(backup, dst)  # inline ROLLBACK: restore the prior so dst is never left missing
+            raise
+        if vacated:
+            _rm(backup)  # promote succeeded -> the aside copy is stale (best-effort; never fail the promote)
+    except OSError as exc:
+        # FAIL CLOSED. Invariant: never leave dst missing when a prior mirror was vacated. If the inline
+        # rollback did not run (or itself raised), restore the prior to dst -- rename first, then a
+        # copytree fallback. Only catastrophic FS failure defeats BOTH; that residual is SURFACED in the
+        # returned warning (prior copy kept at backup), never silently swallowed.
+        if vacated and not dst.exists():
+            # Restore the prior to dst with the ATOMIC rename ONLY. A copytree fallback was deliberately
+            # removed (codex round-6 HIGH): copytree is NOT atomic -- it can partially populate dst and
+            # then raise, which would look like a successful recovery (dst.exists() is True) and trigger
+            # the stale-backup cleanup below, destroying the only CLEAN prior copy while leaving a corrupt
+            # dst. An atomic rename either fully restores dst or leaves it absent (-> the catastrophic
+            # branch keeps + names the backup). A rename that fails where the inverse just succeeded is
+            # FS-death territory; copytree would not fare better there. No partial-state hazard.
+            try:
+                os.replace(backup, dst)
+            except OSError:
+                pass
+        _rm(staging)
+        if vacated and not dst.exists():
+            # Catastrophic: could neither promote the new mirror nor restore the prior. KEEP the backup
+            # and name it so the prior artifacts are manually recoverable; the caller still fails closed.
+            return False, [
+                f"{task_id}: could not mirror cycle artifacts AND could not restore the prior mirror to "
+                f"{dst} ({exc}); the prior copy is preserved at {backup} -- manual recovery needed "
+                f"(fail-closed; cycle worktree preserved)"
+            ]
+        if dst.exists():
+            _rm(backup)  # dst is intact (restored prior, or never vacated) -> the backup is now stale
+        return False, [
+            f"{task_id}: could not mirror cycle artifacts to the parent task dir before teardown "
+            f"({exc}); preserving the cycle worktree so artifacts are not lost (fail-closed)"
+        ]
+    return True, []
+
+
 def _run_cycle_in_task_worktree(
     task_id: str,
     *,
@@ -17915,11 +18299,27 @@ def _run_cycle_in_task_worktree(
             return
         run_cycle(cycle_path)
     finally:
-        # Exit hygiene: tear down on EVERY exit path (seed failure / blocker / exception / stop /
-        # budget). teardown commits uncommitted cycle state first (issue #1719) so aborted work is
-        # recoverable.
-        teardown_warnings = teardown_task_cycle_worktree(task_id, repo_root=parent_root, runner=git_runner)
-        append_warnings(teardown_warnings)
+        # ADR 0095 PR-E3c MED-3: mirror the cycle's active artifacts into the parent task-scoped dir
+        # BEFORE teardown so the re-pointed cycle-dict paths (…/active/tasks/<task_id>/…) survive the
+        # worktree removal. Runs on every exit path that produced artifacts.
+        # codex round-3 HIGH-3 (FAIL-CLOSED): the mirror is now TRANSACTIONAL and returns ok=False if
+        # promotion failed (partial/failed copy). Because the recorded cycle paths were already
+        # re-pointed to the parent mirror, a missing mirror = DANGLING state — so on failure we record
+        # a blocker AND SKIP teardown, preserving the cycle worktree (the in-worktree artifacts are the
+        # only good copy left). On success we proceed to the normal exit-hygiene teardown.
+        mirror_ok, mirror_warnings = _mirror_cycle_artifacts_to_parent(task_id, cycle_path, parent_root)
+        append_warnings(mirror_warnings)
+        if not mirror_ok:
+            # Dangling-state risk: do NOT tear the worktree down. Route the failure through the blocker
+            # guard (fail-closed, same as create/confinement failures) so a sibling stop is honoured.
+            if register_blocker([f"{task_id}: cycle artifact mirror failed; worktree preserved to avoid losing artifacts"]):
+                on_stop()
+        else:
+            # Exit hygiene: tear down on EVERY (mirror-clean) exit path (seed failure / blocker /
+            # exception / stop / budget). teardown commits uncommitted cycle state first (issue #1719)
+            # so aborted work is recoverable.
+            teardown_warnings = teardown_task_cycle_worktree(task_id, repo_root=parent_root, runner=git_runner)
+            append_warnings(teardown_warnings)
 
 
 def _git_worktree_runner(cmd: list[str]) -> "subprocess.CompletedProcess[str]":
@@ -20789,8 +21189,9 @@ def build_parser() -> argparse.ArgumentParser:
     # ADR 0095 PR-E2: X task-pool size. The default is RESOLVED FROM ENV (BIDMATE_AGENT_LOOP_TASK_POOL,
     # Makefile ACTIVE_TASK_POOL) so the operator front door stays the SSoT, falling back to 1
     # (serial == byte-identical, ADR 0001) when unset. PR-F flips the operator default to 2. The
-    # kill-switch (BIDMATE_AGENT_LOOP_PARALLELISM_KILL=1) forces 1 inside _resolve_task_pool_size,
-    # and PR-E2 additionally clamps the EFFECTIVE pool to 1 (ships the substrate dark; PR-E3 enables).
+    # kill-switch (BIDMATE_AGENT_LOOP_PARALLELISM_KILL=1) forces 1 inside _resolve_task_pool_size.
+    # PR-E2 shipped the substrate dark behind an EFFECTIVE-pool clamp; PR-E3c removed that clamp so
+    # a resolved >1 now drives real X>1 fan-out (worktree-per-task isolation).
     auto_loop.add_argument("--task-pool", type=int, default=_resolve_task_pool_size())
     # ADR 0085: the Makefile `시작`/`agent-loop-active-auto-loop` front door is the SSoT
     # for operator defaults. These argparse defaults are aligned with it so a direct

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -2601,7 +2602,7 @@ def test_active_loop_dry_run_creates_four_session_ledger_without_remote_mutation
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2636,7 +2637,7 @@ def test_active_loop_expanded_eight_dry_run_creates_sessions_and_assignments(mon
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2692,7 +2693,7 @@ def test_active_loop_execute_runs_ship_only_after_reviewer_and_ci_pass(monkeypat
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2728,7 +2729,7 @@ def test_active_loop_expanded_eight_execute_uses_conservative_gate(monkeypatch, 
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2770,7 +2771,7 @@ def test_active_loop_expanded_eight_blocks_when_required_auditor_missing(monkeyp
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2807,7 +2808,7 @@ def test_active_loop_expanded_eight_requires_deep_reviewer_for_load_bearing(monk
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
     monkeypatch.setattr(agent_loop, "check_pr_body_text", lambda *args, **kwargs: [])
 
@@ -2834,7 +2835,7 @@ def test_active_loop_blocks_ship_when_reviewer_or_ci_has_not_passed(monkeypatch,
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2874,7 +2875,7 @@ def test_active_loop_execute_blocks_on_readiness_score_blockers(monkeypatch, tmp
 
     monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(execute=True, repo_root=repo)
@@ -2942,7 +2943,7 @@ def test_active_loop_blocks_overlap_and_recovery_needed_leases(monkeypatch, tmp_
 def test_active_loop_requires_claim_evidence_for_eval_surface(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -2967,7 +2968,7 @@ def test_session_heartbeat_refreshes_registry_and_stale_sessions_are_marked(monk
     registry.write_text(json.dumps(payload), encoding="utf-8")
 
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
     result = agent_loop.write_active_loop(
@@ -3025,7 +3026,7 @@ def test_active_loop_cli_accepts_expanded_eight_and_rejects_unknown_topology() -
 def _patch_active_loop_clear(monkeypatch) -> None:
     monkeypatch.setattr(agent_loop.subprocess, "run", lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="", stderr=""))
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
-    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root, coordination_root=None: _clear_overlap_report(issue, branch))
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
 
 
@@ -8684,25 +8685,25 @@ def test_x1_default_uses_root_dir_and_no_worktree(monkeypatch, tmp_path: Path) -
     assert not (repo / ".claude" / "worktrees" / "T-2026-1002-cycle").exists()
 
 
-def test_task_pool_e2_dark_clamps_requested_pool_to_serial(monkeypatch, tmp_path: Path) -> None:
-    """E2 ships the X substrate DARK (ADR 0095 PR-E2): a >1 request is visibly demoted to serial
-    (X=1) with an advisory warning, and the run still completes both tasks in order — no worktree."""
+def test_task_pool_e3c_clamp_removed_request_fans_out(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c removed the E2 dark clamp: a >1 request is NO LONGER demoted to serial. The
+    advisory "substrate dark" warning is gone and each ready task is routed through worktree
+    isolation (``_run_cycle_in_task_worktree``) rather than the direct X=1 run_one_task call."""
     repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A")
     _append_ready_task(repo, "T-2026-1002", "B")
     active_dir = repo / "reports" / "agent_loop" / "active"
     _patch_auto_loop_inner(monkeypatch, active_dir)
-    # If the clamp failed and real fan-out ran, the worktree helper would fire; make that loud.
-    monkeypatch.setattr(
-        agent_loop, "create_task_cycle_worktree",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("E2 must clamp to serial; no worktree")),
-    )
+
+    stub, seen = _stub_cycle_in_worktree_runs_in(repo)
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
 
     result = agent_loop.write_active_auto_loop(
         max_iterations=2, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=3
     )
 
-    assert any("PR-E2 ships the X task-pool substrate dark" in w for w in result.warnings)
-    assert result.completed_task_ids == ("T-2026-1001", "T-2026-1002")
+    assert not any("substrate dark" in w for w in result.warnings), "the E2 dark-clamp warning must be removed"
+    assert sorted(seen) == ["T-2026-1001", "T-2026-1002"], "a >1 request must fan out through worktree isolation"
+    assert set(result.completed_task_ids) == {"T-2026-1001", "T-2026-1002"}
 
 
 def test_task_pool_fcntl_gating_clamps_on_non_posix(monkeypatch, tmp_path: Path) -> None:
@@ -8775,17 +8776,20 @@ def test_per_task_wall_clock_budget_trips_independently(monkeypatch, tmp_path: P
 
 
 def test_claim_next_task_serializes_concurrent_claims(monkeypatch, tmp_path: Path) -> None:
-    """claim_lock serialization (ADR 0095 PR-E2): over a multi-task queue, the locked claim path
-    must never hand the same task to two cycles — every claimed task_id is distinct (no double-claim).
-    E2 clamps the effective pool to 1, so this asserts claim UNIQUENESS over the serial-clamped run;
-    true concurrent-overlap serialization (a Barrier forcing two in-flight tasks) moves to PR-E3 when
-    the clamp is lifted."""
+    """claim_lock serialization (ADR 0095 PR-E2 substrate, PR-E3c fan-out): over a multi-task queue
+    at --task-pool 2, the locked claim path must never hand the same task to two cycles — every
+    claimed task_id is distinct (no double-claim). PR-E3c lifted the E2 clamp, so this now runs the
+    REAL X>1 fan-out (worktree isolation stubbed so the cycle actually executes) and asserts claim
+    UNIQUENESS + all-completed over a live multi-task fan-out."""
     repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A")
     _append_ready_task(repo, "T-2026-1002", "B")
     _append_ready_task(repo, "T-2026-1003", "C")
     active_dir = repo / "reports" / "agent_loop" / "active"
     _patch_active_loop_clear(monkeypatch)
     monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+
+    stub, _seen = _stub_cycle_in_worktree_runs_in(repo)
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
 
     seen_ids: list[str] = []
     original_runner = _infinite_fake_runner(active_dir)
@@ -9235,27 +9239,1320 @@ def test_x1_budget_env_ignored_byte_identical(monkeypatch, tmp_path: Path) -> No
     )
 
 
-def test_run_task_in_worktree_x_gt_1_raises_e3_deferred(monkeypatch, tmp_path: Path) -> None:
-    """ADR 0095 PR-E2 E3-boundary: run_task_in_worktree raises a descriptive RuntimeError when
-    effective_task_pool_size > 1 is actually reached. The E2-dark clamp (_e2_task_pool_dark_clamp_
-    enabled) keeps this branch unreachable at runtime; it is patched to False here to exercise the
-    boundary and verify the E3 work-list error message is present in code."""
-    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="E3 deferred")
+# --- ADR 0095 PR-E3c: X>1 fan-out wiring (dark clamp removed) -----------------------------------
+
+
+def _stub_cycle_in_worktree_runs_in(repo: Path):
+    """A drop-in replacement for ``_run_cycle_in_task_worktree`` that skips the real git worktree
+    and just invokes ``run_cycle`` against ``repo`` (the in-test parent), so a driver-level fan-out
+    test exercises the run_cycle -> run_one_task -> ledger reconcile path WITHOUT a real worktree.
+    Records every isolated task_id so the test can assert each cycle was routed through isolation."""
+    seen_task_ids: list[str] = []
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        seen_task_ids.append(task_id)
+        run_cycle(repo)
+
+    return stub, seen_task_ids
+
+
+def test_x_gt_1_fan_out_runs_each_task_in_isolation_and_reconciles(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c: with --task-pool 2 and two ready tasks, the driver fans out via
+    ``_run_cycle_in_task_worktree`` (one isolated cycle PER task) and the shared LedgerState
+    reconciles BOTH completions automatically — no post-join ledger merge, the in-process lock
+    serializes the writes (ThreadPoolExecutor = threads, one ledger object)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A")
+    _append_ready_task(repo, "T-2026-1002", "B")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_auto_loop_inner(monkeypatch, active_dir)
+
+    stub, seen = _stub_cycle_in_worktree_runs_in(repo)
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite: ready queue is the sole termination signal
+        execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    assert sorted(seen) == ["T-2026-1001", "T-2026-1002"], "each task must be routed through worktree isolation"
+    assert set(result.completed_task_ids) == {"T-2026-1001", "T-2026-1002"}, "both completions auto-reconcile"
+    # The E2 dark-clamp warning must be gone (the clamp was removed in PR-E3c).
+    assert not any("substrate dark" in w for w in result.warnings)
+
+
+def test_x_gt_1_run_cycle_threads_two_roots_and_parent_inheritance(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c: the X>1 driver passes ``parent_root=repo_root`` (closure variable) to
+    ``_run_cycle_in_task_worktree`` and the ``run_cycle`` closure threads the cycle worktree path as
+    ``cycle_repo_root`` + the closure ``repo_root`` as ``coordination_root`` into ``run_one_task``
+    (E3a two-root split, HIGH-3 fix: must NOT hardcode ROOT_DIR).
+
+    Proof: the runner call (write_active_codex_runner) receives
+    ``repo_root == the cycle path`` and ``coordination_root == the closure repo_root (tmp_path)``."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Solo")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+
+    runner_seen: list[dict] = []
+    base_runner = _infinite_fake_runner(active_dir)
+
+    def recording_runner(**kwargs):  # type: ignore[no-untyped-def]
+        runner_seen.append({"repo_root": kwargs.get("repo_root"), "coordination_root": kwargs.get("coordination_root")})
+        return base_runner(**kwargs)
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", recording_runner)
+
+    sentinel_cycle = repo  # real path so context-file reads resolve; identity is what we assert
+    captured: dict = {}
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        captured["parent_root"] = parent_root
+        captured["git_runner"] = git_runner
+        run_cycle(sentinel_cycle)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=1, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    # HIGH-3 fix: driver must pass the closure repo_root, not the hardcoded ROOT_DIR module constant.
+    assert captured["parent_root"] == repo, "driver must pass parent_root=closure repo_root, not hardcoded ROOT_DIR"
+    assert captured["git_runner"] is None, "production git runner default (real subprocess) must be threaded as None"
+    assert runner_seen, "the runner must have been invoked through run_cycle -> run_one_task"
+    assert runner_seen[0]["repo_root"] == sentinel_cycle, "cycle_repo_root must thread to the runner as repo_root"
+    assert runner_seen[0]["coordination_root"] == repo, "coordination_root must be the closure repo_root, not hardcoded ROOT_DIR"
+
+
+def test_x_gt_1_no_double_concurrency_permit_in_driver(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c lock-order: the global-concurrency permit for the worktree create is acquired
+    INSIDE ``_run_cycle_in_task_worktree`` (around the create only). The driver / run_task_in_worktree
+    must NOT acquire it again. Proof: with the lifecycle stubbed out, the driver fan-out path takes
+    ZERO permits from the limiter (any driver-side acquire would show up here)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A")
+    _append_ready_task(repo, "T-2026-1002", "B")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_auto_loop_inner(monkeypatch, active_dir)
+
+    stub, _seen = _stub_cycle_in_worktree_runs_in(repo)
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    acquisitions = {"n": 0}
+    real_limiter = agent_loop.global_concurrency_limiter()
+    real_slot = real_limiter.slot
+
+    def counting_slot(*a, **k):  # type: ignore[no-untyped-def]
+        acquisitions["n"] += 1
+        return real_slot(*a, **k)
+
+    monkeypatch.setattr(real_limiter, "slot", counting_slot)
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=0, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    assert acquisitions["n"] == 0, "the driver must NOT acquire a global-concurrency permit (owned by _run_cycle_in_task_worktree)"
+
+
+def test_x_gt_1_deferred_blocker_records_in_ledger(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c: a task whose isolated cycle hits a blocker is recorded via
+    ``register_task_blocker`` -> in infinite mode it lands in ``deferred_task_ids`` (not completed)
+    and the loop continues; the register_blocker adapter (lambda binding ``task``) routes the right
+    task id through the shared LedgerState."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A-blocks")
+    _append_ready_task(repo, "T-2026-1002", "B-ok")
     active_dir = repo / "reports" / "agent_loop" / "active"
     _patch_active_loop_clear(monkeypatch)
     monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
     monkeypatch.setattr(agent_loop, "write_active_codex_runner", _infinite_fake_runner(active_dir))
-    # Bypass the E2-dark clamp: _e2_task_pool_dark_clamp_enabled() returns False so the
-    # effective_task_pool_size is NOT reduced to 1, letting the X>1 raise be hit.
-    monkeypatch.setattr(agent_loop, "_e2_task_pool_dark_clamp_enabled", lambda: False)
 
-    with pytest.raises(RuntimeError, match="X>1 task-pool fan-out is not enabled in PR-E2"):
-        agent_loop.write_active_auto_loop(
-            max_iterations=1, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        # Task A: simulate a worktree-isolation blocker (e.g. create failure) routed through the
+        # blocker guard WITHOUT running the cycle (fail-closed). Task B: run normally.
+        if task_id == "T-2026-1001":
+            if register_blocker([f"{task_id}: simulated worktree blocker"]):
+                on_stop()
+            return
+        run_cycle(repo)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=0, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    # deferred tasks are surfaced in the persisted ledger state, not on the result object.
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert "T-2026-1001" in state["deferred_task_ids"], "blocked task must be deferred (infinite mode)"
+    assert "T-2026-1001" not in result.completed_task_ids, "blocked task must NOT be completed"
+    assert "T-2026-1002" in result.completed_task_ids, "the healthy sibling still completes"
+
+
+def test_x_gt_1_terminal_blocker_stops_and_no_post_stop_promote(monkeypatch, tmp_path: Path) -> None:
+    """ADR 0095 PR-E3c drain: in BOUNDED mode any task blocker is terminal (register_task_blocker
+    returns True -> on_stop -> stop_event.set). A sibling that had NOT already completed must NOT be
+    promoted post-stop (fail-closed via complete_if_not_stopped), and the run reports blocked."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A-blocks")
+    _append_ready_task(repo, "T-2026-1002", "B")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", _infinite_fake_runner(active_dir))
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        if task_id == "T-2026-1001":
+            if register_blocker([f"{task_id}: terminal blocker"]):
+                on_stop()
+            return
+        run_cycle(repo)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=5,  # bounded: a blocker stops the whole loop
+        execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    assert result.decision == "blocked"
+    assert "T-2026-1001" not in result.completed_task_ids
+    assert "T-2026-1002" not in result.completed_task_ids, "post-stop sibling must NOT be promoted"
+
+
+# --- ADR 0095 PR-E3c codex round-2 fixes (HIGH-1/2/3 + MED-1/2/3) -------------------------------
+#
+# HIGH-1 (X==1 byte-identity REGRESSION): blocked terminal paths used to persist a STALE cycle
+# snapshot. The cycle is deep-copied at initial registration, then runner/gate/ship fields are
+# mutated, but no _snapshot_cycle() ran before register_task_blocker on the runner-blocked /
+# gate-not-ready / ship-blocked terminals, so the immutable upsert ledger kept the pre-mutation
+# copy and the mutated fields vanished from the final cycles. The old by-ref append captured them
+# implicitly. These three tests assert the mutated fields survive into the persisted
+# auto_loop_state.json at X==1 — they FAIL on the pre-fix code (KeyError / missing field) and PASS
+# after _snapshot_cycle() is published before each terminal blocker.
+
+
+def test_e3c_high1_runner_blocked_cycle_persists_mutated_fields_x1(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-1: a runner-blocked (auto_repair=False) cycle must persist runner_decision / runner_report
+    / gate_tier into auto_loop_state.json at X==1 (byte-equivalent to the old by-ref path)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Runner blocked task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        # decision != completed -> runner-blocked terminal (execute_runner=True, auto_repair=False).
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "blocked", (), (), ())
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=True,
+        auto_repair=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    cyc = state["cycles"][0]
+    assert cyc["task_id"] == "T-2026-1001"
+    # These three are mutated AFTER the deep-copied initial registration; pre-fix they were lost.
+    assert cyc["runner_decision"] == "blocked"
+    assert cyc["gate_tier"] == "runner-blocked"
+    assert "runner_report" in cyc
+    # The result object is built from the SAME ledger.snapshot(), so it must agree byte-for-byte.
+    assert result.cycles[0]["runner_decision"] == "blocked"
+    assert result.cycles[0]["gate_tier"] == "runner-blocked"
+
+
+def test_e3c_high1_gate_not_ready_cycle_persists_mutated_fields_x1(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-1: a gate-not-ready (auto_repair=False) cycle must persist gate_evidence / gate_ready /
+    privacy_clean / gate_tier into auto_loop_state.json at X==1."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Gate not ready task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        # ready=False, privacy_clean=True -> gate-not-ready non-repair terminal.
+        return path, {"ready": False, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=True,
+        auto_repair=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    cyc = state["cycles"][0]
+    assert cyc["task_id"] == "T-2026-1001"
+    assert cyc["gate_ready"] is False
+    assert cyc["privacy_clean"] is True
+    assert cyc["gate_tier"] == "repairable"
+    assert "gate_evidence" in cyc
+    assert "runner_decision" in cyc  # runner mutations also survive
+    assert result.cycles[0]["gate_ready"] is False
+
+
+def test_e3c_high1_ship_blocked_cycle_persists_mutated_fields_x1(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-1: a ship-blocked cycle (write_active_loop ship returns != executed) must persist
+    ship_decision / ship_report into auto_loop_state.json at X==1."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Ship blocked task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    # write_active_start calls write_active_loop internally for the CLAIM (execute falsy); the
+    # auto-loop's FINAL ship calls it with execute=True. Only override the execute=True path to
+    # return a non-executed (blocked) ship so the start succeeds but the ship terminal trips.
+    real_write_active_loop = agent_loop.write_active_loop
+
+    def fake_ship(**kwargs):  # type: ignore[no-untyped-def]
+        if not kwargs.get("execute"):
+            return real_write_active_loop(**kwargs)
+        report = active_dir / "active_loop.md"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# ship\n", encoding="utf-8")
+        # decision != executed -> ship-blocked terminal.
+        return agent_loop.ActiveLoopResult(
+            active_dir / "session_registry.json",
+            active_dir / "leases.json",
+            active_dir / "events.jsonl",
+            active_dir / "assignments",
+            report,
+            "blocked",
+            (),
+            (),
+            (),
         )
 
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+    monkeypatch.setattr(agent_loop, "write_active_loop", fake_ship)
 
-# --- PR-D adversarial fixes (HIGH-1/2/3 + LOW-1) ---
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=True,
+        auto_repair=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    cyc = state["cycles"][0]
+    assert cyc["task_id"] == "T-2026-1001"
+    assert cyc["ship_decision"] == "blocked"
+    assert "ship_report" in cyc
+    assert cyc["completed"] is False
+    assert result.cycles[0]["ship_decision"] == "blocked"
+
+
+# HIGH-2 (X>1 lease routing): the repair patch lane must forward coordination_root=PARENT root +
+# this cycle's lease_id while running the patch artifacts against the cycle worktree (repo_root).
+# Before the fix the forward gate keyed on ``repair_coord != repo_root`` which is FALSE once the
+# parent coord root is threaded, so lease reads resolved to the torn-down worktree. At X==1 the gate
+# stays FALSE (no coordination_root/lease_id kwargs) -> byte-identical.
+
+
+def _record_runner_calls(active_dir: Path, calls: list[dict], *, read_decision: str = "blocked"):
+    """A write_active_codex_runner fake that records the kwargs of EACH call (read-only + patch),
+    returning a completed PATCH lane (so run_repair_apply proceeds to apply) and ``read_decision``
+    for the read-only lane."""
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        mode = str(kwargs.get("mode", "read-only"))
+        calls.append({
+            "mode": mode,
+            "repo_root": kwargs.get("repo_root"),
+            "coordination_root": kwargs.get("coordination_root"),
+            "has_coordination_root": "coordination_root" in kwargs and kwargs["coordination_root"] is not None,
+            "has_lease_id": "lease_id" in kwargs and kwargs["lease_id"] is not None,
+            "lease_id": kwargs.get("lease_id"),
+        })
+        report = active_dir / ("auto_repair.md" if mode == "patch" else "codex_runner.md")
+        state = active_dir / ("auto_repair_state.json" if mode == "patch" else "codex_runner_state.json")
+        runs = active_dir / ("patch_runs" if mode == "patch" else "codex_runs")
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(f"# {mode}\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        decision = "completed" if mode == "patch" else read_decision
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, decision, (), (), ())
+
+    return fake_runner
+
+
+def test_e3c_high2_repair_patch_lane_forwards_parent_coord_and_lease_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-2: at X>1 the repair patch lane (run_patch) must forward coordination_root=PARENT repo
+    (so lease ops hit the shared parent lease file) + this cycle's lease_id, while its artifacts run
+    against the cycle worktree (repo_root)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Repair lease task")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+    # Make apply a no-op clean failure so the cycle just defers (we only care about the patch kwargs).
+    monkeypatch.setattr(
+        agent_loop, "write_active_apply",
+        lambda **kw: agent_loop.ActiveApplyResult(active_dir / "apply.md", active_dir / "apply_state.json", "blocked", "n/a", False, (), ()),
+    )
+
+    calls: list[dict] = []
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", _record_runner_calls(active_dir, calls))
+
+    # Distinct cycle worktree path so repo_root(worktree) != coordination_root(parent) is observable.
+    # Seed it with the fixture's tasks/ so run_one_task's context-file reads (rooted at the cycle
+    # repo_root) resolve while the path identity stays distinct from the parent repo.
+    cycle_path = tmp_path / "cycle_wt"
+    shutil.copytree(repo / "tasks", cycle_path / "tasks")
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        run_cycle(cycle_path)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite: a single deferral does not stop on the consecutive guard
+        execute_runner=True, execute_ship=False, auto_repair=True, repo_root=repo, task_pool=2,
+    )
+
+    patch_calls = [c for c in calls if c["mode"] == "patch"]
+    assert patch_calls, "the repair patch lane must have been invoked"
+    pc = patch_calls[0]
+    assert pc["repo_root"] == cycle_path, "patch artifacts must run against the cycle worktree"
+    assert pc["coordination_root"] == repo, "patch lane must forward coordination_root=PARENT repo (lease isolation)"
+    assert pc["has_lease_id"], "patch lane must borrow THIS cycle's lease_id at X>1"
+
+
+def test_e3c_high2_repair_patch_lane_no_coord_or_lease_x1_byte_identical(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-2 X==1 byte-identity: with no worktree (artifact_root=None, coord==repo_root) the patch
+    lane must receive NEITHER coordination_root NOR lease_id (textually identical call)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Repair lease x1")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+    monkeypatch.setattr(
+        agent_loop, "write_active_apply",
+        lambda **kw: agent_loop.ActiveApplyResult(active_dir / "apply.md", active_dir / "apply_state.json", "blocked", "n/a", False, (), ()),
+    )
+
+    calls: list[dict] = []
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", _record_runner_calls(active_dir, calls))
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=1,
+        execute_runner=True, execute_ship=False, auto_repair=True, repo_root=repo, task_pool=1,
+    )
+
+    patch_calls = [c for c in calls if c["mode"] == "patch"]
+    assert patch_calls, "the repair patch lane must have been invoked"
+    pc = patch_calls[0]
+    assert pc["repo_root"] == repo, "X==1 patch lane runs against the parent repo (no worktree)"
+    assert not pc["has_coordination_root"], "X==1 patch lane must NOT forward coordination_root (byte-identical)"
+    assert not pc["has_lease_id"], "X==1 patch lane must NOT forward lease_id (byte-identical)"
+
+
+# HIGH-3 (X>1 driver overrun guard): the bounded-mode guard counted every in-flight future as a
+# GUARANTEED completion, so once ``completed + in_flight >= target`` it broke, drained, and exited —
+# even if a drained future DEFERRED, leaving the target unmet with ready work remaining. The fix
+# drains in-flight work and re-enters the claim loop until the ACTUAL completed count meets the
+# target (or the ready queue is genuinely drained). At X==1 the guard is dead (in_flight always
+# empty + loop_should_continue() breaks first) so this is a no-op there.
+
+
+def test_e3c_high3_deferring_in_flight_task_does_not_abandon_unmet_target_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """HIGH-3: with task_pool=2 and target=1, if the FIRST claimed (in-flight) task DEFERS instead
+    of completing, the driver must still claim + complete the next ready task to reach the target —
+    never silently stop below target with ready work remaining.
+
+    Deterministic trigger: at X>1 the guard fires right after the first claim (in_flight=1 >= target=1).
+    Pre-fix the guard broke + drained + exited at completed=0 (task A deferred). Post-fix it drains A,
+    sees completed(0) < target(1), relaxes the guard, claims B, and completes it -> target reached."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A-defers")
+    _append_ready_task(repo, "T-2026-1002", "B-ok")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", _infinite_fake_runner(active_dir))
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        # Task A: DEFER (infinite mode -> register_blocker returns False, task is deferred, run
+        # continues). Task B: run the cycle normally so it completes.
+        if task_id == "T-2026-1001":
+            if register_blocker([f"{task_id}: simulated deferral"]):
+                on_stop()
+            return
+        run_cycle(repo)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite mode so a single deferral does not stop the whole run
+        target_completed_count=1,  # explicit bound -> the overrun guard is live at X>1
+        execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    # The healthy sibling must have been claimed + completed to reach the target despite A deferring.
+    # Pre-fix the driver counted A's in-flight future as a guaranteed completion, broke at
+    # completed(0)+in_flight(1) >= target(1), drained A (which DEFERRED), and exited WITHOUT ever
+    # claiming B -> completed_task_ids would be empty (target abandoned).
+    assert "T-2026-1002" in result.completed_task_ids, "must claim+complete the next ready task to reach target"
+    assert len(result.completed_task_ids) >= 1, "the target of 1 completion must be reached, not abandoned below target"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert "T-2026-1001" in state["deferred_task_ids"], "the deferring task is recorded as deferred"
+    assert "T-2026-1002" in state["completed_task_ids"], "the persisted ledger reflects the recovered completion"
+
+
+# MED-1 (X>1 lost update): write_cycle_checkpoint used to snapshot() then persist() under two
+# SEPARATE lock acquisitions, so a sibling could upsert+persist a newer state between them and the
+# first thread's persist would clobber it with stale bytes. LedgerState.persist_checkpoint folds
+# snapshot+merge+persist into ONE critical section. These tests pin (a) X==1 byte-identity vs the
+# old two-phase path and (b) that the write reflects the ledger state AT WRITE TIME (no stale capture).
+
+
+def test_e3c_med1_persist_checkpoint_is_byte_identical_to_snapshot_then_persist(tmp_path: Path) -> None:
+    """MED-1 X==1 byte-identity: persist_checkpoint(path, base) must produce byte-for-byte the same
+    file as the old ledger.persist(path, {**base, **snapshot_fields}) two-phase path."""
+    base = {
+        "schema_version": 1,
+        "decision": "running",
+        "next_task_id": None,
+        "warnings": ["w1", "w2"],
+    }
+
+    ledger_new = agent_loop.LedgerState(completed=["T-2026-1001"], deferred=["T-2026-1002"])
+    ledger_new.upsert_cycle("T-2026-1001", {"task_id": "T-2026-1001", "completed": True, "runner_decision": "completed"})
+    ledger_new.extend_blockers(["b1", "b1", "b2"])  # dupes to exercise _dedupe_preserve_order
+    new_path = tmp_path / "new.json"
+    ledger_new.persist_checkpoint(new_path, base)
+
+    # Reconstruct the OLD path byte-for-byte from an identically-seeded ledger.
+    ledger_old = agent_loop.LedgerState(completed=["T-2026-1001"], deferred=["T-2026-1002"])
+    ledger_old.upsert_cycle("T-2026-1001", {"task_id": "T-2026-1001", "completed": True, "runner_decision": "completed"})
+    ledger_old.extend_blockers(["b1", "b1", "b2"])
+    snap = ledger_old.snapshot()
+    old_payload = {
+        **base,
+        "completed_task_ids": snap["completed_task_ids"],
+        "deferred_task_ids": snap["deferred_task_ids"],
+        "cycles": snap["cycles"],
+        "blockers": snap["blockers"],
+    }
+    old_path = tmp_path / "old.json"
+    ledger_old.persist(old_path, old_payload)
+
+    assert new_path.read_bytes() == old_path.read_bytes(), "persist_checkpoint must be byte-identical to snapshot()+persist()"
+    parsed = json.loads(new_path.read_text(encoding="utf-8"))
+    assert parsed["completed_task_ids"] == ["T-2026-1001"]
+    assert parsed["deferred_task_ids"] == ["T-2026-1002"]
+    assert parsed["blockers"] == ["b1", "b2"]  # deduped, order preserved
+    assert parsed["cycles"][0]["runner_decision"] == "completed"
+
+
+def test_e3c_med1_persist_checkpoint_reflects_state_at_write_time(tmp_path: Path) -> None:
+    """MED-1 atomicity contract: a sibling upsert that lands BEFORE the checkpoint's lock write must
+    be reflected in the persisted bytes (no two-phase stale-snapshot capture). This proves the merge
+    reads the live ledger inside the same critical section as the write — the structural guarantee
+    that removes the lost-update window."""
+    ledger = agent_loop.LedgerState()
+    ledger.upsert_cycle("T-2026-1001", {"task_id": "T-2026-1001", "completed": False})
+    path = tmp_path / "state.json"
+
+    # Simulate the sibling landing a NEWER cycle just before persist_checkpoint takes the lock.
+    ledger.upsert_cycle("T-2026-1002", {"task_id": "T-2026-1002", "completed": True})
+    ledger.record_completed("T-2026-1002")
+    ledger.persist_checkpoint(path, {"schema_version": 1, "decision": "running"})
+
+    state = json.loads(path.read_text(encoding="utf-8"))
+    task_ids = {c["task_id"] for c in state["cycles"]}
+    assert task_ids == {"T-2026-1001", "T-2026-1002"}, "checkpoint must reflect the sibling's cycle (no stale snapshot)"
+    assert state["completed_task_ids"] == ["T-2026-1002"], "checkpoint must reflect the sibling's completion at write time"
+
+
+# MED-2 (X>1 nondeterminism): lane-autotune reads shared live `cycles` history and mutates shared
+# effort-override / cooldown / recommendation state with last-writer-wins timing under X>1. Since
+# the cross-task ordering is undefined, the run DISABLES autotune at X>1 (one-time advisory) so the
+# state is deterministic. At X==1 autotune runs exactly as today (byte-identical, covered by the
+# existing ADR 0092 autotune tests).
+
+
+def test_e3c_med2_lane_autotune_disabled_at_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """MED-2: with an injected LaneAutotuneConfig AND task_pool=2, autotune must be disabled — the
+    persisted auto_loop_state.json carries neither lane_autotune_recommendations nor
+    lane_autotune_cooldown, cycles carry no lane_stats, and a one-time advisory warning is recorded."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Autotune x>1")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        sessions = (
+            {"role": "Implementer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "CI / Regression Auditor", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+        )
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", sessions, (), ())
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+
+    stub, _seen = _stub_cycle_in_worktree_runs_in(repo)
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite (ready queue drains -> single task completes)
+        execute_runner=True, execute_ship=False,
+        lane_autotune_config=agent_loop.LaneAutotuneConfig(),
+        repo_root=repo, task_pool=2,
+    )
+
+    assert any("lane-autotune disabled" in w and "X task-pool" in w for w in result.warnings), \
+        "a one-time advisory must explain the X>1 autotune disable"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert "lane_autotune_recommendations" not in state, "autotune disabled -> no recommendations key at X>1"
+    assert "lane_autotune_cooldown" not in state, "autotune disabled -> no cooldown key at X>1"
+    for cyc in state["cycles"]:
+        assert "lane_stats" not in cyc, "autotune disabled -> cycles carry no lane_stats at X>1"
+        assert "lane_autotune" not in cyc, "autotune disabled -> cycles carry no lane_autotune block at X>1"
+
+
+def test_e3c_med2_lane_autotune_runs_at_x1(monkeypatch, tmp_path: Path) -> None:
+    """MED-2 X==1: the disable branch must NOT fire at task_pool=1 — autotune still records its
+    recommendations + cooldown (proving the guard is gated strictly on effective_task_pool_size>1)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Autotune x1")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        # Same slow-lane trio as the ADR 0092 autotune-on test: median 10s, CI lane 100s -> a
+        # within-agent accelerate recommendation is produced (proves autotune is LIVE at X==1).
+        sessions = (
+            {"role": "Implementer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "Reviewer", "agent": "codex", "elapsed_s": 10.0, "status": "completed"},
+            {"role": "CI / Regression Auditor", "agent": "codex", "elapsed_s": 100.0, "status": "completed"},
+        )
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", sessions, (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1, auto_max_iterations_cap=1,
+        execute_runner=True, execute_ship=False,
+        lane_autotune_config=agent_loop.LaneAutotuneConfig(),
+        repo_root=repo, task_pool=1,
+    )
+
+    assert not any("lane-autotune disabled" in w for w in result.warnings), "X==1 must NOT disable autotune"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert "lane_autotune_recommendations" in state, "X==1 autotune still records recommendations (byte-identical behavior)"
+    assert state["lane_autotune_recommendations"], "the slow lane must produce a recommendation at X==1"
+
+
+# MED-3 (X>1 artifact survival): the cycle records artifact paths inside the per-task worktree that
+# is torn down at cycle end -> dead references in the parent auto_loop_state.json. The fix re-points
+# the recorded paths to a parent task-scoped mirror (reports/agent_loop/active/tasks/<task_id>/...)
+# and COPIES the cycle's active artifacts there before teardown. At X==1 (no worktree) the recorded
+# path is unchanged (byte-identical).
+
+
+def test_e3c_med3_cycle_artifact_repo_path_x1_is_plain_repo_path(tmp_path: Path) -> None:
+    """MED-3 X==1 byte-identity: with effective_repo_root == repo_root the helper is exactly
+    _repo_path(path, repo_root) (no tasks/<id> re-point)."""
+    repo = tmp_path
+    p = repo / "reports" / "agent_loop" / "active" / "codex_runner.md"
+    got = agent_loop._cycle_artifact_repo_path(p, effective_repo_root=repo, repo_root=repo, task_id="T-2026-1001")
+    assert got == agent_loop._repo_path(p, repo) == "reports/agent_loop/active/codex_runner.md"
+
+
+def test_e3c_med3_cycle_artifact_repo_path_x_gt_1_repoints_to_parent_task_dir(tmp_path: Path) -> None:
+    """MED-3 X>1: a worktree-relative active artifact path is re-pointed under
+    reports/agent_loop/active/tasks/<task_id>/ so it resolves against the PARENT root post-teardown."""
+    parent = tmp_path / "parent"
+    worktree = tmp_path / "worktree"
+    p = worktree / "reports" / "agent_loop" / "active" / "codex_runner.md"
+    got = agent_loop._cycle_artifact_repo_path(p, effective_repo_root=worktree, repo_root=parent, task_id="T-2026-1001")
+    assert got == "reports/agent_loop/active/tasks/T-2026-1001/codex_runner.md"
+    # A patch-runs nested artifact keeps its suffix under the task mirror.
+    p2 = worktree / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    got2 = agent_loop._cycle_artifact_repo_path(p2, effective_repo_root=worktree, repo_root=parent, task_id="T-2026-1001")
+    assert got2 == "reports/agent_loop/active/tasks/T-2026-1001/patch_runs/implementer/patch_artifact.json"
+
+
+def test_e3c_med3_mirror_copies_active_tree_and_excludes_nested_tasks(tmp_path: Path) -> None:
+    """MED-3: _mirror_cycle_artifacts_to_parent copies <cycle>/reports/agent_loop/active into
+    <parent>/reports/agent_loop/active/tasks/<task_id>, excluding the nested ``tasks/`` namespace so a
+    parent mirror is never recursively copied into a child cycle's mirror."""
+    parent = tmp_path / "parent"
+    cycle = tmp_path / "cycle"
+    active = cycle / "reports" / "agent_loop" / "active"
+    (active).mkdir(parents=True)
+    (active / "codex_runner.md").write_text("# runner\n", encoding="utf-8")
+    (active / "patch_runs" / "implementer").mkdir(parents=True)
+    (active / "patch_runs" / "implementer" / "patch_artifact.json").write_text("{}\n", encoding="utf-8")
+    # A pre-existing nested tasks/ mirror in the cycle must NOT be copied into the parent mirror.
+    (active / "tasks" / "T-OTHER").mkdir(parents=True)
+    (active / "tasks" / "T-OTHER" / "stale.md").write_text("stale\n", encoding="utf-8")
+
+    ok, warns = agent_loop._mirror_cycle_artifacts_to_parent("T-2026-1001", cycle, parent)
+    assert ok is True and warns == []
+    mirror = parent / "reports" / "agent_loop" / "active" / "tasks" / "T-2026-1001"
+    # codex round-3 HIGH-3: the transactional staging dir must be gone after a successful promote.
+    assert not mirror.with_name(mirror.name + ".mirror-tmp").exists()
+    assert (mirror / "codex_runner.md").read_text(encoding="utf-8") == "# runner\n"
+    assert (mirror / "patch_runs" / "implementer" / "patch_artifact.json").is_file()
+    assert not (mirror / "tasks").exists(), "the nested tasks/ namespace must be excluded from the mirror"
+
+
+def test_e3c_med3_recorded_paths_survive_worktree_teardown_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """MED-3 end-to-end: after an X>1 cycle completes and its worktree is torn down, the persisted
+    auto_loop_state.json records artifact paths that are PARENT-resolvable AND the mirrored files
+    physically exist under the parent root (not dead references inside the deleted worktree)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Artifact survival")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+
+    # Build a real cycle worktree dir seeded with tasks/ so run_one_task's context reads resolve.
+    cycle_path = tmp_path / "cycle_wt"
+    shutil.copytree(repo / "tasks", cycle_path / "tasks")
+    cycle_active = cycle_path / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        # Write the runner artifact INSIDE the cycle worktree's active dir (the X>1 root).
+        root = kwargs.get("repo_root")
+        report = root / "reports" / "agent_loop" / "active" / "codex_runner.md"
+        state = root / "reports" / "agent_loop" / "active" / "codex_runner_state.json"
+        runs = root / "reports" / "agent_loop" / "active" / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        root = kwargs.get("repo_root")
+        path = root / "reports" / "agent_loop" / "active" / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    # A stub that mimics the REAL _run_cycle_in_task_worktree flow: run the cycle against the seeded
+    # worktree, mirror artifacts to the parent (the real helper), then "tear down" by deleting the
+    # worktree — so the only surviving copy is the parent mirror.
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        run_cycle(cycle_path)
+        # codex round-3 HIGH-3: the mirror helper now returns (ok, warnings); a successful mirror is ok=True.
+        mirror_ok, mirror_warnings = agent_loop._mirror_cycle_artifacts_to_parent(task_id, cycle_path, parent_root)
+        append_warnings(mirror_warnings)
+        assert mirror_ok is True
+        shutil.rmtree(cycle_path)  # simulate teardown_task_cycle_worktree removing the worktree
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite -> single ready task completes
+        execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    assert "T-2026-1001" in result.completed_task_ids
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    cyc = state["cycles"][0]
+    # The recorded runner_report is parent-resolvable under the task mirror...
+    assert cyc["runner_report"] == "reports/agent_loop/active/tasks/T-2026-1001/codex_runner.md"
+    # ...and the file physically EXISTS at that parent path after worktree teardown (not a dead ref).
+    assert (repo / cyc["runner_report"]).is_file(), "the mirrored artifact must survive worktree teardown"
+    assert not cycle_path.exists(), "the cycle worktree was torn down (only the parent mirror survives)"
+
+
+# --- ADR 0095 PR-E3c codex round-3 fixes (HIGH-1/HIGH-2/HIGH-3 + MED-1/MED-2) -------------------
+#
+# These five tests cover the round-3 adversarial findings. HIGH-1/HIGH-2 src was fixed by the
+# orchestrator; these add the regression coverage that the prior X>1 tests missed (they stubbed
+# _run_cycle_in_task_worktree and never reached the real runner kwargs expansion). HIGH-3/MED-1/MED-2
+# src is fixed in this round. Each behavior-change test FAILS on the pre-fix code and PASSES after.
+
+
+def _record_runner_calls_with_artifact_root(active_dir: Path, calls: list[dict], *, read_decision: str = "completed"):
+    """Like _record_runner_calls, but ALSO records whether each call carried an ``artifact_root`` kwarg
+    (codex round-3 HIGH-1). The read-only runner lane (write_active_codex_runner) has NO artifact_root
+    parameter, so it MUST never receive one (would TypeError at X>1). The repair lane DOES receive
+    artifact_root via run_repair_apply, which CONSUMES it (run_patch threads it as the patch call's
+    ``repo_root`` = the cycle worktree, NOT a literal artifact_root kwarg) — so the observable proof of
+    the repair-lane artifact_root is its patch call's ``repo_root`` being the cycle worktree."""
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        mode = str(kwargs.get("mode", "read-only"))
+        calls.append({
+            "mode": mode,
+            "repo_root": kwargs.get("repo_root"),
+            "has_artifact_root": "artifact_root" in kwargs,
+            "has_lease_id": "lease_id" in kwargs and kwargs["lease_id"] is not None,
+        })
+        report = active_dir / ("auto_repair.md" if mode == "patch" else "codex_runner.md")
+        state = active_dir / ("auto_repair_state.json" if mode == "patch" else "codex_runner_state.json")
+        runs = active_dir / ("patch_runs" if mode == "patch" else "codex_runs")
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(f"# {mode}\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        decision = "completed" if mode == "patch" else read_decision
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, decision, (), (), ())
+
+    return fake_runner
+
+
+def test_e3c_round3_high1_runner_call_omits_artifact_root_at_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 HIGH-1: at X>1 the REAL runner kwargs expansion must reach
+    write_active_codex_runner WITHOUT an ``artifact_root`` kwarg (that function has no such param ->
+    a leak would TypeError at X>1). The repair patch lane MUST still receive artifact_root.
+
+    This closes the gap left by the prior X>1 tests, which stubbed _run_cycle_in_task_worktree and so
+    never exercised the runner_lease_kwargs / repair_lease_kwargs split. Here run_cycle runs against a
+    DISTINCT cycle worktree path (effective_repo_root != repo_root) so the X>1 lease-kwargs branch
+    actually fires, and we record EVERY runner call's kwargs.
+
+    Pre-fix (runner_lease_kwargs still carried artifact_root) this would record has_artifact_root=True
+    on the read-only lane (and the real call would TypeError) -> assertion fails. Post-fix it is gone."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Runner artifact_root split")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+    # Make the read-only runner NOT complete so the cycle routes into the repair patch lane too
+    # (so we observe BOTH the read-only runner call and the patch call's artifact_root handling).
+    monkeypatch.setattr(
+        agent_loop, "write_active_apply",
+        lambda **kw: agent_loop.ActiveApplyResult(active_dir / "apply.md", active_dir / "apply_state.json", "blocked", "n/a", False, (), ()),
+    )
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        agent_loop, "write_active_codex_runner",
+        _record_runner_calls_with_artifact_root(active_dir, calls, read_decision="blocked"),
+    )
+
+    # Distinct cycle worktree path (seeded with tasks/ so context reads resolve) so
+    # effective_repo_root(cycle) != repo_root(parent) -> the X>1 lease-kwargs branch fires.
+    cycle_path = tmp_path / "cycle_wt"
+    shutil.copytree(repo / "tasks", cycle_path / "tasks")
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        run_cycle(cycle_path)
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=0,  # infinite: a single deferral does not trip the consecutive-blocker guard
+        execute_runner=True, execute_ship=False, auto_repair=True, repo_root=repo, task_pool=2,
+    )
+
+    read_calls = [c for c in calls if c["mode"] != "patch"]
+    patch_calls = [c for c in calls if c["mode"] == "patch"]
+    assert read_calls, "the read-only runner lane must have been invoked through the real kwargs expansion"
+    # CORE HIGH-1 ASSERTION: the read-only runner call must NOT carry artifact_root (it has no such
+    # param -> a leak TypeErrors at X>1). Pre-fix runner_lease_kwargs carried it -> this fails.
+    assert all(not c["has_artifact_root"] for c in read_calls), (
+        "HIGH-1: write_active_codex_runner (read-only lane) must NOT receive artifact_root at X>1 "
+        "(it has no such param -> TypeError); the runner_lease_kwargs dict must be lease_id-only"
+    )
+    # No write_active_codex_runner call (read-only OR patch) may carry artifact_root — that function
+    # has no such parameter; the repair lane consumes artifact_root via run_repair_apply (-> repo_root).
+    assert all(not c["has_artifact_root"] for c in calls), (
+        "HIGH-1: NO runner call may carry artifact_root (the param does not exist on the runner)"
+    )
+    assert patch_calls, "the repair patch lane must have been invoked"
+    # The repair lane DID receive artifact_root: run_repair_apply consumed it as effective_artifact_root
+    # and threaded it as the patch call's repo_root = the cycle worktree (the observable artifact_root
+    # effect). At X=1 (no worktree) this would be the parent repo instead.
+    assert all(c["repo_root"] == cycle_path for c in patch_calls), (
+        "HIGH-1: the repair lane MUST receive artifact_root at X>1 (its patch call's repo_root is the "
+        "cycle worktree, proving run_repair_apply got artifact_root=cycle worktree)"
+    )
+
+
+def test_e3c_round3_high1_runner_call_no_artifact_root_or_lease_at_x1(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 HIGH-1 X==1 byte-identity: with no worktree (effective_repo_root == repo_root) the
+    runner call must receive NEITHER artifact_root NOR lease_id — the textually pre-change call."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Runner x1 plain")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        agent_loop, "write_active_codex_runner",
+        _record_runner_calls_with_artifact_root(active_dir, calls, read_decision="completed"),
+    )
+
+    agent_loop.write_active_auto_loop(
+        max_iterations=1, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=1,
+    )
+
+    read_calls = [c for c in calls if c["mode"] != "patch"]
+    assert read_calls, "the read-only runner lane must have been invoked"
+    assert all(not c["has_artifact_root"] and not c["has_lease_id"] for c in read_calls), (
+        "X==1: runner call must carry no artifact_root and no lease_id (byte-identical, ADR 0001)"
+    )
+
+
+def test_e3c_round3_high2_start_blocker_cycle_has_no_completion_decision_x1(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 HIGH-2: when write_active_start returns blockers at X==1, the persisted
+    auto_loop_state.json cycles[0] must NOT carry a ``completion_decision`` key (HEAD never set one on
+    the start-blocker path) while STILL carrying start_decision/start_report (the round-2 snapshot fix).
+
+    Pre-fix the start-blocker path set cycle["completion_decision"]="start-blocker", an extra key that
+    broke X==1 byte-identity -> this assertion (key absent) FAILS pre-fix and PASSES after the removal."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Start blocker task")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+
+    # Force write_active_start to surface a blocker (so run_one_task takes the start.blockers path).
+    real_start = agent_loop.write_active_start
+
+    def blocking_start(**kwargs):  # type: ignore[no-untyped-def]
+        res = real_start(**kwargs)
+        return agent_loop.ActiveStartResult(
+            report_path=res.report_path,
+            active_loop=res.active_loop,
+            outputs=res.outputs,
+            decision=res.decision,
+            blockers=("simulated start blocker",),
+            warnings=res.warnings,
+            next_safe_command=res.next_safe_command,
+        )
+
+    monkeypatch.setattr(agent_loop, "write_active_start", blocking_start)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=1, execute_runner=True, execute_ship=True, repo_root=repo, task_pool=1,
+    )
+
+    assert result.decision == "blocked"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["cycles"], "the start-blocked cycle must still be persisted"
+    cyc = state["cycles"][0]
+    assert "completion_decision" not in cyc, (
+        "HIGH-2: HEAD never set completion_decision on the start-blocker path; an extra key breaks "
+        "X==1 byte-identity (ADR 0001)"
+    )
+    # The round-2 snapshot fix must still preserve the start_* fields on this path.
+    assert cyc.get("start_decision") is not None, "start_decision must survive (round-2 snapshot fix)"
+    assert "start_report" in cyc, "start_report must survive (round-2 snapshot fix)"
+
+
+def test_e3c_round3_high3_mirror_failure_fails_closed_preserves_worktree(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 HIGH-3: a cycle-artifact mirror that fails (copytree raises) must FAIL CLOSED —
+    record a blocker AND skip the worktree teardown so the in-worktree artifacts are not lost (the
+    recorded cycle paths were re-pointed to the parent mirror, so a missing mirror = dangling state).
+
+    Pre-fix the mirror was warning-only and teardown ran unconditionally -> the worktree was torn down
+    and no blocker fired. Post-fix: teardown is skipped (no ``remove``/``branch`` git ops) and a blocker
+    is registered (-> on_stop). Driven through the real _run_cycle_in_task_worktree with an injected git
+    runner; copytree is monkeypatched to raise mid-promote."""
+    parent = _write_repo(tmp_path, task_id="T-2026-1001", title="Mirror fail-closed")
+    runner = _RecordingGitRunner(create_worktree_dirs=True)
+    blockers: list[str] = []
+    stopped = {"v": False}
+
+    def register_blocker(messages):  # type: ignore[no-untyped-def]
+        blockers.extend(messages)
+        return True  # bounded contract
+
+    # The cycle writes a real active artifact inside the worktree so the mirror has something to copy.
+    def run_cycle(cycle_path):  # type: ignore[no-untyped-def]
+        art = cycle_path / "reports" / "agent_loop" / "active" / "codex_runner.md"
+        art.parent.mkdir(parents=True, exist_ok=True)
+        art.write_text("# runner\n", encoding="utf-8")
+
+    # Force the transactional copy to fail.
+    def boom_copytree(*a, **k):  # type: ignore[no-untyped-def]
+        raise OSError("simulated copytree failure")
+
+    monkeypatch.setattr(agent_loop.shutil, "copytree", boom_copytree)
+
+    agent_loop._run_cycle_in_task_worktree(
+        "T-2026-1001",
+        parent_root=parent,
+        run_cycle=run_cycle,
+        register_blocker=register_blocker,
+        on_stop=lambda: stopped.__setitem__("v", True),
+        append_warnings=lambda w: None,
+        git_runner=runner,
+    )
+
+    subs = runner.subcommands()
+    assert "remove" not in subs and "branch" not in subs, (
+        "HIGH-3 fail-closed: a failed mirror must SKIP teardown (no worktree remove / branch delete) "
+        "so the in-worktree artifacts are preserved"
+    )
+    assert any("mirror failed" in b for b in blockers), "HIGH-3: a blocker must be recorded on mirror failure"
+    assert stopped["v"] is True, "HIGH-3: the bounded blocker must route through on_stop (fail-closed)"
+
+
+def test_e3c_round3_high3_mirror_success_still_tears_down(tmp_path: Path) -> None:
+    """codex round-3 HIGH-3 happy path: a clean (successful) mirror leaves the normal teardown intact —
+    the fail-closed branch must NOT regress the success path."""
+    parent = _write_repo(tmp_path)
+    runner = _RecordingGitRunner(create_worktree_dirs=True)
+
+    def run_cycle(cycle_path):  # type: ignore[no-untyped-def]
+        art = cycle_path / "reports" / "agent_loop" / "active" / "codex_runner.md"
+        art.parent.mkdir(parents=True, exist_ok=True)
+        art.write_text("# runner\n", encoding="utf-8")
+
+    agent_loop._run_cycle_in_task_worktree(
+        "T-2026-1001",
+        parent_root=parent,
+        run_cycle=run_cycle,
+        register_blocker=lambda m: True,
+        on_stop=lambda: None,
+        append_warnings=lambda w: None,
+        git_runner=runner,
+    )
+    subs = runner.subcommands()
+    assert "remove" in subs and "branch" in subs, "a clean mirror must still tear the worktree down"
+    # The mirror physically promoted into the parent task dir.
+    mirror = parent / "reports" / "agent_loop" / "active" / "tasks" / "T-2026-1001" / "codex_runner.md"
+    assert mirror.is_file(), "the successful mirror must land under the parent task dir"
+
+
+def test_e3c_round4_high_mirror_promote_failure_restores_prior_mirror(monkeypatch, tmp_path: Path) -> None:
+    """codex round-4 HIGH: the mirror promote must be transactional via BACKUP/ROLLBACK. If the
+    staging->dst rename fails AFTER the prior mirror was moved aside, the PRIOR mirror must be restored
+    (dst never left missing) and the worktree preserved (fail-closed).
+
+    Pre-fix the promote did rmtree(dst) THEN os.replace(staging, dst); a failure between them left dst
+    gone AND the new mirror unpromoted -> the re-pointed auto_loop_state.json paths dangle. This test
+    pre-creates a prior mirror, fails ONLY the staging->dst promote (so dst->backup + backup->dst
+    rollback use the real os.replace), and asserts the prior mirror survives intact."""
+    parent = _write_repo(tmp_path, task_id="T-2026-1001", title="Mirror promote rollback")
+    runner = _RecordingGitRunner(create_worktree_dirs=True)
+    blockers: list[str] = []
+    stopped = {"v": False}
+
+    # Pre-create a PRIOR mirror at the parent task dir (a previous cycle's artifacts that must survive).
+    prior = parent / "reports" / "agent_loop" / "active" / "tasks" / "T-2026-1001"
+    prior.mkdir(parents=True, exist_ok=True)
+    (prior / "prior_artifact.md").write_text("# prior mirror -- must survive\n", encoding="utf-8")
+
+    def run_cycle(cycle_path):  # type: ignore[no-untyped-def]
+        art = cycle_path / "reports" / "agent_loop" / "active" / "codex_runner.md"
+        art.parent.mkdir(parents=True, exist_ok=True)
+        art.write_text("# new runner\n", encoding="utf-8")
+
+    # Fail ONLY the staging->dst promote (the second os.replace). The dst->backup move and the
+    # backup->dst rollback go through the real os.replace, so the double-fault window is exercised.
+    real_replace = agent_loop.os.replace
+    staging_dir = prior.with_name(prior.name + ".mirror-tmp")
+
+    def selective_replace(src, dst, *a, **k):  # type: ignore[no-untyped-def]
+        if str(src) == str(staging_dir) and str(dst) == str(prior):
+            raise OSError("simulated promote failure")
+        return real_replace(src, dst, *a, **k)
+
+    monkeypatch.setattr(agent_loop.os, "replace", selective_replace)
+
+    def register_blocker(messages):  # type: ignore[no-untyped-def]
+        blockers.extend(messages)
+        return True  # bounded contract
+
+    agent_loop._run_cycle_in_task_worktree(
+        "T-2026-1001",
+        parent_root=parent,
+        run_cycle=run_cycle,
+        register_blocker=register_blocker,
+        on_stop=lambda: stopped.__setitem__("v", True),
+        append_warnings=lambda w: None,
+        git_runner=runner,
+    )
+
+    # The PRIOR mirror must be restored (rollback) -- dst is never left missing on a failed promote.
+    assert prior.is_dir(), "round-4 HIGH: dst (prior mirror) must be restored after a failed promote"
+    assert (prior / "prior_artifact.md").read_text(encoding="utf-8") == "# prior mirror -- must survive\n", (
+        "round-4 HIGH: the prior mirror's contents must survive the failed promote (backup/rollback)"
+    )
+    # Fail-closed: teardown skipped + blocker recorded + on_stop (same contract as the copytree test).
+    subs = runner.subcommands()
+    assert "remove" not in subs and "branch" not in subs, "round-4 HIGH: a failed promote must SKIP teardown"
+    assert any("mirror failed" in b for b in blockers), "round-4 HIGH: a blocker must be recorded"
+    assert stopped["v"] is True, "round-4 HIGH: must route through on_stop (fail-closed)"
+    # No staging / backup leftovers pollute the parent task namespace after a clean rollback.
+    assert not staging_dir.exists(), "round-4 HIGH: the staging dir must be cleaned up on failure"
+    assert not prior.with_name(prior.name + ".mirror-bak").exists(), (
+        "round-4 HIGH: the backup must be gone after a successful rollback (renamed back into dst)"
+    )
+
+
+def test_e3c_round5_high_mirror_catastrophic_restore_failure_is_surfaced_not_silent(monkeypatch, tmp_path: Path) -> None:
+    """codex round-5 HIGH: if the promote AND both restores (rename + copytree) fail -- a catastrophic
+    FS-death triple-fault -- the prior mirror cannot be returned to dst. The earlier code did
+    `except: pass`, silently leaving dst missing while auto_loop_state.json still pointed at it. The fix
+    must NOT swallow: it preserves the prior copy at the `.mirror-bak` backup AND surfaces a warning that
+    NAMES that recovery location, while still failing closed (worktree preserved + blocker + on_stop)."""
+    parent = _write_repo(tmp_path, task_id="T-2026-1001", title="Mirror catastrophic restore")
+    runner = _RecordingGitRunner(create_worktree_dirs=True)
+    blockers: list[str] = []
+    warnings_seen: list[str] = []
+    stopped = {"v": False}
+
+    prior = parent / "reports" / "agent_loop" / "active" / "tasks" / "T-2026-1001"
+    prior.mkdir(parents=True, exist_ok=True)
+    (prior / "prior_artifact.md").write_text("# prior mirror -- recoverable\n", encoding="utf-8")
+    staging_dir = prior.with_name(prior.name + ".mirror-tmp")
+    backup_dir = prior.with_name(prior.name + ".mirror-bak")
+
+    def run_cycle(cycle_path):  # type: ignore[no-untyped-def]
+        art = cycle_path / "reports" / "agent_loop" / "active" / "codex_runner.md"
+        art.parent.mkdir(parents=True, exist_ok=True)
+        art.write_text("# new runner\n", encoding="utf-8")
+
+    # Fail the staging->dst promote AND every restore back to dst (rename + copytree). The dst->backup
+    # vacate (real os.replace) still succeeds, so the prior copy lands in backup and stays there.
+    real_replace = agent_loop.os.replace
+    real_copytree = agent_loop.shutil.copytree
+
+    def selective_replace(src, dst, *a, **k):  # type: ignore[no-untyped-def]
+        # promote (staging->dst) and rename-restore (backup->dst) both raise; vacate (dst->backup) is real.
+        if str(dst) == str(prior) and str(src) in (str(staging_dir), str(backup_dir)):
+            raise OSError("simulated rename failure")
+        return real_replace(src, dst, *a, **k)
+
+    def selective_copytree(src, *a, **k):  # type: ignore[no-untyped-def]
+        # the copytree-restore (backup->dst) raises; the staging build (cycle tree -> staging) is real.
+        if str(src) == str(backup_dir):
+            raise OSError("simulated copytree restore failure")
+        return real_copytree(src, *a, **k)
+
+    monkeypatch.setattr(agent_loop.os, "replace", selective_replace)
+    monkeypatch.setattr(agent_loop.shutil, "copytree", selective_copytree)
+
+    def register_blocker(messages):  # type: ignore[no-untyped-def]
+        blockers.extend(messages)
+        return True  # bounded contract
+
+    agent_loop._run_cycle_in_task_worktree(
+        "T-2026-1001",
+        parent_root=parent,
+        run_cycle=run_cycle,
+        register_blocker=register_blocker,
+        on_stop=lambda: stopped.__setitem__("v", True),
+        append_warnings=lambda w: warnings_seen.extend(w),
+        git_runner=runner,
+    )
+
+    # NOT silent: a warning must name the backup recovery location (the codex round-5 ask).
+    assert any("manual recovery" in w and str(backup_dir) in w for w in warnings_seen), (
+        f"round-5 HIGH: the catastrophic restore failure must be SURFACED with the backup recovery path, "
+        f"not silently swallowed; warnings={warnings_seen}"
+    )
+    # The prior artifacts are preserved (recoverable) at the backup, never destroyed.
+    assert (backup_dir / "prior_artifact.md").read_text(encoding="utf-8") == "# prior mirror -- recoverable\n", (
+        "round-5 HIGH: the prior mirror must be preserved at the backup for manual recovery"
+    )
+    # dst must be cleanly ABSENT -- the atomic-rename-only restore leaves no PARTIAL dst (codex round-6:
+    # a non-atomic copytree fallback could have left a partial dst that masquerades as recovery and gets
+    # this clean backup deleted). Absent dst + preserved backup is the correct catastrophic end state.
+    assert not prior.exists(), (
+        "round-6 HIGH: a failed restore must leave dst cleanly ABSENT (no partial copy); the clean prior "
+        "is preserved solely at the backup"
+    )
+    # Still fail-closed: worktree preserved (no teardown) + blocker + on_stop.
+    subs = runner.subcommands()
+    assert "remove" not in subs and "branch" not in subs, "round-5 HIGH: catastrophic mirror must SKIP teardown"
+    assert any("mirror failed" in b for b in blockers), "round-5 HIGH: a blocker must be recorded"
+    assert stopped["v"] is True, "round-5 HIGH: must route through on_stop (fail-closed)"
+
+
+def test_e3c_round3_med2_stop_denied_completion_persists_mutated_cycle_x_gt_1(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 MED-2: at X>1, when a sibling sets stop_event AFTER this task has written its
+    runner/gate fields, the local-gate completion is DENIED (complete_if_not_stopped == False). The
+    early return must still persist the work-done cycle (gate fields + completion_decision) — not the
+    stale initial snapshot.
+
+    Deterministic interleaving: task A's runner returns ``blocked`` -> A registers a (bounded) blocker
+    -> stop_event.set(); the worktree stub for task B WAITS until A's run_cycle returns (stop is set by
+    then) before running B's cycle, so B's runner completes + gate is ready and B reaches the local-gate
+    completion site with stop already set -> denied. The persisted B cycle must carry completion_decision=
+    'local-gate-complete' + gate_ready, proving the pre-return snapshot ran.
+
+    Pre-fix the denied return skipped the upsert and B's persisted cycle stayed the bare initial
+    registration snapshot (no completion_decision / gate fields) -> assertion FAILS. Post-fix it passes.
+    X==1 note: complete_if_not_stopped is ALWAYS True at X=1 (stop_event never set mid-cycle) so this
+    pre-return snapshot is on a dead branch -> byte-identical (ADR 0001)."""
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="A-runner-blocked")
+    _append_ready_task(repo, "T-2026-1002", "B-gate-ready")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_active_loop_clear(monkeypatch)
+
+    def task_aware_runner(**kwargs):  # type: ignore[no-untyped-def]
+        # A (1001) runner BLOCKED -> bounded terminal blocker -> stop_event.set() (with a recorded
+        # blocker so the run decision is 'blocked'). B (1002) runner COMPLETED -> reaches the gate.
+        task_id = str(kwargs.get("task_id") or "")
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        decision = "blocked" if task_id == "T-2026-1001" else "completed"
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, decision, (), (), ())
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", task_aware_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", _infinite_fake_gate(active_dir))
+
+    a_returned = threading.Event()
+
+    def stub(task_id, *, parent_root, run_cycle, register_blocker, on_stop, append_warnings, git_runner=None):  # type: ignore[no-untyped-def]
+        if task_id == "T-2026-1001":
+            run_cycle(repo)            # A runs, hits gate-not-ready terminal, sets stop_event internally
+            a_returned.set()           # signal: stop_event is now set
+        else:
+            assert a_returned.wait(timeout=10), "task A must reach its terminal (and set stop) first"
+            run_cycle(repo)            # B runs fully with stop already set -> denied at completion site
+
+    monkeypatch.setattr(agent_loop, "_run_cycle_in_task_worktree", stub)
+
+    result = agent_loop.write_active_auto_loop(
+        max_iterations=5,  # bounded: A's blocker stops the run
+        execute_runner=True, execute_ship=False, repo_root=repo, task_pool=2,
+    )
+
+    assert result.decision == "blocked"
+    assert "T-2026-1002" not in result.completed_task_ids, "B's completion was denied (stop set)"
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    b_cycles = [c for c in state["cycles"] if c.get("task_id") == "T-2026-1002"]
+    assert b_cycles, "B's cycle must be persisted"
+    b = b_cycles[-1]
+    assert b.get("completion_decision") == "local-gate-complete", (
+        "MED-2: the stop-denied B cycle must persist the mutated completion_decision (not the stale "
+        "initial snapshot)"
+    )
+    assert b.get("gate_ready") is True, "MED-2: B's gate fields must survive into the persisted cycle"
+    assert b.get("completed") is not True, "B must NOT be marked completed (stop denied promotion)"
+
+
+def test_e3c_round3_med1_warnings_list_is_lock_guarded(monkeypatch, tmp_path: Path) -> None:
+    """codex round-3 MED-1: the driver's shared ``warnings`` list is a lock-guarded
+    _ThreadSafeWarningList so concurrent worker-thread appends + a checkpoint/final-serialization read
+    (snapshot) cannot tear or raise. A deterministic data-race test is impractical, so this asserts the
+    lock primitive exists + is exercised: (1) the type is installed at the driver call site (captured via
+    write_cycle_checkpoint's read), and (2) a stress of concurrent append/extend + snapshot never raises
+    and preserves every item.
+
+    Pre-fix ``warnings`` was a plain list (no .snapshot / no lock) -> the captured object would lack the
+    lock + snapshot method -> assertion fails."""
+    # (1) Capture the actual warnings object the driver uses by spying on _dedupe_preserve_order, which
+    # the checkpoint + final serialization call as _dedupe_preserve_order(warnings.snapshot()). We patch
+    # snapshot indirectly by recording the object type the driver builds.
+    captured: dict = {}
+    real_ctor = agent_loop._ThreadSafeWarningList
+
+    class _SpyList(real_ctor):  # type: ignore[misc, valid-type]
+        def snapshot(self):  # type: ignore[no-untyped-def]
+            captured["snapshot_called"] = True
+            return super().snapshot()
+
+    monkeypatch.setattr(agent_loop, "_ThreadSafeWarningList", _SpyList)
+
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Warnings lock")
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    _patch_auto_loop_inner(monkeypatch, active_dir)
+    agent_loop.write_active_auto_loop(
+        max_iterations=1, execute_runner=True, execute_ship=False, repo_root=repo, task_pool=1,
+    )
+    assert captured.get("snapshot_called") is True, (
+        "MED-1: the driver must read warnings via the locked .snapshot() (not the live list)"
+    )
+
+    # (2) Stress: concurrent append/extend while a reader snapshots — must never raise, never lose items.
+    wl = agent_loop._ThreadSafeWarningList()
+    assert hasattr(wl, "_lock"), "MED-1: the warnings list must own a dedicated lock"
+    errors: list[BaseException] = []
+    N = 500
+
+    def writer(prefix: str):  # type: ignore[no-untyped-def]
+        try:
+            for i in range(N):
+                if i % 2 == 0:
+                    wl.append(f"{prefix}-{i}")
+                else:
+                    wl.extend([f"{prefix}-{i}"])
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    def reader():  # type: ignore[no-untyped-def]
+        try:
+            for _ in range(N):
+                _ = _dedupe_helper(wl.snapshot())
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=writer, args=("a",)),
+        threading.Thread(target=writer, args=("b",)),
+        threading.Thread(target=reader),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"MED-1: concurrent append/extend + snapshot must not raise: {errors}"
+    assert len(wl) == 2 * N, "MED-1: every concurrent append/extend must be retained (no lost update)"
+
+
+def _dedupe_helper(items):  # type: ignore[no-untyped-def]
+    """Mirror _dedupe_preserve_order's read pattern (iterate the input) for the MED-1 stress test."""
+    return agent_loop._dedupe_preserve_order(items)
 
 
 def test_omc_heartbeat_invalidation_failure_overwrites_standard_proposed(


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

X-task-pool 병렬 epic(ADR 0094 concurrency substrate + ADR 0095 X+Y)의 **E3c 브릭**. X>1 fan-out 시 cycle-in-worktree 실행 경로를 안전·정확하게 만들고, **X=1 기본값에서는 출력이 byte-identical(ADR 0001)** 하도록 모든 X>1 전용 로직을 dead-code로 게이트한다 (`effective_task_pool_size>1` / `effective_repo_root != repo_root` / `stop_event` — X=1 에서 미발동).

주요 변경 5종:
- **HIGH-1 runner/repair lease-kwargs 분리** — `write_active_codex_runner` 는 `artifact_root` 파라미터가 없어 공유 kwargs 가 X>1 에서 TypeError. `runner_lease_kwargs`(lease_id only) / `repair_lease_kwargs`(lease_id + artifact_root) / `ship_reject_kwargs` 로 분리. 전부 X=1 에서 empty.
- **HIGH-2 start-blocker** — `start.blockers` 경로가 `cycle["completion_decision"]` 를 설정하지 않도록 (HEAD 미설정 → X=1 byte-identity 회귀 방지).
- **MED-1 `_ThreadSafeWarningList`** — lock-guarded append/extend + atomic `snapshot()`. `list` 서브클래스라 JSON 직렬화 동일, X=1 uncontended → byte-identical.
- **MED-2 stop-denied cycle snapshot** — `complete_if_not_stopped` False 인 3경로에서 작업 완료 cycle 을 반환 전 persist (X=1 에서 항상 True → dead).
- **`_mirror_cycle_artifacts_to_parent`** — child cycle worktree → parent task dir 로 artifact transactional 미러. 모든 `dst` 변경은 atomic `os.replace` (vacate→promote→restore), 부분/무성/거짓성공 경로 없음, 실패 시 fail-closed + backup 보존 + worktree 보존. X>1 분기(`_run_cycle_in_task_worktree`)에서만 호출.

Closes #1839

## 2. 영향 파일

- `scripts/agent_loop.py` — **non-load-bearing** (`scripts/_governance.py` `LOAD_BEARING_PATHS` 에 없음 → real-data/eval 표면 무관). X>1 cycle-worktree 경로 안전화.
- `tests/test_agent_loop.py` — 9개 e3c 회귀 테스트 추가.

## 3. 리스크

- 가장 가능성 높은 깨짐: **X=1 기본 경로의 byte-identity 회귀**. 배제 근거 — 모든 X>1 전용 로직을 위 3게이트로 dead-code화; X=1 은 `run_one_task` 를 직접 호출하므로 `_run_cycle_in_task_worktree`(미러 호출자)에 진입 자체를 안 함.
- transactional mirror 의 corrupt/silent-loss/false-promote 위험: 모든 `dst` 변경이 atomic rename 이라 부분 `dst` 불가; clean backup 은 `dst.exists()`(=완전한 dst) 일 때만 삭제; 복구 실패 시 backup 보존 + manual-recovery 경로 surface.
- **7라운드 codex adversarial review** (round-4/5/6 각각 실제 결함 발견 후 수정, round-7 `VERDICT: SHIP` — code-reviewer + architect 양 레인 동의).

## 4. 테스트

- 9개 e3c 회귀 테스트 (round-3 7 + round-4/5 mirror 2): X>1 runner-call artifact_root 누락, start-blocker no-completion_decision, mirror fail-closed/teardown, MED-2 stop-denied 결정적 interleaving, MED-1 lock snapshot stress, mirror promote-failure restore, catastrophic-restore non-silent.
- **통합 검증**: 현재 main 으로 rebase 후 `pytest tests/test_agent_loop.py tests/test_e3b_active_loop_coordination.py tests/test_concurrency_regression.py tests/test_global_concurrency_limiter_regression.py tests/test_lease_claim_disjoint_regression.py tests/test_agent_loop_worktree_confinement.py` → **490 passed** (이전 로컬 e3b lease flake 는 #1850 wall-clock seed 로 upstream 해소).
- **overlap-preflight (parallel worktree PR)**: Result=`clear` — target branch ADR 0007 합치, no open PR/worktree/remote-branch matched issue/branch, warnings None.

## 5. Eval 영향

N/A — `scripts/agent_loop.py` 는 load-bearing 아님 (RAG 파이프라인·real-data 표면 무관). CI eval delta = All `·`.

## 6. 하위 호환

계약/스키마 변경 없음. X=1 기본값 byte-identical (ADR 0001 보존). 답변 계약(ADR 0003) 무관, CLI flag/doc link 변경 없음.

## 7. 범위 외

- `ACTIVE_TASK_POOL` 기본값 1→2 flip + ADR 0094/0095 Proposed→Accepted + runbook `docs/operations/active-agent-loop.md` → **PR-F** (epic 마지막 브릭, 별도 PR). E3c 는 machinery 만 추가하고 dark 유지.
- Pyright line-shift 재노출 진단(pre-existing, untouched code) — CI pytest-only, one-PR-one-concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
