### PR TITLE
docs: state real100_v2 boundary in RAG experiment stack

### DIFF
--- a/docs/evaluation/rag-performance-experiment-stack.md
+++ b/docs/evaluation/rag-performance-experiment-stack.md
@@ -6,6 +6,15 @@ not a performance claim. It contains no private raw questions, answers,
 evidence text, filenames, exact local paths, document identifiers, or chunk
 identifiers.
 
+## Current Evidence Boundary
+
+For new task, PR, claim, and handoff evidence, the current private-eval lane is
+`real100_v2` aggregate-only. Legacy `real100` / v1 / 221-case / `kordoc`
+evidence is archive-only unless the maintainer explicitly re-enables another
+private-eval surface. Any paired delta must use matching dataset, config, index,
+embedding/backend provenance, and command evidence; raw private artifacts remain
+local and ignored.
+
 ## TL;DR
 
 Do not start with GraphRAG, Agentic RAG, late chunking, or multi-vector search.


### PR DESCRIPTION
## §1 Summary
- Add a current evidence-boundary section to the RAG performance experiment stack.
- State that new private-eval planning claims use `real100_v2` aggregate-only evidence and that legacy `real100` / v1 / 221-case / `kordoc` evidence is archive-only unless re-enabled.

## §2 Issue
Closes #2019

## §3 Changes
- Updated `docs/evaluation/rag-performance-experiment-stack.md` only.
- No task ordering, runtime behavior, eval code, or report artifact changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/rag-performance-experiment-stack.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only planning boundary clarification.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2019-rag-stack-real100-v2-boundary`.
- Same-file open PR scan before editing: none for `docs/evaluation/rag-performance-experiment-stack.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime or eval behavior changed.
- No known overlap with active Codex/Claude worktree file sets.
