### PR TITLE
docs: add overlap preflight to verification methodology map

### DIFF
--- a/docs/verification-methodology-map.md
+++ b/docs/verification-methodology-map.md
@@ -34,7 +34,7 @@
 | 6 | PAL / Code-as-Reasoning | **STRONG** | [`eval/`](../eval/) scorer, [`eval/bootstrap.py`](../eval/bootstrap.py), judge 스크립트, [`scripts/build_index.py`](../scripts/build_index.py) |
 | 7 | Spec-First / Test-First | **STRONG** | TEMPLATE의 Acceptance Criteria 우선, `tests/test_*_regression.py`, ADR, pre-commit 게이트 |
 | 8 | Evaluator-Optimizer / Critic | **STRONG** | pre-commit Codex adversarial([ADR 0066](adr/0066-codex-pr-adversarial-review.md)), [`docs/reviews/ai-review-checklists.md`](reviews/ai-review-checklists.md), [`scripts/run_real_eval_delta.py`](../scripts/run_real_eval_delta.py) |
-| 9 | Multi-Agent / Orchestrator | **STRONG** | [`docs/multi-agent-ownership.md`](multi-agent-ownership.md)(role 분담), [`docs/agent-utilization.md`](agent-utilization.md)(5축 × 4-pillar) |
+| 9 | Multi-Agent / Orchestrator | **STRONG** | [`docs/multi-agent-ownership.md`](multi-agent-ownership.md)(role 분담), [`docs/agent-utilization.md`](agent-utilization.md)(5축 × 4-pillar), [`overlap-preflight`](operations/ai-codex-workflow.md#overlap-preflight)(병행 worktree 시작 전 겹침 증거) |
 | 10 | Context Engineering / Memory | **STRONG** (미시 갭 有) | memory 시스템, [`tasks/queue.md`](../tasks/queue.md), plan 문서, [`docs/operations/long-session-workflow.md`](operations/long-session-workflow.md) |
 | 11 | Formal Methods / Solver | **PARTIAL (도메인 적합 형태 구현)** | statistical test = STRONG([`eval/bootstrap.py`](../eval/bootstrap.py) bootstrap CI); property/metamorphic test = 구현됨([`tests/test_retrieval_invariants_property.py`](../tests/test_retrieval_invariants_property.py), #1826); 일반형(Lean/SAT/SMT) = non-goal |
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/verification-methodology-map.md`의 Multi-Agent / Orchestrator 표면에 `overlap-preflight`를 병행 worktree 시작 전 겹침 증거 gate로 추가했습니다. Codex/Claude 병행 작업의 verification 방법론이 구체적인 repo 증거 표면으로 연결되도록 하기 위함입니다.

Closes #1946

## 2. 영향 파일

- `docs/verification-methodology-map.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: 방법론 판정 변경으로 오해될 수 있음.
- 배제: 판정/분류는 그대로 두고 Multi-Agent row의 evidence surface 목록에 기존 canonical preflight 링크만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1946 --branch docs/issue-1946-verification-methodology-overlap-preflight` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/verification-methodology-map.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Methodology classifications remain unchanged.

## 7. 범위 외

- No runtime preflight behavior changes.
- No methodology reclassification.
- No worktree cleanup despite orphan-worktree warnings.
