### PR TITLE
docs: record overlap provenance for benchmark artifacts

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -84,6 +84,10 @@ python3 scripts/summarize_benchmark.py \
 - `logs/`: index build 등 command log
 
 `artifacts/benchmarks/`는 `.gitignore` 대상이다. 공개 fixture smoke 실행이라도 raw prediction과 trace는 noisy하고 커밋 diff를 크게 만들기 때문에 로컬 검증용으로만 둔다.
+병행 Codex/Claude worktree에서 만든 benchmark artifact를 PR 근거로 첨부하려면
+[`overlap-preflight`](operations/ai-codex-workflow.md#overlap-preflight) 결과를 함께
+남긴다. 같은 artifact root나 변경 파일을 공유한 run은 독립 benchmark evidence로
+취급하지 않는다.
 
 ## Stage Latency & Retry Cost
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/benchmarking.md`의 Local Artifacts section에 병행 Codex/Claude worktree에서 만든 benchmark artifact를 PR 근거로 쓸 때 `overlap-preflight` 결과를 함께 남기라는 provenance 문단을 추가했습니다. artifact root나 변경 파일이 다른 세션과 겹친 run을 독립 benchmark evidence로 오해하지 않게 하기 위함입니다.

Closes #1954

## 2. 영향 파일

- `docs/benchmarking.md` — docs-only, load-bearing 아님

## 3. 리스크

- 리스크: benchmark runner나 metrics schema 변경으로 오해될 수 있음.
- 배제: runner/config/metrics/commands는 변경하지 않고 local artifact evidence 문단만 추가했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 1954 --branch docs/issue-1954-benchmarking-overlap-provenance` → `clear`, evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/benchmarking.md` → pass
- `git diff --check` → pass
- `make check-branch` → pass

## 5. Eval 영향

All `·` — docs-only change. Benchmark/eval/runtime behavior unchanged; real-eval not run.

## 6. 하위 호환

No contract/schema/CLI changes. Existing benchmark commands and artifacts remain unchanged.

## 7. 범위 외

- No benchmark runtime execution.
- No eval config, metrics, or runner changes.
- No worktree cleanup despite orphan-worktree warnings.
