### PR TITLE
docs: add current policy note to ADR 0076

### DIFF
--- a/docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md
+++ b/docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md
@@ -5,6 +5,14 @@
 - **Deciders**: hskim (solo author)
 - **Related**: ADR 0001, ADR 0003, ADR 0005, ADR 0069, ADR 0075
 
+> **Current-policy note (2026-06-03)**: this ADR remains an accepted historical
+> decision record for the counts-only multi-chunk failure analysis surface. Its
+> legacy `real100` input/output paths, including `reports/real100/`, are
+> archive-only for new private-eval claims. New task, PR, claim, and handoff
+> evidence must use the `real100_v2` aggregate-only surface in
+> [Surface Map](../evaluation/surface-map.md), unless the maintainer explicitly
+> re-enables another private-eval surface.
+
 ## Context
 
 Real-eval failure analysis already has aggregate-only failure distribution and


### PR DESCRIPTION
## §1 Summary
- Adds a current-policy note to ADR 0076 without changing its accepted counts-only renderer decision.
- Clarifies that the ADR’s legacy `real100` input/output paths are archive-only for new private-eval claims.

## §2 Issue
Closes #1997

## §3 Changes
- Added a top-of-ADR note preserving ADR 0076 as a historical decision record.
- Pointed new task, PR, claim, and handoff evidence to the `real100_v2` aggregate-only surface unless another private-eval surface is explicitly re-enabled.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md`
- `git diff --check`
- `make check-branch`
- pre-commit local Codex adversarial review: passed, 0 blocking findings

## §5 Eval impact
Docs-only ADR framing change. No retrieval, answer, eval runner, report aggregate, index, or private-data artifact changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-1997-adr0076-current-policy-note`.
- Same-file open PR query for `docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md`: empty before PR creation.
- Candidate-file active branch-diff and dirty worktree scans were empty; known Codex/Claude dirty/open surfaces were avoided.

## §7 Notes
- Push hook emitted the standard load-bearing/test reminder for the ADR path; this change is documentation-only and does not change runtime behavior.
