### PR TITLE
docs: clarify ADR 0079 real100_v2 gate boundary

### DIFF
--- a/docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md
+++ b/docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md
@@ -23,8 +23,9 @@ discipline.
 ## Decision
 
 Codex will act as a conservative agent gate for the offline/online RFP evaluation
-loop, using private real-eval as the required claim-bearing surface and adopting
-metric suites by versioned evidence rather than by a single headline score.
+loop, using the current `real100_v2` aggregate-only private real-eval lane as the
+required claim-bearing surface and adopting metric suites by versioned evidence
+rather than by a single headline score.
 
 Specifics:
 
@@ -36,7 +37,11 @@ Specifics:
   precision, claim-citation alignment, comparison coverage, abstention
   calibration, numeric/date/condition accuracy, and human/judge agreement.
 - A single headline score is a triage aid, not a merge/block contract.
-- Claim-bearing metric adoption requires private real-eval aggregate evidence.
+- Claim-bearing metric adoption requires current `real100_v2` aggregate evidence.
+  Legacy real100/v1/221/kordoc evidence remains archive-only unless the
+  maintainer explicitly re-enables a named private-eval surface through later ADR
+  + Surface Map updates that list allowed paths, commands, and aggregate-only
+  boundary.
 - Ambiguous cases default to draft, no performance claim, follow-up issue, or
   fail-closed handling.
 - Existing `human-gated-*` CLI names remain as compatibility names, but their
@@ -48,8 +53,8 @@ Specifics:
   private eval, or cleanup decision.
 - Agent decisions become auditable because the acceptance criteria live in a
   committed policy document.
-- Private real-eval becomes mandatory for performance evidence, increasing run
-  cost and provenance requirements.
+- The current `real100_v2` aggregate-only private-eval surface becomes mandatory
+  for performance evidence, increasing run cost and provenance requirements.
 - Online private-data egress is permitted by policy, so every online run must
   record provider/model/payload provenance and keep raw private outputs out of
   committed artifacts.
@@ -73,3 +78,5 @@ Specifics:
 <!-- verifies-key: docs/evaluation/agent-gated-rfp-eval-loop.md:Metric Suite -->
 <!-- verifies-key: docs/evaluation/agent-gated-rfp-eval-loop.md:Agent Gate -->
 <!-- verifies-key: docs/evaluation/surface-map.md:Environment Axis -->
+<!-- verifies-key: docs/evaluation/surface-map.md:Private Real-Eval -->
+<!-- verifies-key: docs/evaluation/surface-map.md:Critical Warnings -->


### PR DESCRIPTION
## §1 Summary
- Clarify ADR 0079's agent-gated eval claim surface as current `real100_v2` aggregate-only private-eval evidence.
- Keep legacy real100/v1/221/kordoc evidence archive-only unless re-enabled by maintainer through later ADR + Surface Map updates.
- Add Surface Map verification markers for the private real-eval and critical warning sections.

## §2 Issue
Closes #2037

## §3 Changes
- Updated `docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md` only.
- Preserved the accepted offline/online conservative agent-gate policy.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md`
- `python3 scripts/check_doc_links.py --check-all`
- `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md`
- `git diff --check`
- `make check-branch`
- pre-commit Codex adversarial review: final pass 0 blocking / 0 informational findings

## §5 Eval impact
- Documentation-only claim-boundary clarification.
- No eval runner, config, dataset, report artifact, aggregate output, or runtime code changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2037-adr0079-real100v2-gate`.
- Same-file open PR scan before editing: none for `docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only ADR wording change; no runtime behavior changed.
- Push hook emitted the generic load-bearing docs/test reminder; this PR changes no behavior-code and adds no runtime test.
- No known overlap with active Codex/Claude worktree file sets.
