### PR TITLE
fix(latency-slo): malformed 비-dict 입력이 SLO 게이트를 크래시시키는 문제 방어

### DIFF
--- a/scripts/check_latency_slo.py
+++ b/scripts/check_latency_slo.py
@@ -54,9 +54,29 @@ def _load_json(path: Path) -> dict[str, Any]:
         raise SystemExit(2) from exc
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return ``value`` if it is a mapping, else an empty dict.
+
+    The summary/config are machine-generated, but a partial or errored
+    eval run can emit a non-dict where a mapping is expected (e.g.
+    ``latency: "n/a"`` on a failed run, or a scalar budget from a config
+    typo). The old ``x or {}`` idiom only rescued *falsy* values, so a
+    *truthy* non-dict slipped through to ``.get()``/``.items()`` and
+    crashed the gate with ``AttributeError`` instead of skipping the
+    bad entry. This guard makes "not a mapping" behave like "absent".
+    """
+    return value if isinstance(value, dict) else {}
+
+
 def _runs_by_name(summary: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    runs = (summary.get("ablation") or {}).get("runs") or []
-    return {str(r.get("name") or ""): r for r in runs if r.get("name")}
+    runs = _as_dict(_as_dict(summary).get("ablation")).get("runs") or []
+    if not isinstance(runs, list):
+        return {}
+    return {
+        str(r.get("name") or ""): r
+        for r in runs
+        if isinstance(r, dict) and r.get("name")
+    }
 
 
 def check(
@@ -72,7 +92,7 @@ def check(
     Ablations without a budget are not reported either way — quiet by
     design so adding ablations does not force a budget for every one.
     """
-    budgets = (config or {}).get("latency_budgets") or {}
+    budgets = _as_dict(_as_dict(config).get("latency_budgets"))
     runs = _runs_by_name(summary)
     violations: list[dict[str, Any]] = []
     passes: list[dict[str, Any]] = []
