### PR TITLE
docs: clarify T-2026-0007 legacy failure-board output

### DIFF
--- a/docs/plans/T-2026-0007-failure-case-board.md
+++ b/docs/plans/T-2026-0007-failure-case-board.md
@@ -22,6 +22,13 @@ Running the failure distribution renderer writes the existing committable
 Markdown and aggregate JSON plus a local `reports/real100/failure_distribution.html`
 file. The HTML is deterministic, dependency-free, and aggregate-only.
 
+Current-use boundary: the `reports/real100/failure_distribution.html` output is
+historical local review context only. It is not current claim-bearing private
+evidence; new task, PR, claim, and handoff decisions must use the `real100_v2`
+aggregate-only surface in [Surface Map](../evaluation/surface-map.md), or
+regenerate matching v2 failure-board outputs before treating the board as
+current evidence.
+
 ## Constraints
 
 - Scope: reviewer tooling only.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`T-2026-0007` failure-case board plan의 legacy `reports/real100/failure_distribution.html` local output이 새 claim-bearing evidence로 재사용되지 않도록 current-use boundary를 추가했습니다.

Closes #1971

## 2. 영향 파일

- `docs/plans/T-2026-0007-failure-case-board.md` — docs-only, completed plan failure-board output boundary wording.

## 3. 리스크

- 리스크: 기존 renderer output path를 바꾼 것처럼 오해될 수 있음.
- 배제: output path와 renderer scope는 그대로 두고, historical/current-use boundary note만 추가했습니다. Targeted/full doc link checks를 통과했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0007-failure-case-board.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR same-file query returned no PR touching `docs/plans/T-2026-0007-failure-case-board.md`; dirty worktree/status and active worktree branch-diff scans returned no candidate-file conflicts.

## 5. Eval 영향

Docs-only wording change. No renderer code, generated HTML, aggregate artifact, index, or private data path changed. Real-data eval not run because this only clarifies source eligibility for claims.

## 6. 하위 호환

No code/schema/CLI contract change. The local HTML output path remains unchanged; the PR only clarifies that the legacy board is historical unless regenerated from v2 evidence.

## 7. 범위 외

- Did not run or modify `scripts/render_failure_distribution.py`.
- Did not regenerate failure-board outputs or private eval aggregates.
