### PR TITLE
docs(eval): split current v2 config in private eval inventory

### DIFF
--- a/docs/private-real-eval-inventory.md
+++ b/docs/private-real-eval-inventory.md
@@ -7,11 +7,17 @@ deprecated/dead reference 로 분리한다. 조사 기준은 repo-wide `rg` 로
 패턴을 검색하고, `find data eval reports scripts tests -maxdepth 4` 로
 실제 tree 를 대조한 결과다.
 
+Current claim-bearing private eval work uses the `real100_v2` config and
+aggregate surface. Legacy compatibility configs remain documented because
+direct/local tools still accept them, but they are not the current evidence
+surface for new PRs, claims, or handoffs.
+
 ## Inventory
 
 | path | category | referenced by | required before run? | can regenerate? | recommended env/config key |
 |---|---|---|---:|---:|---|
-| `eval/real_config.local.yaml` | required input | `eval/run_eval.py --config`, `scripts/smoke_real.sh`, case proposer/promote tools | yes | no | `REAL_EVAL_CONFIG` |
+| `data/private/real100_v2/real_config_v2.local.yaml` | required input for current private eval | `REAL100_V2_CONFIG`, `make real-eval-v2-*`, v2 judge/rationality targets | yes | no | `REAL100_V2_CONFIG` |
+| `eval/real_config.local.yaml` | compatibility local input | `eval/run_eval.py --config`, `scripts/smoke_real.sh`, case proposer/promote tools | yes for direct compatibility runs; no for current v2 claim surface | no | `REAL_EVAL_CONFIG` |
 | `data/data_list.csv` | required input | `scripts/validate_data_list.py`, `scripts/build_index.py --metadata_csv`, `eval/case_proposer.py`, `scripts/eda_real100.py` | yes | no | `REAL_EVAL_DATA_LIST`, `real_eval.data_list` |
 | `data/files/` | required input | `scripts/build_index.py --files_dir`, `scripts/validate_data_list.py --files_dir`, kordoc source hashing | yes | no | `REAL_EVAL_DATA_DIR`, `real_eval.document_dirs.default` |
 | `data/files_kordoc/` | regenerable cache | `ingestion._resolve_kordoc_cache_dir`, `scripts/build_kordoc_manifest.py`, `BIDMATE_KORDOC_CACHE_DIR` | no | yes | `REAL_EVAL_KORDOC_DATA_DIR`, `real_eval.document_dirs.kordoc` |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The private real-eval local path inventory still listed `eval/real_config.local.yaml` as the required config input. Current claim-bearing private eval work uses `data/private/real100_v2/real_config_v2.local.yaml` / `REAL100_V2_CONFIG`, while the legacy config remains a compatibility/local-only path. This PR splits those two roles in the inventory.

Closes #1998

## 2. 영향 파일

- `docs/private-real-eval-inventory.md` — docs-only local path inventory.

## 3. 리스크

- Risk: readers may confuse compatibility config paths with the current v2 claim surface.
- Mitigation: added current-use boundary wording and separated the inventory rows for v2 required config vs compatibility local config.

## 4. 테스트

- Overlap preflight: latest `origin/main` used as base (`63805bbd`); no open PR modifies `docs/private-real-eval-inventory.md`; best-effort worktree diff scan found no exact diff/dirty match for this file.
- `python3 scripts/check_doc_links.py --check-all --paths docs/private-real-eval-inventory.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check HEAD~1..HEAD`
- `make check-branch`

## 5. Eval 영향

Docs-only. No eval runner, Make target, config, report, index, or aggregate changed. Private eval not run because this PR only updates path inventory documentation.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link contract changes. Compatibility config paths remain documented separately.

## 7. 범위 외

- No code, Makefile, or config changes.
- No private data/report generation.
- No historical artifact edits.
