### PR TITLE
test(check-doc-links): docs-link 게이트 파서 계약 회귀 테스트 (645줄 게이트 테스트 0 커버)

### DIFF
--- a/tests/test_check_doc_links.py
+++ b/tests/test_check_doc_links.py
@@ -1,0 +1,318 @@
+"""Contract/regression tests for scripts/check_doc_links.py (issue #2004).
+
+The 645-line docs cross-reference / fragment-anchor / ADR-ref governance gate
+(Makefile ``check-doc-links``) shipped with ZERO tests despite its anchor
+validation being fixed three times — #1104 (gate + 101-link cleanup), #1174
+(#fragment anchors + i18n repair), f66a170c (Jekyll directory permalinks).
+
+These lock the pure-parser contracts so a future regression fails loudly:
+github-slugger mirroring (Korean / accented slugs — this repo's docs are
+largely Korean), fragment parsing, Jekyll ``permalink: pretty`` handling, and
+ADR forward-reference tolerance. Behavior is UNCHANGED — each expected value
+was confirmed against the live function (which matches github-slugger).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_doc_links import (  # noqa: E402
+    collect_anchors,
+    extract_links,
+    find_broken_adr_refs,
+    find_broken_fragments,
+    find_broken_links,
+    normalize_target,
+    slugify_heading,
+    split_fragment,
+    strip_code_spans,
+)
+
+
+# ---------------------------------------------------------------------------
+# slugify_heading — the github-slugger mirror (the part most exposed to i18n
+# regression: a whitelist re would silently strip Korean/accented headings).
+# ---------------------------------------------------------------------------
+
+
+def test_slug_basic_lowercase_hyphenated():
+    assert slugify_heading("## Hello World") == "hello-world"
+
+
+def test_slug_strips_marker_and_trailing_hashes():
+    assert slugify_heading("### Title ###") == "title"
+    # Already-extracted heading text (no leading ``#``) is accepted too.
+    assert slugify_heading("Title") == "title"
+
+
+def test_slug_korean_preserved():
+    # GitHub keeps unicode word chars; Korean headings must round-trip.
+    assert slugify_heading("## 한국어 제목") == "한국어-제목"
+
+
+def test_slug_accented_preserved():
+    assert slugify_heading("## Café déjà vu") == "café-déjà-vu"
+
+
+def test_slug_punctuation_dropped():
+    assert slugify_heading("## Foo: Bar! (baz)") == "foo-bar-baz"
+
+
+def test_slug_hyphen_and_underscore_kept():
+    # Deliberately absent from the strip set — GitHub keeps them.
+    assert slugify_heading("## a_b-c") == "a_b-c"
+
+
+def test_slug_each_whitespace_becomes_a_hyphen():
+    # Two spaces → two hyphens (matches github-slugger's per-char replace).
+    assert slugify_heading("## a  b") == "a--b"
+
+
+def test_slug_inline_link_reduced_to_visible_text():
+    assert slugify_heading("## see [foo](x.md) here") == "see-foo-here"
+
+
+# ---------------------------------------------------------------------------
+# collect_anchors — heading slugs (+ GitHub -1/-2 duplicate suffixing) plus
+# explicit HTML / kramdown anchors; code/YAML/comment regions skipped.
+# ---------------------------------------------------------------------------
+
+
+def test_anchors_duplicate_headings_get_numeric_suffix():
+    assert collect_anchors("## Foo\n\n## Foo\n\n## Foo") == {"foo", "foo-1", "foo-2"}
+
+
+def test_anchors_html_id_and_name():
+    assert collect_anchors('<a id="custom"></a>\n## Title') == {"custom", "title"}
+    assert "n1" in collect_anchors('<a name="N1"></a>\n# H')
+
+
+def test_anchors_kramdown_explicit_id():
+    assert "myid" in collect_anchors("## Heading {#myid}")
+
+
+def test_anchors_skip_fenced_code_headings():
+    # A "## heading" inside a code fence produces no GitHub anchor.
+    text = "## Real\n\n```\n## Fake In Code\n```\n"
+    anchors = collect_anchors(text)
+    assert "real" in anchors
+    assert "fake-in-code" not in anchors
+
+
+def test_anchors_skip_yaml_front_matter():
+    text = "---\ntitle: Not A Heading\n---\n\n## Real\n"
+    assert collect_anchors(text) == {"real"}
+
+
+def test_anchors_skip_html_comment_block():
+    text = "<!--\n## Commented Out\n-->\n## Real\n"
+    anchors = collect_anchors(text)
+    assert "real" in anchors
+    assert "commented-out" not in anchors
+
+
+# ---------------------------------------------------------------------------
+# split_fragment — parse an href into (path, fragment) when checkable, else None
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_same_file():
+    assert split_fragment("#frag") == ("", "frag")
+
+
+def test_fragment_markdown_target():
+    assert split_fragment("foo.md#bar") == ("foo.md", "bar")
+
+
+def test_fragment_non_markdown_extension_is_none():
+    # foo.py#L10 has no enumerable anchor set → not checkable here.
+    assert split_fragment("foo.py#L10") is None
+
+
+def test_fragment_external_is_none():
+    assert split_fragment("https://example.com#x") is None
+    assert split_fragment("/site-absolute#x") is None
+
+
+def test_fragment_empty_after_hash_is_none():
+    assert split_fragment("foo.md#") is None
+
+
+def test_fragment_jekyll_permalink_kept():
+    # Extensionless / trailing-slash target is kept for deferred resolution.
+    assert split_fragment("../guide/#frag") == ("../guide/", "frag")
+
+
+def test_fragment_strips_path_line_suffix():
+    assert split_fragment("foo.md:10#bar") == ("foo.md", "bar")
+
+
+# ---------------------------------------------------------------------------
+# normalize_target — href → filesystem-checkable path, or None to skip
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_plain_markdown():
+    assert normalize_target("foo.md") == "foo.md"
+
+
+def test_normalize_strips_fragment():
+    assert normalize_target("foo.md#frag") == "foo.md"
+
+
+def test_normalize_same_file_anchor_is_none():
+    assert normalize_target("#frag") is None
+
+
+def test_normalize_external_is_none():
+    assert normalize_target("https://example.com") is None
+    assert normalize_target("//proto-relative") is None
+
+
+def test_normalize_directory_permalink_is_none():
+    # No known extension on the final segment → Jekyll permalink, skipped.
+    assert normalize_target("../guide/") is None
+
+
+def test_normalize_html_is_none():
+    # .html is rendered-output, not a source file.
+    assert normalize_target("architecture.html") is None
+
+
+def test_normalize_angle_brackets_and_title_stripped():
+    assert normalize_target("<foo.md>") == "foo.md"
+    assert normalize_target('foo.md "Title"') == "foo.md"
+
+
+def test_normalize_strips_line_suffix():
+    assert normalize_target("foo.py:10") == "foo.py"
+    assert normalize_target("foo.py:10-20") == "foo.py"
+
+
+# ---------------------------------------------------------------------------
+# strip_code_spans / extract_links — keep example links out of the link set
+# ---------------------------------------------------------------------------
+
+
+def test_strip_fenced_code_block():
+    text = "before\n```\n[x](evil.md)\n```\nafter"
+    out = strip_code_spans(text)
+    assert "evil.md" not in out
+    assert "before" in out and "after" in out
+
+
+def test_strip_tilde_fence():
+    text = "a\n~~~\n[y](y.md)\n~~~\nb"
+    assert "y.md" not in strip_code_spans(text)
+
+
+def test_strip_inline_code():
+    assert "x.md" not in strip_code_spans("see `[x](x.md)` here")
+
+
+def test_extract_basic_and_image_links():
+    assert extract_links("[foo](bar.md)") == ["bar.md"]
+    # ![alt](src) — the (src) portion is matched, so broken images are caught.
+    assert extract_links("![alt](img.png)") == ["img.png"]
+
+
+# ---------------------------------------------------------------------------
+# find_broken_links / find_broken_fragments — filesystem-resolved (tmp_path)
+# ---------------------------------------------------------------------------
+
+
+def test_broken_link_missing_target_reported(tmp_path):
+    (tmp_path / "doc.md").write_text("[x](missing.md)", encoding="utf-8")
+    broken = find_broken_links(["doc.md"], repo_root=tmp_path)
+    assert len(broken) == 1 and broken[0][0] == "doc.md"
+
+
+def test_broken_link_existing_target_ok(tmp_path):
+    (tmp_path / "doc.md").write_text("[x](other.md)", encoding="utf-8")
+    (tmp_path / "other.md").write_text("# Other", encoding="utf-8")
+    assert find_broken_links(["doc.md"], repo_root=tmp_path) == []
+
+
+def test_broken_fragment_bad_anchor_reported(tmp_path):
+    (tmp_path / "doc.md").write_text("[x](target.md#nope)", encoding="utf-8")
+    (tmp_path / "target.md").write_text("# Real Heading", encoding="utf-8")
+    broken = find_broken_fragments(["doc.md"], repo_root=tmp_path)
+    assert len(broken) == 1 and broken[0][2] == "nope"
+
+
+def test_good_fragment_anchor_ok(tmp_path):
+    (tmp_path / "doc.md").write_text("[x](target.md#real-heading)", encoding="utf-8")
+    (tmp_path / "target.md").write_text("# Real Heading", encoding="utf-8")
+    assert find_broken_fragments(["doc.md"], repo_root=tmp_path) == []
+
+
+def test_same_file_fragment_resolves_against_self(tmp_path):
+    (tmp_path / "doc.md").write_text("# Top\n\n[jump](#top)", encoding="utf-8")
+    assert find_broken_fragments(["doc.md"], repo_root=tmp_path) == []
+
+
+def test_missing_fragment_target_file_not_double_reported(tmp_path):
+    # A missing TARGET file is find_broken_links' job; find_broken_fragments
+    # stays silent so one broken link is not reported twice.
+    (tmp_path / "doc.md").write_text("[x](gone.md#frag)", encoding="utf-8")
+    assert find_broken_fragments(["doc.md"], repo_root=tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# find_broken_adr_refs — ADR prose refs vs docs/adr/NNNN-*.md, forward-tolerant
+# ---------------------------------------------------------------------------
+
+
+def _make_adr_dir(tmp_path, numbers):
+    adr = tmp_path / "docs" / "adr"
+    adr.mkdir(parents=True)
+    for n in numbers:
+        (adr / f"{n:04d}-example.md").write_text("# ADR", encoding="utf-8")
+    return adr
+
+
+def test_adr_ref_existing_is_ok(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("See ADR 0007 for details.", encoding="utf-8")
+    assert find_broken_adr_refs(["doc.md"], repo_root=tmp_path, adr_dir=adr) == []
+
+
+def test_adr_ref_dead_below_max_is_broken(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("See ADR 0005 (never created).", encoding="utf-8")
+    assert find_broken_adr_refs(["doc.md"], repo_root=tmp_path, adr_dir=adr) == [
+        ("doc.md", "0005")
+    ]
+
+
+def test_adr_ref_forward_skipped_by_default(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("Planned ADR 0099.", encoding="utf-8")
+    # 99 > max(7) → planned forward-ref, tolerated.
+    assert find_broken_adr_refs(["doc.md"], repo_root=tmp_path, adr_dir=adr) == []
+
+
+def test_adr_ref_forward_flagged_when_disallowed(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("Planned ADR 0099.", encoding="utf-8")
+    assert find_broken_adr_refs(
+        ["doc.md"], repo_root=tmp_path, adr_dir=adr, allow_forward=False
+    ) == [("doc.md", "0099")]
+
+
+def test_adr_ref_in_code_span_ignored(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("`ADR 0005` is an example.", encoding="utf-8")
+    # Code-span stripped before scanning → not a live ref.
+    assert find_broken_adr_refs(["doc.md"], repo_root=tmp_path, adr_dir=adr) == []
+
+
+def test_adr_ref_deduplicated_per_source(tmp_path):
+    adr = _make_adr_dir(tmp_path, [1, 7])
+    (tmp_path / "doc.md").write_text("ADR 0005 and again ADR 0005.", encoding="utf-8")
+    assert find_broken_adr_refs(["doc.md"], repo_root=tmp_path, adr_dir=adr) == [
+        ("doc.md", "0005")
+    ]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/check_doc_links.py` (645줄, docs cross-reference dead-link / fragment-anchor / ADR-ref governance 게이트 — Makefile `check-doc-links`) 가 **테스트 0개**로 운영돼 왔다. 이 surface 의 anchor/fragment 검증 로직은 세 번 깨졌다 고쳐진 **실증된 fragile 영역**이다 (#1104 gate 도입, #1174 #fragment anchor + i18n 복구, f66a170c Jekyll permalink anchor). 미묘한 파서 로직(github-slugger 미러, fragment 파싱, Jekyll permalink, ADR forward-ref)의 현재 계약을 회귀 테스트로 lock 한다.

**버그 수정이 아니라 characterization / 회귀 방어 테스트다** — 동작은 변경하지 않으며, 각 기댓값은 live 함수로 github-slugger 와 일치함을 확인했다(버그 없음). 이 PR 의 가치는 "fragile 게이트의 올바른 동작을 고정해 미래 회귀를 loud-fail 시키는 것".

Closes #2004

## 2. 영향 파일

- `tests/test_check_doc_links.py` — **신규** (45 tests). **non-load-bearing**
- `scripts/check_doc_links.py` — **무수정** (읽기만)

## 3. 리스크

가장 가능성 높은 깨짐 = **기댓값이 실제 동작과 어긋나 false 계약을 고정하는 것**. 배제 근거: 모든 기댓값을 작성 전 live 함수 실행으로 관찰해 확정했고(한글 `한국어-제목`, 악센트 `café-déjà-vu`, 중복 `foo`/`foo-1`/`foo-2`, permalink `../guide/` → None 등), 45개 전부 첫 실행에서 pass. 테스트 전용 PR 이라 프로덕션 동작 영향 0.

## 4. 테스트

이 PR 자체가 테스트다. 신규 45개가 다음 순수/통합 함수를 커버:
- `slugify_heading` (8) — 한글/악센트/punctuation/inline-link/중복-suffix/trailing-`#`/hyphen·underscore 보존/per-char 공백
- `collect_anchors` (6) — `-1`/`-2` 중복접미 + HTML `id`/`name` + kramdown `{#id}` + code-fence/YAML/comment skip
- `split_fragment` (7) + `normalize_target` (8) — md-target/non-md(None)/external/Jekyll permalink/`path:line`/angle-bracket/title/`.html`(None)
- `strip_code_spans` (3) + `extract_links` (1) — fenced ```` ``` ````/`~~~` + inline code 제거
- `find_broken_links`/`find_broken_fragments` (6, tmp_path) — missing target / bad·good anchor / same-file / no-double-report
- `find_broken_adr_refs` (6, tmp_path) — existing / forward-ref(`allow_forward`) / dead-ref / code-span / dedup

characterization test 라 fail-before 단계는 없음(동작 무변경) — 정직하게 명시. 단일 worktree, 비-load-bearing → overlap-preflight `[OK]`.

## 5. Eval 영향

All `·` — RAG 파이프라인 무관. docs governance 게이트의 테스트일 뿐. real-data 델타 없음.

## 6. 하위 호환

해당 없음 — 테스트 추가만. 프로덕션 코드/계약/CLI 변경 0.

## 7. 범위 외

- `_iter_heading_lines` 의 setext heading 미지원(ATX 전용, 코드 주석에 명시)은 의도된 설계라 테스트 대상에서 제외
- CLI `main()` / `_run()` 의 end-to-end exit-code 경로는 별도 (이 PR 은 파서 계약에 집중, One PR one concern)
- emoji heading slug (`hello-🚀-world`) 는 github-slugger 와의 정확한 일치가 불확실해 lock 하지 않음
