### PR TITLE
docs: add overlap preflight to deployment checklist

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -17,6 +17,9 @@ CLI / eval 흐름(배포 아님)에 대해서는
 
 ## Pre-flight 체크리스트
 
+- [ ] 병행 Codex/Claude worktree에서 배포 PR 또는 배포 증거를 만들고 있다면
+      [`overlap-preflight`](./ai-codex-workflow.md#overlap-preflight) 결과와
+      evidence sink를 PR에 남겼다.
 - [ ] `make smoke` 가 로컬에서 통과 — 데모는 같은 파이프라인을 실행한다.
 - [ ] `data/index/index.json` 이 존재(또는 컨테이너가 첫 시작 시
       빌드한다 — cold start 에 ~10 s 추가).


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/deployment.md`의 Pre-flight 체크리스트에 병행 Codex/Claude worktree에서 배포 PR 또는 배포 증거를 준비할 때 `overlap-preflight` 결과와 evidence sink를 PR에 남기라는 항목을 추가했습니다. 배포 evidence가 다른 세션 변경과 섞이지 않았음을 보존하기 위함입니다.

Closes #1932

## 2. 영향 파일

- `docs/operations/deployment.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: 실제 배포 workflow나 secrets 요구사항 변경으로 오해될 수 있음.
- 배제: 체크리스트 문서 항목만 추가했고 deploy workflow, Fly/HF/Railway commands, secrets 설정은 변경하지 않았습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1932 --branch docs/issue-1932-deployment-overlap-preflight` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/deployment.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Deployment/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing deployment recipes and commands are unchanged.

## 7. 범위 외

- No deploy command execution.
- No workflow/secrets/branch-protection changes.
- No worktree cleanup despite orphan-worktree warnings.
