### PR TITLE
docs: mark construct-validity audit as historical evidence

### DIFF
--- a/docs/audits/construct-validity-gold-grounding-inspection.md
+++ b/docs/audits/construct-validity-gold-grounding-inspection.md
@@ -1,5 +1,12 @@
 # real-100 정확도 천장의 construct-validity inspection (gold-grounding 결함)
 
+> **Archive/current-use boundary (2026-06-03)**: this inspection preserves
+> historical v1 `real100` / 221-case construct-validity findings. It is not
+> current claim-bearing private-eval evidence. New task, PR, claim, and handoff
+> evidence must use the `real100_v2` aggregate-only surface in
+> [Surface Map](../evaluation/surface-map.md), unless the maintainer explicitly
+> re-enables another private-eval surface.
+
 | field | value |
 |---|---|
 | Issue | #1347 |


### PR DESCRIPTION
## §1 Summary
- Marks the construct-validity audit as historical v1 `real100` / 221-case context.
- Prevents its archived measurements from being cited as current claim-bearing private-eval evidence.

## §2 Issue
Closes #1982

## §3 Changes
- Added an archive/current-use boundary at the top of `docs/audits/construct-validity-gold-grounding-inspection.md`.
- Pointed current private-eval claims to the `real100_v2` aggregate-only surface.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/audits/construct-validity-gold-grounding-inspection.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
Docs-only. No eval code, report aggregate, index, or private-data artifact changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-1982-construct-validity-historical-evidence`.
- Same-file open PR query for `docs/audits/construct-validity-gold-grounding-inspection.md`: empty before PR creation.
- Candidate-file active branch-diff and dirty worktree scans were empty; known Codex/Claude dirty/open surfaces were avoided.

## §7 Notes
- The audit’s historical findings remain intact; only the evidence-use boundary was added.
