### PR TITLE
docs(plan): clarify T-2026-0024 legacy make eval wording

### DIFF
--- a/docs/plans/T-2026-0024-page-metadata-reindex.md
+++ b/docs/plans/T-2026-0024-page-metadata-reindex.md
@@ -24,10 +24,16 @@ prompt, answer, or eval scoring behavior.
 ## Scope
 
 - Preserve explicit section-level `page_span` through `fixed_parent_section`.
-- Keep the existing `make real-eval` defaults unchanged.
+- Keep the historical `make real-eval` default behavior unchanged; under the
+  current policy that means leaving legacy real100/v1 targets disabled, not
+  reviving them for new evidence.
 - Add an isolated `real-eval-page-aware` target for local page-aware rebuilds
   that reuse private converted PDFs and write to separate output paths.
 - Record only aggregate validation evidence.
+
+Current-use note: new private eval claims and handoffs must stay on
+`real100_v2` aggregate evidence and `real-eval-v2-*` guards unless the
+maintainer explicitly re-enables legacy real100/v1 targets.
 
 ## Out Of Scope
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The T-2026-0024 page metadata plan said to keep existing `make real-eval` defaults unchanged. Since current policy keeps legacy real100/v1 targets disabled, that line needed a narrow current-use clarification so it cannot be read as permission to revive legacy outputs. This PR preserves the historical plan while noting that new evidence must stay on `real100_v2` / `real-eval-v2-*` guards.

Closes #2001

## 2. 영향 파일

- `docs/plans/T-2026-0024-page-metadata-reindex.md` — docs-only plan clarification.

## 3. 리스크

- Risk: historical plan wording could imply legacy `make real-eval` should be restored for new evidence.
- Mitigation: clarified that the current meaning is to keep legacy targets disabled unless the maintainer explicitly re-enables them.

## 4. 테스트

- Overlap preflight: latest `origin/main` used as base (`28a2ff88`); no open PR modifies this plan; safe-candidate scan found no exact worktree diff/dirty match for this file.
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0024-page-metadata-reindex.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check HEAD~1..HEAD`
- `make check-branch`

## 5. Eval 영향

Docs-only. No eval runner, Make target, index, report, task queue, or aggregate changed. Private eval not run because this PR only clarifies a historical plan note.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link contract changes. Historical plan content remains intact with a current-policy clarification.

## 7. 범위 외

- No Makefile or code changes.
- No task queue status changes.
- No report regeneration or private data access.
