### PR TITLE
docs: clarify T-2026-0015 legacy real100 boundary

### DIFF
--- a/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
+++ b/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
@@ -21,7 +21,10 @@ metrics, partial proxies, and missing measurement work.
 v0/v1/v2 milestones, but it does not classify current aggregate artifacts.
 Committed private real-eval aggregate files exist under `reports/real100/` and
 `reports/real100_v2/`, while raw private eval summaries and per-case rows remain
-local-only.
+local-only. The `reports/real100/` side is historical field-availability context
+only; new task, PR, claim, and handoff evidence must use the current
+`real100_v2` aggregate-only surface in [Surface Map](../evaluation/surface-map.md)
+or regenerate matching v2 aggregates before claiming metric-family coverage.
 
 ## Desired Behavior
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

완료된 `T-2026-0015` plan의 `reports/real100/` 언급이 새 v0 metric-suite evidence로 재사용되지 않도록, historical field-availability context와 현재 `real100_v2` claim-bearing boundary를 명시했습니다.

Closes #1960

## 2. 영향 파일

- `docs/plans/T-2026-0015-v0-metric-suite-inventory.md` — docs-only, completed plan current-use boundary wording.

## 3. 리스크

- 리스크: 완료된 plan의 acceptance evidence를 바꾸는 것처럼 보일 수 있음.
- 배제: plan status/acceptance/validation은 보존하고 Current Behavior의 source-boundary 문구만 추가했습니다. Targeted/full doc link checks를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0015-v0-metric-suite-inventory.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/plans/T-2026-0015-v0-metric-suite-inventory.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No eval code, report artifact, metric definition, index, or private data path changed. Real-data eval not run because this only clarifies source eligibility for claims.

## 6. 하위 호환

No code/schema/CLI contract change. Completed plan evidence remains intact; the PR only clarifies current-use boundaries for legacy `reports/real100/` references.

## 7. 범위 외

- Did not change `docs/evaluation/v0-metric-suite-inventory.md` beyond the already merged #1959 follow-up.
- Did not regenerate v2 aggregates or update queue state.
