### PR TITLE
docs(eval): sync readiness checklist with real100_v2 guard

### DIFF
--- a/docs/evaluation/pre_improvement_readiness_checklist.md
+++ b/docs/evaluation/pre_improvement_readiness_checklist.md
@@ -24,6 +24,13 @@ real-eval aggregate에서만 후보로 삼을 수 있다.
 `private real-eval aggregate`도 raw output 자체가 아니라 privacy check를 통과한
 aggregate summary만 claim 후보가 된다.
 
+현재 claim-bearing private real-eval 표면은 `real100_v2`다. 새 작업은
+`data/private/real100_v2/real_config_v2.local.yaml` 또는 `REAL100_V2_CONFIG`가
+가리키는 ignored local config를 사용하고, `make real-eval-v2-check` /
+`make real-eval-v2-guard`로 legacy real100/v1 경계가 fail-closed인지 확인한다.
+Legacy real100/v1/221/kordoc evidence는 maintainer가 명시적으로 다시 열기
+전까지 새 claim, PR, handoff에 쓰지 않는다.
+
 ## Definition Of Ready
 
 성능 개선 PR을 시작하기 전 다음 항목이 준비돼야 한다.
@@ -60,26 +67,38 @@ content가 제거된 aggregate summary 또는 문서화된 checklist뿐이다.
 
 ## Exact Local Commands
 
-이 readiness workflow의 단일 local config는 `eval/real_config.local.yaml`이다.
-별도의 `configs/eval/private_real_eval.local.yaml`를 만들지 않는다.
+이 readiness workflow의 current-use local config는
+`data/private/real100_v2/real_config_v2.local.yaml`이다. 다른 ignored local v2
+config를 써야 하면 `REAL100_V2_CONFIG`로 명시한다.
+`eval/real_config.local.yaml` 또는 `configs/eval/private_real_eval.local.yaml`는
+compatibility/local-only 실험 경로일 뿐이며, 새 기준선 claim은 `real100_v2`
+surface로 수렴시킨다.
 
 Parse/data readiness audit:
 
 ```bash
-python3 scripts/audit_private_data_readiness.py --config eval/real_config.local.yaml --out-dir experiments/private_runs/readiness_audit
+python3 scripts/audit_private_data_readiness.py \
+  --config data/private/real100_v2/real_config_v2.local.yaml \
+  --out-dir experiments/private_runs/readiness_audit
 ```
 
 Validate-only:
 
 ```bash
-python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
+REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml make real-eval-v2-check
+make real-eval-v2-guard
 ```
 
 Baseline run:
 
 ```bash
-python3 scripts/run_private_real_eval.py --config eval/real_config.local.yaml
+REAL_EVAL_ROOT=<private-real-eval-root> make real-eval-v2-chroma
 ```
+
+Direct runner invocations remain local-only compatibility paths. If used, their
+config must keep `output_dir`, `index_dir`, `index_build.hwp_pdf_artifact_dir`,
+`run_id`, and `redacted_summary_path` inside the current `real100_v2` guard
+boundary.
 
 ## Privacy Boundary
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The pre-improvement readiness checklist still described `eval/real_config.local.yaml` as the single private eval config and did not name the current `real100_v2` guard targets. This PR updates the docs-only checklist so new claim-bearing readiness work uses the `real100_v2` local config surface, validates with `real-eval-v2-check` / `real-eval-v2-guard`, and keeps raw private outputs separate from redacted aggregate evidence.

Closes #1985

## 2. 영향 파일

- `docs/evaluation/pre_improvement_readiness_checklist.md` — docs-only readiness checklist guidance.

## 3. 리스크

- Risk: readers may continue to run or cite legacy real100/v1 private eval paths for new baseline claims.
- Mitigation: documented `real100_v2` as the current-use surface, added v2 guard commands, and labeled compatibility direct-runner paths as local-only.

## 4. 테스트

- Overlap preflight: latest `origin/main` used as base (`13a382e7`); open PR files are analyze hook, latency SLO, codex gate, and unrelated audit docs, not this checklist.
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/pre_improvement_readiness_checklist.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check HEAD~1..HEAD`
- `make check-branch`

## 5. Eval 영향

Docs-only. No eval code, Make target, config default, report, index, or aggregate changed. Private eval not run because this PR only updates readiness guidance.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link contract changes. Compatibility local config references remain documented as local-only paths, not current claim-bearing evidence.

## 7. 범위 외

- No Makefile or runner changes.
- No private data or report generation.
- No updates to historical audit reports.
