### PR TITLE
docs: add current policy note to ADR 0073

### DIFF
--- a/docs/adr/0073-real100-retrieval-surface-keeps-minilm.md
+++ b/docs/adr/0073-real100-retrieval-surface-keeps-minilm.md
@@ -11,6 +11,14 @@
   [ADR 0069](./0069-retrieval-aggregate-and-citation-coverage-surface.md) (소비한 retrieval aggregate 표면),
   [`docs/eval/embedding-ablation.md`](../eval/embedding-ablation.md) Phase 2.0, issue #1359
 
+> **Current-policy note (2026-06-03)**: this ADR remains an accepted historical
+> decision record for keeping MiniLM as the default embedding model. Its legacy
+> `real100` retrieval aggregates and `reports/real100/` references are
+> archive-only for new private-eval claims. New task, PR, claim, and handoff
+> evidence must use the `real100_v2` aggregate-only surface in
+> [Surface Map](../evaluation/surface-map.md), unless the maintainer explicitly
+> re-enables another private-eval surface.
+
 ## TL;DR
 
 - 5모델(MiniLM/EmbeddingGemma-300M/bge-m3-korean/KURE-v1/Qwen3-0.6B)을 **real100 비공개 corpus**(26376 kordoc 청크)에서 **retrieval 표면**(ADR 0069 `chunk_recall@k`/`mrr`/`ndcg` + bootstrap CI)으로 측정. Phase 1.x의 public-fixture-smoke answer-quality 표면에서 처음 벗어남.


### PR DESCRIPTION
## §1 Summary
- Adds a current-policy note to ADR 0073 without changing its accepted MiniLM default decision.
- Clarifies that the ADR’s legacy `real100` retrieval aggregates are archive-only for new private-eval claims.

## §2 Issue
Closes #1990

## §3 Changes
- Added a top-of-ADR note preserving ADR 0073 as a historical decision record.
- Pointed new task, PR, claim, and handoff evidence to the `real100_v2` aggregate-only surface unless another private-eval surface is explicitly re-enabled.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0073-real100-retrieval-surface-keeps-minilm.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0073-real100-retrieval-surface-keeps-minilm.md`
- `git diff --check`
- `make check-branch`
- pre-commit local Codex adversarial review: passed, 0 blocking findings

## §5 Eval impact
Docs-only ADR framing change. No retrieval, answer, eval runner, report aggregate, index, or private-data artifact changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-1990-adr0073-current-policy-note`.
- Same-file open PR query for `docs/adr/0073-real100-retrieval-surface-keeps-minilm.md`: empty before PR creation.
- Candidate-file active branch-diff and dirty worktree scans were empty; known Codex/Claude dirty/open surfaces were avoided.

## §7 Notes
- Push hook emitted the standard load-bearing/test reminder for the ADR path; this change is documentation-only and does not change runtime behavior.
