### PR TITLE
docs: clarify private manifest evidence boundary

### DIFF
--- a/docs/evaluation/private_real_eval_manifest_schema.md
+++ b/docs/evaluation/private_real_eval_manifest_schema.md
@@ -3,6 +3,13 @@
 이 manifest는 private real-eval의 문서 inventory 단일 출처(source of truth)다.
 원문 파일명이나 고객명은 커밋하지 않는다. 아래 값은 모두 fake placeholder다.
 
+> **Current-use boundary (2026-06-03)**: this schema describes local private
+> inventory bookkeeping only. The example `private_real_eval` split and ignored
+> `data/files_kordoc/` paths do not re-enable legacy `real100`/v1 claim-bearing
+> evidence. New task, PR, claim, and handoff evidence must use the `real100_v2`
+> aggregate-only surface in [Surface Map](./surface-map.md), unless the
+> maintainer explicitly re-enables another private-eval surface.
+
 ## Required Columns
 
 | column | purpose |


### PR DESCRIPTION
## §1 Summary
- Adds a current-use boundary to the private real-eval manifest schema.
- Clarifies that fake manifest rows and ignored local paths are inventory placeholders, not claim-bearing private-eval evidence.

## §2 Issue
Closes #1980

## §3 Changes
- Documented that legacy `private_real_eval` split wording and `data/files_kordoc/` examples do not re-enable legacy `real100`/v1 evidence.
- Pointed current private-eval claims to the `real100_v2` aggregate-only surface.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_manifest_schema.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
Docs-only. No eval runner, retrieval code, report aggregate, index, or private-data artifact changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-1980-private-manifest-evidence-boundary`.
- Same-file open PR query for `docs/evaluation/private_real_eval_manifest_schema.md`: empty before PR creation.
- Candidate-file active branch-diff and dirty worktree scans were empty; known Codex/Claude dirty/open surfaces were avoided.

## §7 Notes
- This keeps the schema useful for local inventory bookkeeping while preventing fake examples from being cited as evidence.
