### PR TITLE
docs: add overlap preflight to experiment report multi-worktree note

### DIFF
--- a/docs/operations/experiment-report-html.md
+++ b/docs/operations/experiment-report-html.md
@@ -82,6 +82,9 @@ BIDMATE_EXPERIMENT_REPORT_FORCE=1 \
 디렉터리를 공유하는 경우 HTML write 가 race 할 수 있어서 atomic write
 (`tempfile.NamedTemporaryFile` + `os.replace`) 로 완화하지만, 동시 실행은
 권장하지 않는다.
+병행 Codex/Claude 세션에서 report HTML을 PR evidence로 붙이려면 먼저
+[`overlap-preflight`](./ai-codex-workflow.md#overlap-preflight)를 실행해
+공유 reports/ 경로 또는 변경 파일 충돌이 없다는 근거를 남긴다.
 
 ## Non-goals
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/operations/experiment-report-html.md`의 Multi-worktree 주의에 report HTML을 PR evidence로 붙이기 전 `overlap-preflight` 결과를 남기라는 문장을 추가했습니다. 병행 Codex/Claude 세션에서 생성된 report HTML이 공유 `reports/` 경로나 변경 파일 충돌과 섞이지 않았음을 증명하기 위함입니다.

Closes #1942

## 2. 영향 파일

- `docs/operations/experiment-report-html.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: renderer behavior나 artifact schema 변경으로 오해될 수 있음.
- 배제: renderer command, hooks, allowlist/denylist, artifact paths는 변경하지 않고 Multi-worktree 주의 문장만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1942 --branch docs/issue-1942-experiment-report-overlap-preflight` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/experiment-report-html.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Report renderer/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing report HTML generation remains unchanged.

## 7. 범위 외

- No report renderer runtime test.
- No hook, Make target, allowlist, or denylist changes.
- No worktree cleanup despite orphan-worktree warnings.
