### PR TITLE
docs: clarify ADR 0075 real100_v2 evidence boundary

### DIFF
--- a/docs/adr/0075-normalized-failure-taxonomy.md
+++ b/docs/adr/0075-normalized-failure-taxonomy.md
@@ -54,6 +54,12 @@ signal stable while decomposing the old residual bucket.
   answer, ingestion, API, and preset defaults are not part of this decision.
 - Private raw content remains local-only. Committed reports contain aggregate
   counts and closed buckets only.
+- Current private-eval evidence for new tasks, PRs, claims, and agent handoffs
+  must use the `real100_v2` aggregate-only surface. The v1 taxonomy/baseline
+  context above, plus legacy real100/v1/221/kordoc aggregate wording, is
+  archive-only unless the maintainer explicitly re-enables a named private-eval
+  surface through a later ADR and Surface Map update that list allowed paths,
+  commands, and the aggregate-only boundary.
 
 ## Verification
 


### PR DESCRIPTION
## §1 Summary
- Clarify ADR 0075's private baseline taxonomy evidence boundary.
- State that current private-eval evidence for new tasks/PRs/claims/handoffs must use `real100_v2` aggregate-only output.
- Keep legacy real100/v1/221/kordoc taxonomy/baseline context archive-only unless re-enabled by maintainer through later ADR + Surface Map update.

## §2 Issue
Closes #2035

## §3 Changes
- Updated `docs/adr/0075-normalized-failure-taxonomy.md` only.
- Preserved the accepted normalized failure taxonomy and interface names.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0075-normalized-failure-taxonomy.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0075-normalized-failure-taxonomy.md`
- `git diff --check`
- `make check-branch`
- pre-commit Codex adversarial review: final pass 0 blocking / 0 informational findings

## §5 Eval impact
- Documentation-only claim-boundary clarification.
- No failure classifier code, eval runner, dataset, report artifact, or aggregate output changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2035-adr0075-real100v2-boundary`.
- Same-file open PR scan before editing: none for `docs/adr/0075-normalized-failure-taxonomy.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only ADR wording change; no runtime behavior changed.
- Push hook emitted the generic load-bearing docs/test reminder; this PR changes no behavior-code and adds no runtime test.
- No known overlap with active Codex/Claude worktree file sets.
