### PR TITLE
chore(codex-gate): finding-field severity 검증 + embed scope 축소 (#1920)

### DIFF
--- a/scripts/run_codex_adversarial_precommit.py
+++ b/scripts/run_codex_adversarial_precommit.py
@@ -231,8 +231,11 @@ def build_focus(
             )
         else:
             focus += (
-                "\n\nStaged diff (`git diff --cached`) follows; treat it as the "
-                "authoritative change set for this commit." + instr_tail + body
+                "\n\nStaged diff (`git diff --cached`) follows, scoped to the "
+                "load-bearing staged paths under review; treat it as the "
+                "authoritative change set for those paths. Other staged files "
+                "listed above are out of this gate's scope and not embedded."
+                + instr_tail + body
             )
     return focus
 
@@ -557,14 +560,36 @@ def _payload_findings(payload: dict[str, object] | None) -> list[dict[str, objec
     return [f for f in findings if isinstance(f, dict)]
 
 
+def _is_recognized_severity(value: object) -> bool:
+    """True iff ``value`` is a severity string the block decision actually honors.
+
+    ``severity_rank`` / ``Cluster.max_severity`` silently fold any unrecognized
+    severity to ``unknown`` / ``"low"`` — i.e. NON-blocking. So a finding whose
+    severity is malformed or missing (``None``, an int, a typo like ``"critikal"``)
+    is treated as low and slips past the critical/high block gate, silently
+    downgrading what may be a real critical finding (issue #1920). Requiring a
+    recognized severity for a pass to count as valid closes that hole. The Codex
+    companion's structured output constrains severity to the same enum, so a
+    well-formed response always passes — only broken output is rejected.
+    """
+    return isinstance(value, str) and value.lower() in SEVERITY_RANK
+
+
 def _is_valid_result(payload: dict[str, object] | None) -> bool:
-    """True iff a pass carries a known verdict and a list of dict ``findings``.
+    """True iff a pass carries a known verdict and well-formed dict ``findings``.
 
     A non-dict / unknown-verdict / non-list-findings ``result`` — or a findings
     list with non-dict items — would otherwise read as a clean empty-findings
     success (via ``_payload_findings`` dropping non-dict items), inflating
     ``successful_passes`` and weakening the ``successful_passes < min_frequency``
     fail-closed gate (issue #1693; the non-dict-item case is a dogfood self-catch).
+    Each finding must also carry a recognized ``severity`` (issue #1920): the
+    block decision reads only ``max_severity``, which folds an unrecognized
+    severity to non-blocking, so a malformed-severity pass is classified as an
+    error (fail-closed) rather than trusted as a clean success. Block-irrelevant
+    fields (summary/title/body/recommendation/confidence) are left to the
+    renderer's ``.get`` defaults — over-validating them would only manufacture
+    false fail-closed blocks.
     """
     if payload is None or payload.get("parseError"):
         return False
@@ -574,7 +599,12 @@ def _is_valid_result(payload: dict[str, object] | None) -> bool:
     if result.get("verdict") not in VALID_VERDICTS:
         return False
     findings = result.get("findings")
-    return isinstance(findings, list) and all(isinstance(f, dict) for f in findings)
+    if not isinstance(findings, list):
+        return False
+    return all(
+        isinstance(f, dict) and _is_recognized_severity(f.get("severity"))
+        for f in findings
+    )
 
 
 def severity_rank(severity: str | None) -> int:
@@ -870,7 +900,9 @@ def _staged_diff_digest() -> str | None:
     return hashlib.sha256(proc.stdout or b"").hexdigest()
 
 
-def _staged_diff_snapshot(*, max_bytes: int = 60_000) -> str | None:
+def _staged_diff_snapshot(
+    *, paths: Sequence[str] | None = None, max_bytes: int = 60_000
+) -> str | None:
     """Text of the staged diff (`git diff --cached --no-color`), truncated to
     ``max_bytes`` UTF-8 bytes, or None on git failure.
 
@@ -880,10 +912,21 @@ def _staged_diff_snapshot(*, max_bytes: int = 60_000) -> str | None:
     empty HEAD..HEAD structured diff, so the focus is the only reliable channel
     for the actual staged content (issue #1693). Fail-open: returns None on any
     git error so the gate falls back to the prose-only focus, never crashing.
+
+    When ``paths`` is given (the load-bearing hits that triggered the gate), the
+    diff is scoped to those paths (`git diff --cached -- <paths>`). The gate only
+    fires on load-bearing changes, so embedding the *entire* staged diff would
+    ship unrelated staged content — potentially secrets a co-staged file carries —
+    to Codex for no review benefit. Scoping bounds the payload to exactly what the
+    review is about (issue #1920). ``changed_files`` in the focus prose still
+    lists every staged path for awareness.
     """
+    cmd = ["git", "diff", "--cached", "--no-color"]
+    if paths:
+        cmd += ["--", *paths]
     try:
         proc = subprocess.run(
-            ["git", "diff", "--cached", "--no-color"],
+            cmd,
             capture_output=True,
             text=True,
             check=False,
@@ -1061,7 +1104,7 @@ def run_precommit_review(
         raise ValueError("--timeout-sec must be >= 1")
 
     digest = _staged_diff_digest()
-    staged_diff = _staged_diff_snapshot()
+    staged_diff = _staged_diff_snapshot(paths=hits)
     pol_dgst = _policy_digest(
         start_attempts=start_attempts,
         cap_attempts=attempts,

--- a/tests/test_codex_adversarial_precommit.py
+++ b/tests/test_codex_adversarial_precommit.py
@@ -1399,6 +1399,115 @@ def test_is_valid_result_rejects_nondict_finding_items():
     assert precommit._is_valid_result(mixed) is False
 
 
+# ----- finding-field severity validation (issue #1920) ----------------------
+# The block decision reads only max_severity, which folds an unrecognized
+# severity to non-blocking. A finding whose severity is malformed/missing would
+# silently downgrade a would-be critical past the gate, so such a pass is an
+# error (fail-closed), not a clean success.
+
+
+def test_is_recognized_severity_accepts_known_rejects_malformed():
+    for good in ("critical", "high", "medium", "low", "CRITICAL", "High"):
+        assert precommit._is_recognized_severity(good) is True
+    for bad in (None, 42, "", "critikal", "sev-1", ["high"], {"x": 1}):
+        assert precommit._is_recognized_severity(bad) is False
+
+
+def test_malformed_severity_finding_counts_as_error_pass():
+    missing = {"result": {"verdict": "needs-attention", "findings": [{"title": "x"}]},
+               "parseError": None}
+    typo = {"result": {"verdict": "needs-attention",
+                       "findings": [{"severity": "critikal", "title": "x"}]},
+            "parseError": None}
+    nonstr = {"result": {"verdict": "needs-attention",
+                        "findings": [{"severity": 42, "title": "x"}]},
+              "parseError": None}
+    good = _payload([_finding(severity="critical")])
+    assert precommit._is_valid_result(missing) is False
+    assert precommit._is_valid_result(typo) is False
+    assert precommit._is_valid_result(nonstr) is False
+    assert precommit._is_valid_result(good) is True
+    # PassResult.is_error mirrors it.
+    assert precommit.PassResult(index=0, payload=typo, stdout="", stderr="", rc=0).is_error is True
+    assert precommit.PassResult(index=0, payload=good, stdout="", stderr="", rc=0).is_error is False
+
+
+def test_malformed_severity_does_not_silently_pass_gate(tmp_path: Path, monkeypatch):
+    # End-to-end: passes that all report a CRITICAL finding with a malformed
+    # severity ("CRITICAL!!" → folds to non-blocking) must NOT slip through as a
+    # clean rc=0 — they classify as errors, so successful_passes=0 < min_frequency
+    # → fail-closed block (rc=1). Pre-#1920 this returned rc=0 (silent pass).
+    monkeypatch.setattr(precommit, "_staged_diff_snapshot", lambda **_: "diff")
+    bad = {"result": {"verdict": "needs-attention",
+                      "findings": [{"severity": "CRITICAL!!", "file": "rag_core.py",
+                                    "line_start": 1, "line_end": 2, "title": "boom"}]},
+           "parseError": None}
+
+    def runner(cmd, timeout_sec):
+        return _proc(bad)
+
+    rc = precommit.run_precommit_review(
+        attempts=2, base="HEAD", scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py"], hits=["rag_core.py"],
+        out_dir=tmp_path, timeout_sec=900, min_frequency=2, runner=runner,
+    )
+    assert rc == 1  # fail-closed, not a silent rc=0
+
+
+# ----- embedded staged-diff scope (issue #1920) -----------------------------
+# The gate fires on load-bearing paths but previously embedded the ENTIRE staged
+# diff, shipping unrelated co-staged content to Codex. Scope the snapshot to the
+# hits so the payload is bounded to what the review is about.
+
+
+def test_staged_diff_snapshot_scopes_to_load_bearing_paths(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="diff body", stderr="")
+
+    monkeypatch.setattr(precommit.subprocess, "run", fake_run)
+    precommit._staged_diff_snapshot(paths=["rag_core.py", "docs/adr/0066-x.md"])
+    assert captured["cmd"][:4] == ["git", "diff", "--cached", "--no-color"]
+    assert captured["cmd"][4:] == ["--", "rag_core.py", "docs/adr/0066-x.md"]
+
+
+def test_staged_diff_snapshot_no_paths_diffs_everything(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="d", stderr="")
+
+    monkeypatch.setattr(precommit.subprocess, "run", fake_run)
+    precommit._staged_diff_snapshot()  # paths=None → no pathspec
+    assert "--" not in captured["cmd"]
+
+
+def test_run_precommit_review_scopes_snapshot_to_hits(tmp_path: Path, monkeypatch):
+    seen: dict[str, object] = {}
+
+    def fake_snapshot(*, paths=None, max_bytes=60_000):
+        seen["paths"] = paths
+        return "diff"
+
+    monkeypatch.setattr(precommit, "_staged_diff_snapshot", fake_snapshot)
+
+    def runner(cmd, timeout_sec):
+        return _proc(_payload([], verdict="approve"))
+
+    rc = precommit.run_precommit_review(
+        attempts=2, base="HEAD", scope="branch",
+        companion=Path("/tmp/codex-companion.mjs"),
+        changed_files=["rag_core.py", "foo.txt"], hits=["rag_core.py"],
+        out_dir=tmp_path, timeout_sec=900, min_frequency=2, runner=runner,
+    )
+    assert rc == 0
+    assert seen["paths"] == ["rag_core.py"]  # scoped to load-bearing hits, not foo.txt
+
+
 # ----- staged-diff snapshot embedded in focus (issue #1693 #3) --------------
 # The companion is invoked with `--base HEAD --scope branch`, so its structured
 # REVIEW_INPUT "Branch Diff" is empty (HEAD..HEAD). Capturing the staged diff


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#1693 dogfood 가 codex adversarial pre-commit 게이트의 자기 변경에서 재현한 강한 finding 중 **입력검증/스코프** 하드닝 2건. 게이트의 union/freq/fail-closed/escalation 기본 모델은 불변(semantics 무변경) — ADR 0066 의 "malformed→fail-closed" 원칙 내 정제다. **(1)** block 판정이 `max_severity ∈ {critical, high}` 에만 의존하는데 `severity_rank`/`max_severity` 가 인식 못 하는 severity 를 non-blocking 으로 fold 하므로, severity 가 malformed/누락된 critical finding 이 조용히 강등돼 게이트를 통과하던 hole 을 `_is_valid_result` 의 finding-field 검증으로 닫았다. **(2)** 게이트는 load-bearing 경로에서만 발화하는데 embed 는 전체 staged diff 를 보내 무관 staged 내용을 Codex 로 전송하던 것을, snapshot 을 load-bearing hits 로 scope 했다.

Closes #1920

**스택**: 이 PR 은 #1925 (chore/issue-1693-codex-gate-robustness) 위에 stack — `_is_valid_result`/`_staged_diff_snapshot` 가 #1925 에서 도입되어 base 가 main 이 아니다. #1925 머지 후 main 으로 자동 retarget.

## 2. 영향 파일

- `scripts/run_codex_adversarial_precommit.py` — `_is_recognized_severity` helper 신규 + `_is_valid_result` 가 각 finding 의 severity 인식성 검증; `_staged_diff_snapshot(paths=...)` 로 scope + caller 가 `hits` thread; `build_focus` prose 에 scope 명시. **비-load-bearing** (LOAD_BEARING_PATHS 미포함 → 이 PR 은 codex 게이트를 트리거하지 않음)
- `tests/test_codex_adversarial_precommit.py` — severity 검증 + scope 회귀 6건

load-bearing 파일 변경 없음.

## 3. 리스크

- **과검증으로 인한 false fail-closed**: severity 검증이 너무 엄격하면 정상 패스를 error 로 오분류해 게이트가 항상 fail-closed. 완화: companion 의 structured output 은 severity 를 동일 enum(critical/high/medium/low)으로 제약하므로 정상 응답은 항상 통과 — 깨진 출력만 거부. block-무관 필드(summary/title/recommendation/confidence)는 검증 안 함(renderer `.get` 방어). `test_malformed_severity_finding_counts_as_error_pass` 가 정상 severity 는 valid 유지를 고정.
- **scope 가 리뷰를 약화**: load-bearing 만 embed 하면 co-staged 비-load-bearing 파일과의 상호작용을 놓칠 수 있음. 완화: 게이트의 mandate 자체가 load-bearing 경로이고, focus prose 의 `changed_files` 전체 목록 + scope 명시로 모델이 다른 staged 파일 존재를 인지.
- **silent downgrade 회귀 재발**: `test_malformed_severity_does_not_silently_pass_gate` 가 end-to-end 로 pre-#1920 rc=0(silent pass) → post rc=1(fail-closed) 을 고정.

## 4. 테스트

103 green (기존 97 + 신규 6). Behavior change 마다 fail-before/pass-after:
- `test_is_recognized_severity_accepts_known_rejects_malformed` — helper 단위(enum/대소문자/비-str 거부)
- `test_malformed_severity_finding_counts_as_error_pass` — malformed/누락/비-str severity → `_is_valid_result` False + `PassResult.is_error` True; 정상 severity → valid
- `test_malformed_severity_does_not_silently_pass_gate` — **end-to-end**: "CRITICAL!!" finding 패스들이 rc=0 으로 조용히 통과하지 않고 fail-closed rc=1 (pre-#1920 은 rc=0)
- `test_staged_diff_snapshot_scopes_to_load_bearing_paths` — `git diff --cached -- <paths>` pathspec
- `test_staged_diff_snapshot_no_paths_diffs_everything` — paths=None → pathspec 없음(하위호환)
- `test_run_precommit_review_scopes_snapshot_to_hits` — caller 가 hits 를 snapshot 에 thread(foo.txt 제외)

overlap-preflight: 단일 worktree, codex 게이트 표면(`run_codex_adversarial_precommit.py`)을 편집하는 다른 활성 세션 0 (ps/worktree 조사 — live Codex 는 게이트를 *사용*만, *편집* 안 함). #1925 위 stack.

## 5. Eval 영향

**동작 변화 없음 (real-eval delta 없음).** 변경 표면은 local pre-commit governance 도구(`scripts/run_codex_adversarial_precommit.py`)와 그 테스트뿐. RAG 파이프라인·인덱스·답변 계약·eval 을 전혀 건드리지 않으므로 retrieval/answer/eval aggregate 영향 없음. load-bearing 파일 변경도 없음(이 PR 은 codex 게이트조차 트리거하지 않음).

## 6. 하위 호환

- **유지**: `_staged_diff_snapshot()` 의 `paths` 는 keyword-only 기본 None(기존 무인자 호출 = 전체 diff, 동작 동일). `_is_valid_result` 시그니처 무변경. 게이트 knob env·`START=CAP` flat-N 동등성·union/freq/fail-closed 모델 불변.
- **분류 강화는 fail-closed 방향**: severity 검증으로 더 많은 깨진 패스가 error 로 분류될 수 있으나 이는 안전 방향(약화 아님). 정상 companion 출력은 영향 없음.
- 답변 계약(ADR 0003) `schema_version` 무변경(RAG 미접촉).

## 7. 범위 외

- **errored-pass finding salvage → #1938**: malformed 패스의 dict findings 를 클러스터링용으로 salvage 하는 항목은 **blocking-semantics 를 바꾸므로**(error 패스 findings 가 freq 에 기여) ADR 0066 개정 동반 별개 concern. 본 PR 의 입력검증/스코프(semantics 무변경)와 분리.
- **block-무관 finding 필드의 full-schema 검증**: summary/next_steps/title/body/recommendation/confidence 타입 검증은 게이트 결정에 무관(renderer `.get` 방어)하고 과검증은 false fail-closed 만 늘리므로 의도적 제외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
