### PR TITLE
docs: add overlap preflight entry to docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - **[1-페이지 아키텍처 심층 분석](./architecture-deep-dive.md)** — 파이프라인 / ADR 매핑 / 측정 highlight 한 페이지 요약
 - [엔지니어링 거버넌스(워크플로 맵)](./engineering-governance.md)
 - [AI Engineering Operating System](operations/ai-engineering-operating-system.md) — 장기 AI-agent task / plan / review / eval evidence 운영 모델
+- [AI Codex Workflow / overlap preflight](operations/ai-codex-workflow.md#overlap-preflight) — 병행 Codex/Claude worktree 시작 전 겹침 차단 증거
 - [Persistent Task Queue](../tasks/queue.md) — 세션 간 이어지는 작업 상태
 - [AI Review Checklists](reviews/ai-review-checklists.md)
 - [Evaluation Surface Map](evaluation/surface-map.md)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/README.md`에 `AI Codex Workflow / overlap preflight` entry를 추가했습니다. 새 Codex/Claude 세션이 docs portal에서 병행 worktree 시작 전 겹침 차단 증거 표면을 바로 찾을 수 있게 하기 위함입니다.

Closes #1950

## 2. 영향 파일

- `docs/README.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: docs portal 링크 fragment가 깨질 수 있음.
- 배제: canonical `operations/ai-codex-workflow.md#overlap-preflight` fragment를 링크 검증했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1950 --branch docs/issue-1950-docs-readme-overlap-entry` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/README.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only index change. Eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing docs links remain unchanged.

## 7. 범위 외

- No runtime preflight behavior changes.
- No worktree cleanup despite orphan-worktree warnings.
