### PR TITLE
fix(governance): analyze_hook_outcomes inventory·threshold 를 _governance SSoT 에서 파생

### DIFF
--- a/scripts/analyze_hook_outcomes.py
+++ b/scripts/analyze_hook_outcomes.py
@@ -63,6 +63,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
+# Governance SSoT — the hook inventory and memory-lines thresholds live in
+# scripts/_governance.py. Import them so this analyzer can't silently drift
+# from the emit-time typo guard (issue #1972). _governance is import-safe
+# (constants + functions behind an __main__ guard).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _governance import KNOWN_HOOKS, THRESHOLDS  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Parsing
 # ---------------------------------------------------------------------------
@@ -238,12 +245,13 @@ def filter_window(events: list[dict], window: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-# Canonical hook inventory — matches scripts/claude-hooks/README.md table.
-ALL_HOOKS = [
-    "bash-guard", "loadbearing", "memory-lines",
-    "adr-template", "adr-collision", "plan-slug-race",
-    "delegation-gate", "stop-ship",
-]
+# Canonical hook inventory — DERIVED from _governance.KNOWN_HOOKS (the emit-time
+# typo guard) so the analysis-time inventory can never drift from it. agent-loop
+# and experiment-report (emitted by stop-agent-loop.sh / stop-experiment-report.sh)
+# are now included automatically; sorted for stable, readable report ordering.
+# Was a hand-maintained list that silently dropped those two → they got
+# misclassified as "Unrecognized hook names (legacy / typo)" (issue #1972).
+ALL_HOOKS = sorted(KNOWN_HOOKS)
 
 
 def outcome_breakdown(events: list[dict]) -> dict[str, dict[str, int]]:
@@ -275,7 +283,10 @@ def threshold_recommendation(events: list[dict]) -> dict:
     blocked = sum(1 for e in ml_events if e["outcome"] == "blocked")
     if total == 0:
         return {
-            "current": {"aware": 20, "block": 30},
+            "current": {
+                "aware": THRESHOLDS["MEMORY_LINE_AWARE"],
+                "block": THRESHOLDS["MEMORY_LINE_BLOCK"],
+            },
             "observed_total": 0,
             "verdict": "insufficient_data",
             "rationale": "memory-lines hook 이 윈도우 안에 0회 fire — 데이터 부족.",
@@ -297,7 +308,10 @@ def threshold_recommendation(events: list[dict]) -> dict:
         verdict = "maintain"
         rationale = f"BLOCK fire ratio = {block_ratio:.1%} — 정상 범위."
     return {
-        "current": {"aware": 20, "block": 30},
+        "current": {
+            "aware": THRESHOLDS["MEMORY_LINE_AWARE"],
+            "block": THRESHOLDS["MEMORY_LINE_BLOCK"],
+        },
         "observed_total": total,
         "observed_aware": aware,
         "observed_blocked": blocked,

--- a/scripts/analyze_hook_outcomes.py
+++ b/scripts/analyze_hook_outcomes.py
@@ -19,8 +19,8 @@ PR4 표준 (5-field+)::
 
     outcome ∈ {aware, blocked, bypassed, false_positive,
                false_negative, nudged, pipeline_start, pipeline_end}
-    hook    ∈ {bash-guard, loadbearing, memory-lines, adr-template,
-               plan-slug-race, delegation-gate, stop-ship}
+    hook    ∈ ``_governance.KNOWN_HOOKS`` — 단일 출처 (``ALL_HOOKS`` 가 이로부터
+               파생되므로 hook 명을 여기서 중복 나열하지 않는다)
 
 Legacy 3-field (loadbearing 현재 포맷)::
 

--- a/tests/test_analyze_hook_outcomes.py
+++ b/tests/test_analyze_hook_outcomes.py
@@ -358,3 +358,43 @@ def test_main_single_hook_scopes_surface_reduction(tmp_path, aho, capsys):
     # scope, so they must NOT appear as surface-reduction candidates.
     assert js["surface_reduction_candidates"] == []
     assert "memory-lines" not in js["surface_reduction_candidates"]
+
+
+# ---------------------------------------------------------------------------
+# SSoT sync with _governance (issue #1972)
+# ---------------------------------------------------------------------------
+
+
+def test_all_hooks_matches_governance_known_hooks(aho):
+    # ALL_HOOKS must be the SAME SET as _governance.KNOWN_HOOKS. KNOWN_HOOKS is
+    # the emit-time typo guard (enforced in emit_hook_fire); ALL_HOOKS is the
+    # analysis-time inventory. If they drift, a hook that legitimately emits is
+    # silently dropped from / misclassified by the analysis. This test is the
+    # guard that was missing when agent-loop / experiment-report drifted out.
+    assert set(aho.ALL_HOOKS) == set(aho.KNOWN_HOOKS)
+
+
+def test_emitting_hooks_not_misclassified_as_unrecognized(aho):
+    # agent-loop / experiment-report are emitted by stop-agent-loop.sh /
+    # stop-experiment-report.sh (pipeline_end). They must sit in the inventory
+    # so render_text counts them under their own name, not the
+    # "Unrecognized hook names (legacy / typo)" bucket.
+    for hook in ("agent-loop", "experiment-report"):
+        assert hook in aho.ALL_HOOKS
+    now = datetime.now(timezone.utc)
+    events = [
+        _make_event(now, "agent-loop", "pipeline_end"),
+        _make_event(now, "experiment-report", "pipeline_end"),
+    ]
+    out = aho.render_text(events, "all")
+    assert "Unrecognized hook names" not in out
+    assert "agent-loop" in out
+    assert "experiment-report" in out
+
+
+def test_threshold_current_reflects_governance_thresholds(aho):
+    # The reported "current" thresholds must read from _governance.THRESHOLDS,
+    # not a hardcoded {aware: 20, block: 30} that drifts when the SSoT changes.
+    rec = aho.threshold_recommendation([])
+    assert rec["current"]["aware"] == aho.THRESHOLDS["MEMORY_LINE_AWARE"]
+    assert rec["current"]["block"] == aho.THRESHOLDS["MEMORY_LINE_BLOCK"]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/analyze_hook_outcomes.py` 의 hook inventory와 memory-lines 임계값이 governance SSoT(`scripts/_governance.py`)와 분기(drift)해 있었다. (1) `ALL_HOOKS`(하드코딩 8개)가 `KNOWN_HOOKS`(10개)에서 `agent-loop`·`experiment-report` 를 누락 → `stop-agent-loop.sh`/`stop-experiment-report.sh` 가 **실제 emit** 하는 이 두 hook 이 `render_text` 의 차집합 분류(L367)에서 "Unrecognized hook names (legacy / typo)" 버킷으로 오분류돼 governance ROI/surface-reduction 분석에서 누락됐다. (2) `threshold_recommendation` 이 `{aware:20, block:30}` 을 하드코딩해 `THRESHOLDS` 변경 시 "current" 표시가 stale 됐다. 둘 다 SSoT 에서 파생/참조하도록 고친다.

Closes #1972

## 2. 영향 파일

- `scripts/analyze_hook_outcomes.py` — **non-load-bearing** leaf. `_governance` 에서 `KNOWN_HOOKS`/`THRESHOLDS` import (표준 `sys.path.insert(parent)` 패턴), `ALL_HOOKS = sorted(KNOWN_HOOKS)` 파생, threshold 를 `THRESHOLDS` 참조로 교체
- `tests/test_analyze_hook_outcomes.py` — SSoT 동기화/오분류 방지/threshold 반영 회귀 테스트 3종

`_governance.py`(load-bearing)는 **읽기/import 만** — 수정 없음.

## 3. 리스크

가장 가능성 높은 깨짐 경로 = **import 파급**. `analyze_hook_outcomes` 는 `scripts/claude-hooks/_self_review.py:534` 가 `parse_log_line` 을 lazy-import 한다 — 새 top-level `from _governance import` 가 그 경로에서 깨질 수 있다. 배제 근거: `sys.path.insert(0, Path(__file__).resolve().parent)` 가 import 주체와 무관하게 `scripts/` 를 path 에 넣으므로 `_self_review` 컨텍스트에서도 `_governance` 해석됨 — `_self_review` 단독 import + 연관 스위트(telemetry/self_review/governance) **115 passed** 로 확인. `ALL_HOOKS` 는 `sorted(...)` 로 여전히 `list[str]` 이라 `inventory`/`hooks_scope` 사용처 시그니처 불변.

## 4. 테스트

TDD fail-before/pass-after:
- **fix 전:** 3 신규 테스트가 fail — `aho.KNOWN_HOOKS`/`aho.THRESHOLDS` 미존재(AttributeError) + `agent-loop` 가 `ALL_HOOKS` 누락(AssertionError)
- **fix 후:** 30 passed

신규 테스트:
- `test_all_hooks_matches_governance_known_hooks` — `set(ALL_HOOKS) == KNOWN_HOOKS` (drift 회귀 가드)
- `test_emitting_hooks_not_misclassified_as_unrecognized` — agent-loop/experiment-report 이벤트가 "Unrecognized" 버킷에 안 들어가고 자기 이름으로 집계됨 (render_text)
- `test_threshold_current_reflects_governance_thresholds` — "current" 가 `THRESHOLDS` 반영

비-load-bearing leaf 단독 변경, 단일 worktree → overlap-preflight `[OK]`(stale base 없음, path overlap 없음).

## 5. Eval 영향

All `·` — RAG 파이프라인(retrieval/answer/verify/eval scoring) 무관. `analyze_hook_outcomes.py` 는 maintainer 가 90일 누적 fire-log 텔레메트리를 분석하는 governance 측정 도구일 뿐이다. real-data 델타 없음.

## 6. 하위 호환

계약 변경 없음. `ALL_HOOKS` 는 `list[str]` 유지(이제 10개, sorted), `threshold_recommendation` 반환 dict 키(`current.aware`/`current.block`) 동일 — 값이 SSoT 와 일치하도록 정정될 뿐. CLI 출력 포맷·exit code 불변. answer-contract(ADR 0003) 무관.

## 7. 범위 외

- `analyze_hook_outcomes` 가 `KNOWN_OUTCOMES`(L75 부근)도 자체 정의해 `_governance.KNOWN_OUTCOMES` 와 잠재 중복 — 동일 SSoT-파생 패턴 적용은 별도 concern 이라 분리 (One PR one concern)
- `scripts/claude-hooks/README.md` hook 테이블과의 정합성 점검은 별도
