### PR TITLE
docs: clarify T-2026-0025 legacy MiniLM target boundary

### DIFF
--- a/docs/plans/T-2026-0025-minilm-baseline-target.md
+++ b/docs/plans/T-2026-0025-minilm-baseline-target.md
@@ -21,6 +21,13 @@ Make the three baseline surfaces explicit:
 - `make real-eval-minilm`: MiniLM sentence-transformers private baseline.
 - `make real-eval-semantic`: BGE-M3 semantic comparison surface.
 
+Current-use boundary: this plan records historical target disambiguation. Under
+the current policy, legacy `make real-eval-minilm`, `make real-eval-semantic`,
+and `real100_minilm`/`real100_m3` path names are archive-only for new task, PR,
+claim, and handoff evidence unless the maintainer explicitly re-enables them.
+Use the `real100_v2` aggregate-only surface in [Surface Map](../evaluation/surface-map.md)
+for current private-eval claims.
+
 ## Scope
 
 - Add a named MiniLM target with isolated local index/output/report paths.


### PR DESCRIPTION
## §1 Summary
- Clarifies that `docs/plans/T-2026-0025-minilm-baseline-target.md` is historical target-disambiguation context.
- Adds the current-use boundary for legacy `make real-eval-minilm`, `make real-eval-semantic`, `real100_minilm`, and `real100_m3` private-eval lane names.

## §2 Issue
Closes #1974

## §3 Changes
- Added a short current-use boundary pointing current private-eval claims to the `real100_v2` aggregate-only surface.
- Preserved the completed plan's historical MiniLM/M3 target names instead of rewriting old context.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0025-minilm-baseline-target.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
Docs-only. No retrieval, answer, eval script, report aggregate, index, or private-data path changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-1974-t2026-0025-legacy-minilm-boundary`.
- Same-file open PR query for `docs/plans/T-2026-0025-minilm-baseline-target.md`: empty before PR creation.
- Pre-branch dirty/status and active branch-diff scans found no candidate-file conflicts; avoided known Codex/Claude dirty/open surfaces.

## §7 Notes
- Current private-eval evidence should remain on `real100_v2`; legacy target names in this plan are archive-only unless explicitly re-enabled.
