### PR TITLE
docs: mark private real-eval summary template legacy

### DIFF
--- a/docs/evaluation/private_real_eval_summary_template.md
+++ b/docs/evaluation/private_real_eval_summary_template.md
@@ -1,6 +1,8 @@
-# Private Real-Eval Redacted Summary Template
+# Legacy Private Real-Eval Redacted Summary Template
 
-이 파일은 private real-eval 결과를 공개 가능한 형태로 요약할 때의 필드 계약(contract)이다. 실제 raw 질문(question), 답변(answer), 근거(evidence), 파일명, 고객명, private path는 포함하지 않는다.
+> **Archive-only note (2026-06-03)**: this schema-1 example belongs to the legacy `private_real_eval` / `reports/private_real_eval_summary.redacted.json` lane. Its 100-document / 221-question placeholders are not current claim-bearing evidence. New task, PR, claim, and handoff evidence must use the `real100_v2` aggregate-only surface described in [Surface Map](./surface-map.md), or introduce an explicit v2 template before reusing this shape.
+
+이 파일은 legacy private real-eval 결과를 공개 가능한 형태로 요약할 때의 historical 필드 계약(contract)이다. 실제 raw 질문(question), 답변(answer), 근거(evidence), 파일명, 고객명, private path는 포함하지 않는다.
 
 ```json
 {
@@ -50,6 +52,7 @@
   },
   "known_limitations": [
     "Private aggregate only; raw cases and traces remain local.",
+    "Legacy schema-1 example; do not use the 221-question placeholders for new claims.",
     "Answer metrics are deterministic contract checks, not an LLM judge.",
     "No retrieval, reranking, prompt, chunking, or verifier optimization is included."
   ]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Legacy `private_real_eval` redacted-summary template의 100-doc/221-question 예시가 새 claim-bearing private evidence로 재사용되지 않도록 archive-only 경고와 `real100_v2` aggregate-only 정책 링크를 추가했습니다.

Closes #1949

## 2. 영향 파일

- `docs/evaluation/private_real_eval_summary_template.md` — docs-only, legacy private eval summary template wording.

## 3. 리스크

- 리스크: schema-1 예시 문구가 실제 JSON 예시를 깨뜨리거나 문서 링크를 깨뜨릴 수 있음.
- 배제: JSON fence를 `json.loads`로 검증했고, targeted/full doc link check를 통과했습니다.

## 4. 테스트

- `python3` JSON fence validation for `docs/evaluation/private_real_eval_summary_template.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_summary_template.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/evaluation/private_real_eval_summary_template.md`; dirty worktree scan avoided codex-gate, naive eval, operator eval, eval regen, and root no-touch audit files.

## 5. Eval 영향

Docs-only wording change. No eval code, report artifact, index, or private data path changed. Real-data eval not run because behavior is unchanged and the change only clarifies legacy template status.

## 6. 하위 호환

No code/schema contract migration. The schema-1 JSON example remains valid; the PR only marks it archive-only and adds a limitation string warning against new claim reuse.

## 7. 범위 외

- Did not introduce a new `real100_v2` summary template or ADR-backed schema.
- Did not change `reports/private_real_eval_summary.redacted.json` tooling or private eval runner behavior.
