### PR TITLE
docs: clarify failure-mode case study evidence boundary

### DIFF
--- a/docs/case-studies/failure-modes.md
+++ b/docs/case-studies/failure-modes.md
@@ -11,6 +11,11 @@
 
 아래 5개 모드는 정본 taxonomy 의 C1–C6 에 대응한다 (A=C2, B=C1/C2, C=C6, D=C4, E=C5).
 
+## Evidence boundary
+
+- 이 문서는 failure-mode 설명용 case study 이며, archive-only v1 `real100` taxonomy 를 current private-eval 성능 주장으로 승격하지 않는다.
+- Reviewer takeaway 의 정량 수치는 현재 README/eval artifact 로 추적되는 지표 포인터다. 새로운 private-eval claim 은 `real100_v2` aggregate-only 근거를 명시해야 한다.
+
 ---
 
 ## A. Comparison query starvation (비교 질의 한쪽 문서 기아)


### PR DESCRIPTION
## §1 Summary
- Add an evidence-boundary note to the failure-mode case-study page.
- Clarify that archive-only v1 `real100` taxonomy references do not become current private-eval performance claims.
- Require `real100_v2` aggregate-only evidence for new private-eval claims.

## §2 Issue
Closes #2033

## §3 Changes
- Updated `docs/case-studies/failure-modes.md` only.
- Kept the case-study taxonomy and reviewer takeaways unchanged.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/case-studies/failure-modes.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only claim-boundary clarification.
- No README metrics, reports, eval config, scorer, or runtime code changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2033-failure-mode-evidence-boundary`.
- Same-file open PR scan before editing: none for `docs/case-studies/failure-modes.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
