### PR TITLE
docs: clarify T-2026-0011 legacy review-board outputs

### DIFF
--- a/docs/plans/T-2026-0011-remaining-html-review-boards.md
+++ b/docs/plans/T-2026-0011-remaining-html-review-boards.md
@@ -148,6 +148,13 @@ artifacts and can be deleted or regenerated without touching source aggregates.
 - `reports/governance_automation.html`
 - `reports/claim_validator.html`
 
+Current-use boundary: any `reports/real100/*` HTML outputs above are historical
+generated review views only. They are not current claim-bearing private
+evidence; new task, PR, claim, and handoff decisions must use the `real100_v2`
+aggregate-only surface in [Surface Map](../evaluation/surface-map.md), or
+regenerate matching v2 review-board outputs before treating a board as current
+evidence.
+
 ## Reviewer Notes
 
 Attack privacy boundary, over-claiming, and whether HTML is clearly generated


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`T-2026-0011` remaining review-board plan의 legacy `reports/real100/*` HTML outputs가 새 claim-bearing evidence로 재사용되지 않도록 current-use boundary를 추가했습니다.

Closes #1966

## 2. 영향 파일

- `docs/plans/T-2026-0011-remaining-html-review-boards.md` — docs-only, completed plan review-board output boundary wording.

## 3. 리스크

- 리스크: 기존 generated HTML output contract를 바꾼 것처럼 오해될 수 있음.
- 배제: Observability path 목록은 그대로 두고, historical/current-use boundary note만 추가했습니다. Targeted/full doc link checks를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0011-remaining-html-review-boards.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/plans/T-2026-0011-remaining-html-review-boards.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No renderer code, generated HTML, aggregate artifact, index, or private data path changed. Real-data eval not run because this only clarifies source eligibility for claims.

## 6. 하위 호환

No code/schema/CLI contract change. Observability paths remain unchanged; the PR only clarifies that legacy `reports/real100/*` generated views are historical unless regenerated from v2 evidence.

## 7. 범위 외

- Did not run or modify `scripts/render_priority_review_boards.py`.
- Did not regenerate board outputs or private eval aggregates.
