### PR TITLE
docs: narrow README private eval wording to real100_v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ python3 eval/run_eval.py --index_dir data/index --output_dir reports --config ev
 python3 scripts/check_latency_slo.py --config eval/config.yaml --summary reports/eval_summary.json
 ```
 
-상세 실행 (FastAPI 데모, PDF/HWP ingestion, visual parsing v2, 비공개 100-doc eval, harness): [`docs/operations/api-demo.md`](docs/operations/api-demo.md).
+상세 실행 (FastAPI 데모, PDF/HWP ingestion, visual parsing v2, `real100_v2` aggregate-only private eval, harness): [`docs/operations/api-demo.md`](docs/operations/api-demo.md).
 
 ---
 


### PR DESCRIPTION
## §1 Summary
- Replace README quickstart wording from “private 100-doc eval” to current `real100_v2` aggregate-only private eval wording.
- Keep the existing README evidence-boundary notes consistent with the quickstart pointer.

## §2 Issue
Closes #2021

## §3 Changes
- Updated `README.md` only.
- No command, runtime behavior, eval code, or artifact changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths README.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only wording change.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2021-readme-real100-v2-wording`.
- Same-file open PR scan before editing: none for `README.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime or eval behavior changed.
- No known overlap with active Codex/Claude worktree file sets.
