### PR TITLE
docs(eval): record private Naive real-eval guard boundaries

### DIFF
--- a/docs/evaluation/surface-map.md
+++ b/docs/evaluation/surface-map.md
@@ -69,6 +69,18 @@ agent gate behavior is [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-
 - dataset/config/index/provenance/command가 함께 있는 paired delta.
 - private/non-public임을 명시한 reviewer evidence.
 
+Naive RAG local private runner 경계:
+
+- `eval.naive_rag.private_real_eval` 은 새 run 의 `output_dir`, `index_dir`,
+  `index_build.hwp_pdf_artifact_dir` 가 legacy `data/index/real100*`,
+  `reports/real100*`, `outputs/real100*` 표면으로 향하면 실패해야 한다.
+  `real100_v2*` 는 현재 private-eval 표면으로 허용된다.
+- `run_id` 는 단일 안전 path segment 여야 하며 `..`, 절대경로, `/`, `\`
+  로 output root 를 벗어나면 안 된다.
+- Raw/private run output 은 gitignored/local-only 여야 한다. Redacted aggregate
+  summary 는 `reports/*.redacted.json` 처럼 raw case/id/path 를 포함하지 않는
+  allowlisted aggregate artifact 일 때만 commit boundary 에 들어갈 수 있다.
+
 금지:
 
 - raw private question, answer, evidence, filename, exact local path, doc/chunk id 노출.
@@ -110,6 +122,9 @@ agent gate behavior is [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-
 - `reports/real100_v2/` is the current claim-bearing aggregate surface.
 - `judge.aggregate.json`, `judge_ragas.aggregate.json`, and `rationality.aggregate.json` are aggregate-only reviewer evidence. Their local per-case siblings (`*.local.json`, traces, prompts, completions) and human review views such as `rationality.md` must stay outside the commit boundary.
 - Legacy `reports/real100/`, 221-case aggregates, and kordoc/v1 indexes are archive-only and must not be used for new tasks until the maintainer explicitly re-enables them.
+- New private Naive RAG runs must not write fresh result/index/artifact outputs
+  to legacy `real100*` surfaces; use `real100_v2*` paths or another explicitly
+  approved current surface.
 - `artifacts/runs/*/metrics/eval_summary.json` belongs to a harness run. Compare only after checking
   dataset/config/index/provenance.
 - `naive_baseline` is Chroma-backed by default (ADR 0081). `memory` and `qdrant`


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR #1886으로 추가된 private Naive RAG real-eval path guard의 reviewer-facing 경계를 `docs/evaluation/surface-map.md`에 기록합니다. 새 private run은 legacy `real100*` result/index/artifact 표면으로 쓰면 안 되고, raw/private output은 local-only이며 redacted aggregate summary만 allowlisted commit boundary에 들어갈 수 있음을 명시합니다.

Closes #1975

## 2. 영향 파일

- `docs/evaluation/surface-map.md` — evaluation surface 문서. Load-bearing 코드/ADR 아님.

## 3. 리스크

- 리스크: 문서가 코드 guard보다 넓거나 좁게 해석될 수 있음.
- 배제: #1886에서 구현된 실제 guard 항목(`output_dir`, `index_dir`, `hwp_pdf_artifact_dir`, `run_id`, redacted summary)을 문서에만 반영했고, 명령/코드/Make target은 변경하지 않음.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/surface-map.md`
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR/worktree/issue scan 후 active worktree/PR이 없는 새 issue #1975 생성, 별도 worktree `/Users/hskim/Desktop/projects/bidmate-wt/issue-1975-private-naive-guard-docs` 사용.

## 5. Eval 영향

문서-only 변경입니다. Eval 실행 경로, RAG pipeline, private aggregate 산출물은 변경하지 않았습니다. real-eval 미실행(동작 변화 없음).

## 6. 하위 호환

N/A — 문서 추가만 있으며 CLI/스키마/답변 계약 변경 없음.

## 7. 범위 외

- #1886 코드 guard 추가 자체는 이미 merged.
- outside-repo redacted summary 허용/차단 정책 변경은 하지 않음.
- legacy real100 archive artifacts 삭제/이름변경 없음.