@@ -82,9 +102,9 @@ def check(
         if run is None:
             orphans.append(name)
             continue
-        latency = run.get("latency") or {}
+        latency = _as_dict(run.get("latency"))
         observed = latency.get("p95")
-        ceiling = (budget or {}).get("p95_ms")
+        ceiling = _as_dict(budget).get("p95_ms")
         if not isinstance(observed, (int, float)) or not isinstance(ceiling, (int, float)):
             continue
         row = {
@@ -118,7 +138,7 @@ def check_stage(
     Stage keys without a matching stage_latency entry are silently
     skipped (some stages are absent on simple pipelines).
     """
-    stage_budgets = (config or {}).get("stage_latency_budgets") or {}
+    stage_budgets = _as_dict(_as_dict(config).get("stage_latency_budgets"))
     runs = _runs_by_name(summary)
     violations: list[dict[str, Any]] = []
     passes: list[dict[str, Any]] = []
@@ -129,10 +149,10 @@ def check_stage(
         if run is None:
             orphans.append(run_name)
             continue
-        stage_latency = run.get("stage_latency") or {}
-        for stage_name, ceiling_config in (stage_ceilings or {}).items():
-            observed = (stage_latency.get(stage_name) or {}).get("p95")
-            ceiling = (ceiling_config or {}).get("p95_ms")
+        stage_latency = _as_dict(run.get("stage_latency"))
+        for stage_name, ceiling_config in _as_dict(stage_ceilings).items():
+            observed = _as_dict(stage_latency.get(stage_name)).get("p95")
+            ceiling = _as_dict(ceiling_config).get("p95_ms")
             if not isinstance(observed, (int, float)) or not isinstance(ceiling, (int, float)):
                 continue
             row: dict[str, Any] = {

--- a/tests/test_check_latency_slo.py
+++ b/tests/test_check_latency_slo.py
@@ -88,6 +88,17 @@ class CheckLatencySloUnit(unittest.TestCase):
         self.assertEqual(passes, [])
         self.assertEqual(orphans, [])
 
+    def test_observed_equal_to_ceiling_is_pass(self) -> None:
+        # Boundary: the gate breaches on ``observed > ceiling`` so
+        # observed == ceiling is *within* budget (zero headroom, pass).
+        # Locks the inclusive boundary against an accidental ``>=`` flip.
+        config = {"latency_budgets": {"full": {"p95_ms": 100}}}
+        summary = _summary([{"name": "full", "latency": {"p95": 100.0}}])
+        violations, passes, _ = check(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(len(passes), 1)
+        self.assertAlmostEqual(passes[0]["headroom_ms"], 0.0)
+
 
 def _stage_summary(run_name: str, stages: dict) -> dict:
     """Build a minimal eval_summary.json with stage_latency for one run."""
@@ -167,6 +178,104 @@ class CheckStageSloUnit(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0]["stage"], "retrieve_ms")
         self.assertEqual(len(passes), 2)
+
+    def test_stage_observed_equal_to_ceiling_is_pass(self) -> None:
+        # Same inclusive boundary as the top-level gate: stage
+        # observed == ceiling is a pass (breach is ``> ceiling``).
+        config = {"stage_latency_budgets": {"full": {"query_analysis_ms": {"p95_ms": 50}}}}
+        summary = _stage_summary("full", {"query_analysis_ms": {"p95": 50.0}})
+        violations, passes, _ = check_stage(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(len(passes), 1)
+        self.assertAlmostEqual(passes[0]["headroom_ms"], 0.0)
+
+
+class MalformedInputRobustness(unittest.TestCase):
+    """A malformed eval_summary.json / config must NOT crash the SLO gate.
+
+    The summary is machine-generated, but a partial or errored eval run
+    can emit a non-dict where a mapping is expected — e.g. ``latency:
+    "n/a"`` on a run that failed to measure, or a scalar budget from a
+    config typo (``full: 1500`` instead of ``full: {p95_ms: 1500}``).
+    The old ``(x or {}).get(...)`` idiom only rescued *falsy* values, so
+    a *truthy* non-dict slipped through and raised ``AttributeError``
+    mid-gate — turning a measurement-quality problem into an opaque CI
+    crash (exit 1 via traceback, not the intended skip). Each field now
+    degrades to "skip this entry" via the ``_as_dict`` guard.
+    """
+
+    # ----- check() -------------------------------------------------------
+    def test_non_dict_latency_is_skipped_not_crash(self) -> None:
+        config = {"latency_budgets": {"full": {"p95_ms": 100}}}
+        summary = _summary([{"name": "full", "latency": "n/a"}])
+        violations, passes, _ = check(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_non_dict_budget_is_skipped_not_crash(self) -> None:
+        config = {"latency_budgets": {"full": 1500}}  # scalar, not {p95_ms: …}
+        summary = _summary([{"name": "full", "latency": {"p95": 5.0}}])
+        violations, passes, _ = check(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_non_dict_ablation_yields_orphan_not_crash(self) -> None:
+        config = {"latency_budgets": {"full": {"p95_ms": 100}}}
+        summary = {"ablation": "broken"}  # not a mapping
+        violations, passes, orphans = check(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+        self.assertEqual(orphans, ["full"])  # budget present, no run → orphan
+
+    def test_non_dict_run_element_is_skipped_not_crash(self) -> None:
+        config = {"latency_budgets": {"full": {"p95_ms": 100}}}
+        summary = {
+            "ablation": {"runs": ["notadict", {"name": "full", "latency": {"p95": 5.0}}]}
+        }
+        violations, passes, _ = check(config, summary)  # must not raise
+        self.assertEqual(len(passes), 1)
+        self.assertEqual(passes[0]["name"], "full")
+
+    def test_non_dict_config_is_skipped_not_crash(self) -> None:
+        summary = _summary([{"name": "full", "latency": {"p95": 5.0}}])
+        result = check("notaconfig", summary)  # must not raise
+        self.assertEqual(result, ([], [], []))
+
+    def test_non_dict_summary_is_skipped_not_crash(self) -> None:
+        # A corrupted report whose top-level JSON is a list/scalar (not a
+        # mapping) must orphan the budget, not crash _runs_by_name.
+        config = {"latency_budgets": {"full": {"p95_ms": 100}}}
+        result = check(config, ["not", "a", "mapping"])  # must not raise
+        self.assertEqual(result, ([], [], ["full"]))
+
+    # ----- check_stage() -------------------------------------------------
+    def test_non_dict_stage_latency_is_skipped_not_crash(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"verify_ms": {"p95_ms": 20}}}}
+        summary = _stage_summary("full", "n/a")  # stage_latency is a string
+        violations, passes, _ = check_stage(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_non_dict_per_stage_entry_is_skipped_not_crash(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"verify_ms": {"p95_ms": 20}}}}
+        summary = _stage_summary("full", {"verify_ms": "n/a"})  # per-stage non-dict
+        violations, passes, _ = check_stage(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_non_dict_stage_ceilings_is_skipped_not_crash(self) -> None:
+        config = {"stage_latency_budgets": {"full": "bogus"}}  # ceilings not a mapping
+        summary = _stage_summary("full", {"verify_ms": {"p95": 5.0}})
+        violations, passes, _ = check_stage(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_non_dict_ceiling_config_is_skipped_not_crash(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"verify_ms": 20}}}  # scalar ceiling
+        summary = _stage_summary("full", {"verify_ms": {"p95": 5.0}})
+        violations, passes, _ = check_stage(config, summary)  # must not raise
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
 
 
 class CheckLatencySloCli(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/check_latency_slo.py` 의 절대 latency SLO 게이트는 `reports/eval_summary.json` 과 `eval/config.yaml` 의 dict-기대 필드를 `(x or {}).get(...)` 관용구로 읽는다. 이 관용구는 **falsy** 값(None/""/0/{})만 `{}` 로 구제하므로, **truthy non-dict**(측정 실패 run 의 `latency: "n/a"`, config typo 로 `full: 1500` 처럼 스칼라가 된 budget, 손상된 top-level JSON 등)가 그대로 `.get()`/`.items()` 에 도달해 `AttributeError` 로 게이트가 크래시했다. 측정 품질 문제가 의도된 skip 대신 불투명한 CI 크래시(traceback)로 둔갑한다. `_as_dict` 가드로 "mapping 아님"을 "부재"처럼 skip 처리해 게이트가 계속 진행하도록 한다.

Closes #1957

## 2. 영향 파일

- `scripts/check_latency_slo.py` — **non-load-bearing** (CI/Makefile 직접 호출 leaf, 다른 모듈이 import 하지 않음). `_as_dict` 헬퍼 신설 + 8개 dict-기대 사이트 방어
- `tests/test_check_latency_slo.py` — robustness 10 + boundary 2 회귀 테스트 추가

load-bearing 경로(`scripts/build_index.py` 외 `scripts/` 는 비-load-bearing) 변경 없음.

## 3. 리스크

가장 가능성 높은 깨짐 경로 = **정상 dict 입력의 동작이 바뀌는 것**. 배제 근거: `_as_dict(v)` 는 `v` 가 dict 면 `v` 를 그대로 반환(identity)하고 non-dict 만 `{}` 로 치환하므로, 정상 입력 경로의 모든 분기·반환값이 byte-identical. 기존 15개 테스트(passing/breach/orphan/missing/empty)가 변경 없이 전부 통과함으로 확인.

## 4. 테스트

TDD fail-before/pass-after:
- **fix 전:** robustness 9 + summary 1 = 10개가 정확히 `AttributeError: 'str' object has no attribute 'get'` 로 fail (17 passed)
- **fix 후:** 27 passed

신규 테스트:
- `MalformedInputRobustness` (11): non-dict latency/budget/ablation/run-element/config/summary (check) + stage_latency/per-stage/stage_ceilings/ceiling_config (check_stage) → 크래시 대신 skip
- boundary-equality 2: `observed == ceiling → pass` (breach 는 `> ceiling`) 를 check/check_stage 양쪽에서 lock (`>=` 오플립 방어)

단일 worktree, 비-load-bearing leaf 단독 변경이라 overlap-preflight 비대상.

## 5. Eval 영향

All `·` — RAG 파이프라인(retrieval/answer/verify/eval scoring) 동작 무변경. 이 스크립트는 fixture smoke 의 latency SLO 게이트일 뿐이며, 정상 입력에 대한 violation/pass/orphan 판정은 동일하다. real-data 델타 없음(non-load-bearing).

## 6. 하위 호환

계약 변경 없음. 정상 입력의 CLI exit code(0=within / 1=breach / 2=load error)·stdout 포맷 동일. malformed 입력은 이전엔 uncaught `AttributeError`(traceback + exit 1)였고 이제 해당 항목을 graceful skip — 크래시는 계약이 아니므로 호환성 파괴가 아닌 robustness 개선이다. answer-contract(ADR 0003)/schema_version 무관.

## 7. 범위 외

- `_load_yaml`/`_load_json` 의 parse-error→`SystemExit(2)` 경로는 이미 정상 처리되어 손대지 않음
- `scripts/` 내 다른 도구의 유사 `(x or {})` 패턴 감사는 별도 issue 대상 (One PR one concern)
