### PR TITLE
docs: add current policy note to ADR 0070

### DIFF
--- a/docs/adr/0070-content-grounded-gold-measurement-surface.md
+++ b/docs/adr/0070-content-grounded-gold-measurement-surface.md
@@ -7,6 +7,14 @@
 - Related: ADR 0001 (naive_baseline byte-identical), ADR 0005 (private/public eval 분리), ADR 0029 (case-proposer human-gate), ADR 0048 (realN metrics), ADR 0052 (n=221), ADR 0054 (conditional-on-answer scorer), ADR 0059 (failure-mode classifier), ADR 0068 (oracle 천장)
 - Issue: #1347
 
+> **Current-policy note (2026-06-03)**: this ADR remains an accepted historical
+> decision record for the additive content-grounded gold surface. Its legacy
+> `real-100` / 221-case motivating context and local-only `reports/real100_cg*`
+> measurements are not current claim-bearing private-eval evidence. New task,
+> PR, claim, and handoff evidence must use the `real100_v2` aggregate-only
+> surface in [Surface Map](../evaluation/surface-map.md), unless the maintainer
+> explicitly re-enables another private-eval surface.
+
 ## Context
 
 real-100 (ADR 0052, n=221) 헤드라인 정확도가 **0.085** (hashing) 에 고착. 5-lever null cascade audit (`docs/audits/construct-validity-gold-grounding-inspection.md`) 가 천장의 binding constraint 를 **파이프라인이 아니라 gold 의 construct-validity 결함**으로 확정했다:


### PR DESCRIPTION
## §1 Summary
- Adds a current-policy note to ADR 0070 without changing its accepted additive content-grounded gold decision.
- Clarifies that its legacy `real-100` / 221-case context and local-only `reports/real100_cg*` measurements are not current claim-bearing private-eval evidence.

## §2 Issue
Closes #2003

## §3 Changes
- Added a top-of-ADR note preserving ADR 0070 as a historical decision record.
- Pointed new task, PR, claim, and handoff evidence to the `real100_v2` aggregate-only surface unless another private-eval surface is explicitly re-enabled.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0070-content-grounded-gold-measurement-surface.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0070-content-grounded-gold-measurement-surface.md`
- `git diff --check`
- `make check-branch`
- pre-commit local Codex adversarial review: passed, 0 blocking findings

## §5 Eval impact
Docs-only ADR framing change. No retrieval, answer, eval runner, report aggregate, index, or private-data artifact changed. Private real-eval not run.

## §6 Overlap / worktree safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2003-adr0070-current-policy-note`.
- Same-file open PR query for `docs/adr/0070-content-grounded-gold-measurement-surface.md`: empty before PR creation.
- Candidate-file active branch-diff and dirty worktree scans were empty; known Codex/Claude dirty/open surfaces were avoided.

## §7 Notes
- Push hook emitted the standard load-bearing/test reminder for the ADR path; this change is documentation-only and does not change runtime behavior.
