### PR TITLE
docs: scope private eval inventory stale real100 index rule

### DIFF
--- a/docs/private-real-eval-inventory.md
+++ b/docs/private-real-eval-inventory.md
@@ -58,9 +58,11 @@ friendly error 로 중단해야 한다.
 
 - Cache/index 는 missing 이어도 hard failure 가 아니다. 원본 input 이 있으면
   재생성(regeneration) 경로로 진행한다.
-- Existing private real100 index 의 metadata 가 `num_documents >= 50` 이고
-  `0 < num_chunks <= 1000` 이면 stale/invalid CSV fallback index 로 표시한다.
-  현재 허용 기준은 kordoc 26k급 index 다.
+- Existing legacy/non-v2 private `real100` index 의 metadata 가
+  `num_documents >= 50` 이고 `0 < num_chunks <= 1000` 이면 stale/invalid CSV
+  fallback index 로 표시한다. 이 heuristic 은 archive-only v1/legacy path 점검용이며,
+  현재 `real100_v2` index claim 은 `data/index/real100_v2/` manifest 와
+  `make real-eval-v2-guard` 로 별도 검증한다.
 - `reports/real100_v2/eval_summary.json` 은 output artifact 다. 실행 전 required
   input 으로 요구하면 안 된다.
 - Baseline comparison 은 `REAL_EVAL_BASELINE_SUMMARY` 또는


### PR DESCRIPTION
## §1 Summary
- Scope the private eval inventory stale-index heuristic to legacy/non-v2 `real100` paths.
- Keep current index claims tied to `real100_v2` manifest and guard validation.

Closes #1929

## §2 Changes
- Updated `docs/private-real-eval-inventory.md` cache/index rules to distinguish archive-only v1 diagnostics from current `real100_v2` validation.

## §3 Verification
- `python3 scripts/check_doc_links.py --check-all --paths docs/private-real-eval-inventory.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §4 Risk / Rollback
- Risk: low; docs-only wording update.
- Rollback: revert this PR.

## §5 Eval Impact
- Documentation-only; no eval/runtime behavior changed.
- Clarifies that stale legacy index detection is not current `real100_v2` evidence.

## §6 Screenshots / Artifacts
N/A — markdown-only docs update.

## §7 Follow-ups
N/A.

Constraint: Current private-eval evidence must use real100_v2, while this inventory still needs to document stale legacy real100 index detection.
Rejected: Remove the stale-index heuristic | it remains useful for diagnosing archive-only v1/non-v2 paths.
Confidence: high
Scope-risk: narrow
Directive: Inventory rules should separate legacy real100 path diagnostics from current real100_v2 claim validation.
Tested: python3 scripts/check_doc_links.py --check-all --paths docs/private-real-eval-inventory.md; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
Not-tested: GitHub Pages render after merge.
