### PR TITLE
docs: record overlap evidence for observability traces

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -167,6 +167,11 @@ flyctl deploy
 - `diagnostics` 의 `trace_url` — Streamlit 에서 클릭 가능, CLI 모드에서는
   `outputs/answer.json` 에 기록, FastAPI JSON 응답에서 반환됨.
 
+병행 Codex/Claude worktree에서 생성한 trace URL을 PR/debug evidence로 첨부할 때는
+[`overlap-preflight`](ai-codex-workflow.md#overlap-preflight) 결과를 함께 남긴다.
+trace가 가리키는 실행이 다른 세션의 파일 변경과 겹치지 않았다는 provenance 없이는
+regression 근거로 승격하지 않는다.
+
 ```jsonc
 // diagnostics block of a tracing-enabled run
 {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/observability.md`에 병행 Codex/Claude worktree에서 만든 trace URL을 PR/debug evidence로 붙일 때 `overlap-preflight` 결과를 함께 남기라는 evidence hygiene 문단을 추가했습니다. trace 기반 regression 근거가 다른 세션 변경과 섞이지 않았음을 증명하기 위함입니다.

Closes #1928

## 2. 영향 파일

- `docs/operations/observability.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: trace runtime이나 backend 설정 변경으로 오해될 수 있음.
- 배제: env var, trace schema, backend setup, code path는 변경하지 않고 PR/debug evidence 문단만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1928 --branch docs/issue-1928-observability-overlap-evidence` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/observability.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Observability/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing observability env vars and trace diagnostics remain unchanged.

## 7. 범위 외

- No observability backend runtime test.
- No trace schema or dependency changes.
- No worktree cleanup despite orphan-worktree warnings.
