### PR TITLE
fix(routed-measurement): compute_spread 모델<2 시 saturation_cross_validated false-green 차단 (off-by-one)

### DIFF
--- a/scripts/run_routed_measurement.py
+++ b/scripts/run_routed_measurement.py
@@ -210,8 +210,21 @@ def compute_spread(rows: list[dict[str, Any]]) -> dict[str, Any]:
         for r in rows
         if r["routed"]["accuracy_mean"] is not None
     ]
-    if not routed_means:
-        return {"spread_pp": None, "verdict": "no_data"}
+    if len(routed_means) < 2:
+        # A top-vs-bottom spread / cross-validation needs >= 2 successful
+        # models. With one valid mean the spread is trivially 0.0, which must
+        # NOT be reported as cross-validated saturation (issue #2023): the
+        # missing model(s) failed to build/eval, so there is no cross-model
+        # evidence. Emit no_data — the same shape the all-failed case produces,
+        # which the downstream gate already treats as a hard "re-run".
+        return {
+            "spread_pp": None,
+            "verdict": "no_data",
+            "verdict_description": (
+                f"Insufficient routed means ({len(routed_means)}) — a top-vs-bottom "
+                "spread needs ≥2 successful models; re-run the measurement."
+            ),
+        }
     spread = (max(routed_means) - min(routed_means)) * 100.0
     if spread >= SPREAD_THRESHOLD_PP:
         verdict = "adr0019_reopen_trigger"

