### PR TITLE
docs(ops): clarify legacy real100 HTML privacy scan scope

### DIFF
--- a/docs/operations/experiment-report-html.md
+++ b/docs/operations/experiment-report-html.md
@@ -26,6 +26,11 @@
 - `reports/**/eval_summary.json` — smoke / eval 산출물
 - `reports/retrieval/**/REPORT.md` — retrieval-eval skill phase 보고서
 
+Current claim-bearing private eval evidence is `real100_v2` only. Legacy
+`reports/real100/` artifacts remain in this renderer's documented input and
+privacy-scan scope so historical artifacts are still checked before any HTML
+view is generated; they are not current private-eval claim evidence.
+
 ## 입력 denylist (ADR 0005 boundary)
 
 다음은 자동으로 거부된다 (exit 2 `denied`, stderr 에 사유):
@@ -39,6 +44,10 @@
 - `EVAL_PRIVACY_ARTIFACT_GLOBS` (`reports/retrieval`, `reports/real100`,
   `reports/real100_v2`) 아래: `_governance.find_eval_private_text`
   (한글 문자 + 콜론 포함 dict key)
+
+`reports/real100` is included here as a historical privacy-scan surface, not as
+permission to use legacy real100/v1 outputs for new task, PR, claim, or handoff
+evidence.
 
 2026-05-21 #1144 (realistic-metadata `raw_results.json` 의 `gold_agency`
 실값 committed 노출 → history-rewrite) 재발 방지가 명시 동기.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The experiment HTML operations guide correctly lists `reports/real100` in renderer inputs and privacy-scan globs, but that can be misread as current private-eval claim evidence. This docs-only PR clarifies that legacy `reports/real100/` remains in scope for historical privacy scanning only; current claim-bearing private eval evidence is `real100_v2`.

Closes #1995

## 2. 영향 파일

- `docs/operations/experiment-report-html.md` — docs-only operations guidance.

## 3. 리스크

- Risk: removing or hiding `reports/real100` could weaken privacy-scan documentation for historical artifacts.
- Mitigation: kept the legacy path in the documented scan scope while explicitly labeling it historical/non-claim evidence.

## 4. 테스트

- Overlap preflight: latest `origin/main` used as base (`adf3bcce`); open PRs do not modify `docs/operations/experiment-report-html.md`; no worktree branch/path hint matched this file.
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/experiment-report-html.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check HEAD~1..HEAD`
- `make check-branch`

## 5. Eval 영향

Docs-only. No renderer code, governance constant, report, index, eval script, or aggregate changed. Private eval not run because this PR only clarifies operations documentation.

## 6. 하위 호환

No schema, CLI, renderer, or doc-link contract changes. Legacy paths remain documented as scan inputs.

## 7. 범위 외

- No renderer or governance code changes.
- No report regeneration.
- No historical artifact edits.
