### PR TITLE
docs: clarify T-2026-0010 legacy review-board inputs

### DIFF
--- a/docs/plans/T-2026-0010-priority-html-review-boards.md
+++ b/docs/plans/T-2026-0010-priority-html-review-boards.md
@@ -29,6 +29,13 @@ six priority surfaces are still spread across:
 - `reports/private_real_eval_summary.redacted.json`
 - benchmark/evaluation governance docs
 
+Current-use boundary: the `reports/real100/*` and
+`reports/private_real_eval_summary.redacted.json` inputs above are historical
+review-board context only. They are not current claim-bearing private evidence;
+new task, PR, claim, and handoff decisions must use the `real100_v2`
+aggregate-only surface in [Surface Map](../evaluation/surface-map.md), or
+regenerate matching v2 board inputs before treating a board as current evidence.
+
 ## Desired Behavior
 
 A single local script renders six self-contained HTML boards:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`T-2026-0010` priority review-board plan의 legacy `reports/real100/*` 및 `reports/private_real_eval_summary.redacted.json` inputs가 새 claim-bearing evidence로 재사용되지 않도록 current-use boundary를 추가했습니다.

Closes #1963

## 2. 영향 파일

- `docs/plans/T-2026-0010-priority-html-review-boards.md` — docs-only, completed plan review-board source-boundary wording.

## 3. 리스크

- 리스크: 기존 local board renderer 입력을 바꾼 것처럼 오해될 수 있음.
- 배제: 입력 목록과 renderer scope는 그대로 두고, historical/current-use boundary note만 추가했습니다. Targeted/full doc link checks를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0010-priority-html-review-boards.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/plans/T-2026-0010-priority-html-review-boards.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No renderer code, tests, generated report HTML, aggregate artifact, index, or private data path changed. Real-data eval not run because this only clarifies source eligibility for claims.

## 6. 하위 호환

No code/schema/CLI contract change. Historical input lists remain unchanged; the PR only clarifies they are not current claim-bearing evidence without v2 regeneration.

## 7. 범위 외

- Did not run or modify `scripts/render_priority_review_boards.py`.
- Did not regenerate board inputs or HTML artifacts.
