### PR TITLE
docs: mark private eval suitability audit as historical snapshot

### DIFF
--- a/docs/evaluation/private_real_eval_suitability_audit.md
+++ b/docs/evaluation/private_real_eval_suitability_audit.md
@@ -1,5 +1,11 @@
 # Private Real-Eval Suitability Audit
 
+> **Snapshot note.** 이 audit 의 verdict 는 작성 당시 checkout 에 대한 historical
+> readiness snapshot 이며, 현재 private eval 준비 상태나 claim 근거가 아니다. 새
+> 작업·PR·claim 에서 private eval readiness 를 주장하려면 현재 `real100_v2` 표면을
+> `make real-eval-v2-check`, `make real-eval-v2-inventory`,
+> `make real-eval-v2-guard` 로 다시 검증해야 한다.
+
 ## Executive Summary
 
 최종 verdict: **A. Not ready**.


### PR DESCRIPTION
## §1 Summary
- Mark the private real-eval suitability audit verdict as a historical checkout snapshot.
- Direct current readiness claims to fresh `real100_v2` check/inventory/guard validation.

Closes #1933

## §2 Changes
- Added a snapshot note at the top of `docs/evaluation/private_real_eval_suitability_audit.md`.

## §3 Verification
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_suitability_audit.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §4 Risk / Rollback
- Risk: low; docs-only qualifier.
- Rollback: revert this PR.

## §5 Eval Impact
- Documentation-only; no eval/runtime behavior changed.
- Prevents an older readiness verdict from being reused as current `real100_v2` evidence.

## §6 Screenshots / Artifacts
N/A — markdown-only docs update.

## §7 Follow-ups
N/A.

Constraint: Current private-eval readiness claims must be validated on real100_v2, while this audit preserves an older checkout verdict.
Rejected: Re-run private eval readiness checks | not needed for a docs-only snapshot qualifier and would require local private state.
Confidence: high
Scope-risk: narrow
Directive: Historical audits should not present checkout-specific readiness verdicts as current evidence without fresh real100_v2 checks.
Tested: python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_suitability_audit.md; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
Not-tested: Current private data readiness; GitHub Pages render after merge.
