### PR TITLE
docs: clarify v0 metric suite legacy real100 rows

### DIFF
--- a/docs/evaluation/v0-metric-suite-inventory.md
+++ b/docs/evaluation/v0-metric-suite-inventory.md
@@ -8,6 +8,8 @@ which gaps remain before a v0 metric-suite report can claim coverage.
 This is an aggregate-only inventory. It is not a performance claim, does not run
 private real-eval, and does not compare deltas.
 
+> **Current-use boundary (2026-06-03)**: rows that mention legacy `reports/real100/` or `reports/private_real_eval_summary.redacted.json` artifacts record historical field availability only. They are not current claim-bearing private evidence. New task, PR, claim, and handoff wording must use the `real100_v2` aggregate-only surface in [Surface Map](./surface-map.md), or regenerate a v2 aggregate before marking a metric family present.
+
 Issue #1544 adds the first v0 report renderer:
 `scripts/render_v0_metric_suite_report.py`. It consumes aggregate-only private
 real-eval artifacts plus an optional local judge/human agreement CSV, and emits


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/evaluation/v0-metric-suite-inventory.md`의 legacy `reports/real100/` 및 `reports/private_real_eval_summary.redacted.json` 언급이 새 metric-suite claim 근거로 재사용되지 않도록 current-use boundary note를 추가했습니다.

Closes #1958

## 2. 영향 파일

- `docs/evaluation/v0-metric-suite-inventory.md` — docs-only, metric inventory claim-boundary wording.

## 3. 리스크

- 리스크: 과거 v0 inventory rows의 historical meaning을 바꾸거나 링크를 깨뜨릴 수 있음.
- 배제: inventory rows/values/status는 그대로 두고 상단 boundary note만 추가했습니다. Targeted/full doc link checks를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/v0-metric-suite-inventory.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/evaluation/v0-metric-suite-inventory.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No eval code, metric implementation, report artifact, index, or private data path changed. Real-data eval not run because this only clarifies source eligibility for claims.

## 6. 하위 호환

No code/schema/CLI contract change. Historical inventory rows remain unchanged; the PR only clarifies that legacy rows are not current claim-bearing evidence.

## 7. 범위 외

- Did not regenerate private `real100_v2` metric-suite aggregates.
- Did not change v0 renderer code or metric-family definitions.
