### PR TITLE
docs: record overlap evidence for API demo runs

### DIFF
--- a/docs/operations/api-demo.md
+++ b/docs/operations/api-demo.md
@@ -16,6 +16,10 @@
 API 는 인덱스를 스스로 빌드하지 않는다; 디스크에 준비된 것을 로드해
 `rag_core.run_rag_query` 를 세 개의 작은 엔드포인트 뒤에 감싼다.
 
+병행 Codex/Claude worktree에서 API demo 응답을 PR evidence로 첨부할 때는 먼저
+[`overlap-preflight`](./ai-codex-workflow.md#overlap-preflight)를 실행하고 결과를
+함께 남긴다. 다른 세션의 인덱스·코드 변경과 겹친 demo 응답은 재현 근거로 쓰지 않는다.
+
 ## 엔드포인트
 
 | Method | Path | Description |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/api-demo.md`에 병행 Codex/Claude worktree에서 만든 API demo 응답을 PR evidence로 첨부할 때 `overlap-preflight` 결과를 함께 남기라는 provenance 문단을 추가했습니다. demo 응답이 다른 세션의 인덱스/코드 변경과 섞이지 않았음을 증명하기 위함입니다.

Closes #1936

## 2. 영향 파일

- `docs/operations/api-demo.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: API/container 동작 변경으로 오해될 수 있음.
- 배제: endpoints, request/response body, env vars, container commands는 변경하지 않고 evidence 문단만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1936 --branch docs/issue-1936-api-demo-overlap-evidence` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/api-demo.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. API/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing API demo commands and response contract remain unchanged.

## 7. 범위 외

- No API runtime/container test.
- No endpoint, env var, or index behavior changes.
- No worktree cleanup despite orphan-worktree warnings.
