### PR TITLE
docs: mark rationality judge real100 audit historical

### DIFF
--- a/docs/audits/rationality-llm-judge-comparison.md
+++ b/docs/audits/rationality-llm-judge-comparison.md
@@ -3,7 +3,12 @@
 - Date: 2026-05-23
 - Issue/PR: #1377
 - ADR: [0056](../adr/0056-rationality-judge-measurement-surface.md) (Measurement appendix — LLM backend)
-- Surface: 비공개 real-100, n=221 (aggregate-only — ADR 0005)
+- Surface: historical v1 비공개 real-100, n=221 (aggregate-only archive-only — ADR 0005)
+
+> **Historical scope note.** 이 audit 은 2026-05-23 v1 `real100` judge 비교 기록이며,
+> 현재 private eval claim 근거가 아니다. 새 작업·PR·claim 에서 rationality judge
+> 성능이나 slice-sensitive 변별력을 주장하려면 별도 `real100_v2` aggregate evidence 를
+> 먼저 생성·검증해야 한다.
 
 ## 무엇을 측정했나
 


### PR DESCRIPTION
## §1 Summary
- Mark the rationality LLM judge comparison audit as historical v1 `real100` archive-only evidence.
- Require fresh `real100_v2` aggregate evidence before reusing judge comparison claims in new work.

Closes #1941

## §2 Changes
- Qualified the audit surface line in `docs/audits/rationality-llm-judge-comparison.md`.
- Added a historical scope note for current claim boundaries.

## §3 Verification
- `python3 scripts/check_doc_links.py --check-all --paths docs/audits/rationality-llm-judge-comparison.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §4 Risk / Rollback
- Risk: low; docs-only qualifier.
- Rollback: revert this PR.

## §5 Eval Impact
- Documentation-only; no eval/runtime behavior changed.
- Prevents a v1 `real100` judge comparison from being used as current private eval evidence.

## §6 Screenshots / Artifacts
N/A — markdown-only docs update.

## §7 Follow-ups
N/A.

Constraint: Current private-eval claims must use real100_v2, while this audit preserves a 2026-05 v1 real100 judge comparison.
Rejected: Re-run the rationality judge on real100_v2 | outside this docs-only qualifier and would require private eval work.
Confidence: high
Scope-risk: narrow
Directive: Judge comparison audits should identify legacy v1 real100 evidence as archive-only unless fresh real100_v2 aggregates are attached.
Tested: python3 scripts/check_doc_links.py --check-all --paths docs/audits/rationality-llm-judge-comparison.md; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
Not-tested: real100_v2 rationality judge rerun; GitHub Pages render after merge.
