### PR TITLE
docs: mark multi-chunk real100 strategy historical

### DIFF
--- a/docs/evaluation/multi_chunk_retrieval_strategy.md
+++ b/docs/evaluation/multi_chunk_retrieval_strategy.md
@@ -2,6 +2,8 @@
 
 This report is aggregate-only. It uses counts from `reports/real100/multi_chunk_evidence_failures.aggregate.json` and does not include raw questions, answers, document IDs, chunk IDs, paths, sections, or source text.
 
+> **Archive-only note (2026-06-03)**: the source aggregate is a legacy `real100` / 221-prediction artifact. It is historical context, not current claim-bearing private eval evidence. New task, PR, claim, and handoff decisions must use the `real100_v2` aggregate-only surface in [Surface Map](./surface-map.md), or regenerate a matching `real100_v2` multi-chunk aggregate before reusing this strategy.
+
 ## Source Provenance
 
 | Field | Value |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/evaluation/multi_chunk_retrieval_strategy.md`가 legacy `reports/real100/` 221-prediction aggregate를 현재 retrieval 전략 근거로 오해하지 않도록 archive-only 경고와 `real100_v2` aggregate-only 정책 링크를 추가했습니다.

Closes #1953

## 2. 영향 파일

- `docs/evaluation/multi_chunk_retrieval_strategy.md` — docs-only, historical multi-chunk strategy report wording.

## 3. 리스크

- 리스크: historical aggregate 값이나 추천 자체를 바꿔 과거 report 의미를 훼손할 수 있음.
- 배제: 수치/추천은 그대로 두고 source boundary note만 추가했습니다. 문서 링크 전체 검증도 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/multi_chunk_retrieval_strategy.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/evaluation/multi_chunk_retrieval_strategy.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No eval code, retrieval behavior, report artifact, index, or private data path changed. Real-data eval not run because this only labels an existing legacy aggregate as archive-only.

## 6. 하위 호환

No code/schema/CLI contract change. Historical aggregate values and recommendation remain unchanged; the PR only adds a claim-boundary note.

## 7. 범위 외

- Did not regenerate a `real100_v2` multi-chunk aggregate.
- Did not choose or implement a retrieval strategy.
