### PR TITLE
docs(eval): align private data audit with real100_v2 validation

### DIFF
--- a/docs/evaluation/private_data_quality_audit.md
+++ b/docs/evaluation/private_data_quality_audit.md
@@ -8,6 +8,13 @@ No public synthetic benchmark performance claim is produced by these audits.
 Private real-eval remains local-only; only redacted aggregate summaries may be
 reviewed as commit candidates.
 
+Current claim-bearing private eval work uses the `real100_v2` surface. Keep the
+local config at `data/private/real100_v2/real_config_v2.local.yaml` or point
+`REAL100_V2_CONFIG` at another ignored local v2 config, then validate with
+`make real-eval-v2-check` and `make real-eval-v2-guard`. Legacy real100/v1,
+221-case, and kordoc/v1 evidence is archive-only until the maintainer
+explicitly re-enables it.
+
 ## Required Order Before Baseline Measurement
 
 1. Parse audit
@@ -113,8 +120,12 @@ measurement warning, not as a system performance claim.
 After both audits pass, run the private real-eval validator:
 
 ```bash
-python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
+REAL100_V2_CONFIG=data/private/real100_v2/real_config_v2.local.yaml make real-eval-v2-check
+make real-eval-v2-guard
 ```
 
-Then run the private baseline only after validate-only passes. Review only
-redacted aggregate summaries before considering any commit.
+Direct readiness-script invocations remain local-only compatibility paths. If
+used, point `--config` at an ignored v2 config and keep index/report/output
+paths inside the current guard boundary. Then run the private baseline only
+after validate-only passes. Review only redacted aggregate summaries before
+considering any commit.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The private data quality audit guide still followed audit pass with a legacy `eval/real_config.local.yaml` readiness command. This PR updates the docs-only follow-up validation guidance to name the current `real100_v2` local config surface and require `real-eval-v2-check` / `real-eval-v2-guard` before any private baseline run.

Closes #1992

## 2. 영향 파일

- `docs/evaluation/private_data_quality_audit.md` — docs-only private audit workflow guidance.

## 3. 리스크

- Risk: audit readers may validate against legacy real100/v1 paths after parse/dataset checks.
- Mitigation: added current `real100_v2` boundary wording and replaced the follow-up command with v2 guard targets, while preserving direct readiness script usage as local-only compatibility.

## 4. 테스트

- Overlap preflight: latest `origin/main` used as base (`60d7b2c6`); no open PR or worktree branch matched `docs/evaluation/private_data_quality_audit.md`.
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_data_quality_audit.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check HEAD~1..HEAD`
- `make check-branch`

## 5. Eval 영향

Docs-only. No audit script, eval runner, Make target, config default, report, index, or aggregate changed. Private eval not run because this PR only updates workflow guidance.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link contract changes. Direct readiness-script usage remains documented as a local-only compatibility path.

## 7. 범위 외

- No code or Makefile changes.
- No private data/report generation.
- No historical audit/report rewrite.
