### PR TITLE
docs: add current policy note to ADR 0077

### DIFF
--- a/docs/adr/0077-real-eval-difficulty-profile.md
+++ b/docs/adr/0077-real-eval-difficulty-profile.md
@@ -5,6 +5,14 @@
 - **Deciders**: hskim (solo author)
 - **Related**: ADR 0001, ADR 0005, ADR 0052, ADR 0069, ADR 0075, ADR 0076
 
+> **Current-policy note (2026-06-03)**: this ADR remains an accepted historical
+> decision record for the legacy difficulty-profile measurement surface. Its
+> `reports/real100/` and `data/index/real100` paths are not current
+> claim-bearing private-eval evidence. New task, PR, claim, and handoff evidence
+> must use the `real100_v2` aggregate-only surface in
+> [Surface Map](../evaluation/surface-map.md), unless the maintainer explicitly
+> re-enables another private-eval surface.
+
 ## Context
 
 The private real-eval baseline can show low Naive RAG scores without telling a
@@ -17,7 +25,7 @@ failure distribution, and multi-chunk failure analysis. They do not provide one
 aggregate profile that joins difficulty buckets with Naive RAG retrieval,
 citation, abstention, and failure outcomes.
 
-The required inputs live in local-only artifacts:
+For this historical surface, the required inputs lived in local-only artifacts:
 `reports/real100/eval_summary.json::case_results` and
 `data/index/real100/index.json::chunks`. These may contain private question
 text, evidence text, document identifiers, chunk identifiers, filenames, and
@@ -25,18 +33,20 @@ paths, so ADR 0005 allows only aggregate outputs to cross the commit boundary.
 
 ## Decision
 
-Add `scripts/render_difficulty_profile.py` as a read-only renderer that consumes
-the local private eval summary and matching index, computes difficulty features
-in memory, and emits:
+For the accepted historical surface, `scripts/render_difficulty_profile.py` was
+added as a read-only renderer that consumes the local private eval summary and
+matching index, computes difficulty features in memory, and emits legacy-path
+outputs:
 
 - `reports/real100/difficulty_profile.aggregate.json`
 - `reports/real100/difficulty_profile.md`
 
-The aggregate schema is `schema_version: 1` and contains only safe provenance,
-population counts, closed difficulty buckets, per-bucket metric means, failure
-category distributions, validity counters, and explicit conclusions. The
-renderer rejects non-Naive primary runs unless `--allow-non-naive` is passed, so
-claims about Naive RAG do not accidentally use an agentic run.
+The historical aggregate schema is `schema_version: 1` and contains only safe
+provenance, population counts, closed difficulty buckets, per-bucket metric
+means, failure category distributions, validity counters, and explicit
+conclusions. The renderer rejects non-Naive primary runs unless
+`--allow-non-naive` is passed, so claims about Naive RAG do not accidentally use
+an agentic run.
 
 Difficulty buckets include answerability, single-doc vs multi-doc gold
 evidence, single-chunk vs multi-chunk gold evidence, expected-terms count,


### PR DESCRIPTION
## §1 Summary
- Add a current-policy note to ADR 0077 so its legacy difficulty-profile `reports/real100/` surface is not used as current claim-bearing private-eval evidence.
- Mark the local-only `reports/real100` and `data/index/real100` inputs/outputs as historical while preserving the accepted ADR decision.

## §2 Issue
Closes #2013

## §3 Changes
- Updated `docs/adr/0077-real-eval-difficulty-profile.md` only.
- Clarified that current task, PR, claim, and handoff evidence must use the `real100_v2` aggregate-only surface unless another private-eval surface is explicitly re-enabled.
- Kept runtime/eval implementation references unchanged.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0077-real-eval-difficulty-profile.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0077-real-eval-difficulty-profile.md`
- `git diff --check`
- `make check-branch`
- pre-commit local Codex adversarial review: passed with 0 blocking and 0 informational findings

## §5 Eval impact
- Documentation-only ADR evidence-boundary clarification.
- No runtime, retrieval, verifier, answer, ingestion, index, renderer, or eval code changed.
- Private eval not run; current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2013-adr0077-current-policy-note`.
- Same-file open PR scan before editing: none for `docs/adr/0077-real-eval-difficulty-profile.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Load-bearing ADR push hook warned about no tests; this is documentation-only and changes no runtime behavior.
- pre-commit review passed the blocking gate; no review finding remained to address.
