### PR TITLE
docs: clarify run manifest is provenance not private eval result

### DIFF
--- a/docs/evaluation/offline-online-run-manifest.md
+++ b/docs/evaluation/offline-online-run-manifest.md
@@ -111,4 +111,7 @@ Top-level fields:
 
 This manifest is provenance evidence only. It supports later v0-c report review,
 but it is not a private real-eval result, benchmark lift, regression fix, or RFP
-quality claim.
+quality claim. New private-eval task, PR, claim, and handoff evidence must use
+`real100_v2` aggregate-only results with matching provenance; legacy `real100` /
+v1 / 221-case / `kordoc` evidence remains archive-only unless the maintainer
+explicitly re-enables another private-eval surface.


### PR DESCRIPTION
## §1 Summary
- Clarify that offline/online run manifests are provenance evidence only, not private eval result or performance claim surfaces.
- Point private-eval claims back to `real100_v2` aggregate-only results with matching provenance.

## §2 Issue
Closes #2027

## §3 Changes
- Updated `docs/evaluation/offline-online-run-manifest.md` only.
- No manifest generator, eval runner, config, or metric behavior changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/offline-online-run-manifest.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only claim-boundary clarification.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2027-run-manifest-private-boundary`.
- Same-file open PR scan before editing: none for `docs/evaluation/offline-online-run-manifest.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime or eval behavior changed.
- No known overlap with active Codex/Claude worktree file sets.