--- a/tests/test_run_routed_measurement.py
+++ b/tests/test_run_routed_measurement.py
@@ -1,0 +1,103 @@
+"""Regression test for ``scripts/run_routed_measurement.py::compute_spread`` (issue #2023).
+
+A spread / cross-validation verdict is only meaningful with >= 2 valid routed
+accuracy means. With fewer than two, the ADR 0032 top-vs-bottom spread is
+undefined and the runner must emit ``no_data`` (``spread_pp=None``) — NOT a
+false-green ``saturation_cross_validated`` synthesized from a single point
+(``spread = x - x = 0.0``).
+
+The regression is realistic: requesting two models where one fails to build
+(e.g. BGE-M3 OOM — a documented local blocker) leaves exactly one valid mean.
+The downstream gate ``check_embedding_routed_spread.py`` already treats a
+non-numeric ``spread_pp`` as a hard exit-2 "re-run" — so the producer emitting
+``no_data`` for the 1-model case is the consistent, correct behavior (the same
+shape the 0-model case has always produced). This locks both the buggy boundary
+(fail-before for the single-mean case) and the unchanged >=2-model verdicts.
+
+Import bootstrap: ``run_routed_measurement`` does ``from eval.bootstrap import
+bootstrap_ci``, so both the repo root (for the ``eval`` namespace package) and
+``scripts/`` (for the bare module name) go on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from run_routed_measurement import SPREAD_THRESHOLD_PP, compute_spread  # noqa: E402
+
+
+def _row(mean):
+    """Minimal row shape consumed by ``compute_spread`` (only ``routed.accuracy_mean``)."""
+    return {"routed": {"accuracy_mean": mean}}
+
+
+# ---------------------------------------------------------------------------
+# Insufficient data: 0 or 1 valid means => no_data (never a real verdict)
+# ---------------------------------------------------------------------------
+
+
+def test_zero_valid_means_is_no_data():
+    result = compute_spread([_row(None), _row(None)])
+    assert result["verdict"] == "no_data"
+    assert result["spread_pp"] is None
+
+
+def test_single_valid_mean_is_no_data_not_false_saturation():
+    # THE REGRESSION (fail-before / pass-after): exactly one valid mean — the
+    # other model's build/eval failed (accuracy_mean=None). A 0.0 spread from a
+    # single data point must NOT be reported as cross-validated saturation.
+    result = compute_spread([_row(0.73), _row(None)])
+    assert result["verdict"] != "saturation_cross_validated"
+    assert result["verdict"] == "no_data"
+    assert result["spread_pp"] is None
+
+
+def test_single_row_only_is_no_data():
+    result = compute_spread([_row(0.80)])
+    assert result["verdict"] == "no_data"
+    assert result["spread_pp"] is None
+
+
+def test_insufficient_yields_nonnumeric_spread_pp_for_consumer_gate():
+    # check_embedding_routed_spread.py treats a non-numeric spread_pp as a hard
+    # exit-2 "re-run the routed measurement". Lock that <2 means hits that path.
+    result = compute_spread([_row(0.73), _row(None)])
+    assert not isinstance(result["spread_pp"], (int, float))
+
+
+# ---------------------------------------------------------------------------
+# Sufficient data: >= 2 valid means => real verdict (behavior unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_two_equal_means_small_spread_is_saturation():
+    result = compute_spread([_row(0.70), _row(0.70)])
+    assert result["verdict"] == "saturation_cross_validated"
+    assert result["spread_pp"] == 0.0
+
+
+def test_two_means_just_below_threshold_is_saturation():
+    small = (SPREAD_THRESHOLD_PP - 1.0) / 100.0
+    result = compute_spread([_row(0.70), _row(0.70 + small)])
+    assert result["verdict"] == "saturation_cross_validated"
+    assert result["spread_pp"] < SPREAD_THRESHOLD_PP
+
+
+def test_two_means_large_spread_is_reopen_trigger():
+    big = (SPREAD_THRESHOLD_PP + 2.0) / 100.0
+    result = compute_spread([_row(0.60), _row(0.60 + big)])
+    assert result["verdict"] == "adr0019_reopen_trigger"
+    assert result["spread_pp"] >= SPREAD_THRESHOLD_PP
+
+
+def test_extra_none_rows_do_not_lower_the_count_below_two():
+    # Two valid means plus a failed (None) model still has >=2 valid points,
+    # so the real verdict stands — None rows are filtered, not counted.
+    result = compute_spread([_row(0.70), _row(0.71), _row(None)])
+    assert result["verdict"] == "saturation_cross_validated"
+    assert isinstance(result["spread_pp"], (int, float))


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/run_routed_measurement.py::compute_spread` (ADR 0032 routed-subset spread 측정) 가 유효 routed `accuracy_mean` 이 **1개뿐일 때** `spread = (x − x)·100 = 0.0 < 3pp` → `verdict = "saturation_cross_validated"` 를 silently 반환하는 off-by-one 을 고친다. `if not routed_means:` 가드가 **0개**만 `no_data` 로 잡고 **1개**는 통과시켰다 — spread/cross-validation 은 ≥2 데이터 포인트가 필요하다. 결과적으로 모델 1개만 실행됐는데도 `reports/embedding_routed.json` + stdout 에 "MiniLM default lock empirically justified; saturation cross-validated" 가 cross-model 근거 0 인 채로 기록됐다.

Closes #2023

## 2. 영향 파일

- `scripts/run_routed_measurement.py` — `compute_spread` boundary `not routed_means` → `len(routed_means) < 2` + `verdict_description` 보강. **load-bearing 아님** (LOAD_BEARING_PATHS 중 scripts/ 는 build_index.py 뿐)
- `tests/test_run_routed_measurement.py` (신규, 8 cases) — 회귀 테스트

## 3. 리스크

- 가장 가능성 높은 깨짐: ≥2 모델 정상 경로의 verdict 가 바뀌는 것 → 회귀 테스트로 배제 (small spread→`saturation_cross_validated`, large→`adr0019_reopen_trigger`, 2 valid + 1 None→여전히 saturation 모두 lock).
- 소비처 `check_embedding_routed_spread.py` 는 **무변경**. 이미 비-numeric `spread_pp`(=None) 를 exit 2("re-run")로 처리 — 0-model `no_data` 가 늘 내던 shape 와 동일하므로 1-model 도 같은 올바른 경로를 탄다. 소비처 깨짐 없음(해당 스크립트 전용 테스트는 부재, grep 확인).
- 스키마 무변경: `no_data` + `spread_pp=None` 형태는 기존 0-model 산출과 동일.

## 4. 테스트

`tests/test_run_routed_measurement.py` 신규 8 cases. **TDD fail-before/pass-after**: 픽스 전 1-model 케이스 3개 RED(`saturation_cross_validated`/`spread_pp=0.0`) → 픽스 후 8 GREEN.
- insufficient(0·1 model): `no_data` + `spread_pp=None` + 소비처 게이트 계약(비-numeric)
- sufficient(≥2 model): small→saturation / 임계값 직하→saturation / large→reopen_trigger / 2-valid+1-None→saturation (None row 는 필터, 카운트 제외)

`python3 -m pytest tests/test_run_routed_measurement.py -q` → 8 passed. overlap-preflight: Blockers/Warnings None.

## 5. Eval 영향

RAG 파이프라인·검색·답변 경로 **무변경**. 이 변경은 on-demand 측정 러너(`run_routed_measurement.py`, PR CI 미실행)의 **verdict 결정 boundary 버그 수정**으로, 잘못된 "saturation" 결론(false-green)을 차단해 게이트를 **더 정확하게** 만든다. `embedding_routed.json` 스키마 무변경. load-bearing/RAG 경로 미변경이라 real-data 델타 N/A. README metric sync 무관.

## 6. 하위 호환

영향 없음. `compute_spread` 반환 dict 의 키 집합 무변경(`spread_pp`/`verdict` 항상 존재, `verdict_description` 은 기존에도 verdict 분기에서 제공). 0-model 경로는 동작 동일, 1-model 만 false-green→no_data 로 교정. ADR 0003 답변 계약 무관, CLI flag 무변경.

## 7. 범위 외

- 같은 파일의 사전 존재 lint(`datetime.utcnow()` deprecation L322, `bootstrap_ci`/`eval.bootstrap` Pyright 경고) — 무관하므로 미수정(one concern).
- 빌드 실패를 row 단위로 surface 하는 더 큰 리팩터(현재는 None mean 으로만 표현) — 별도 issue 후보.
