### PR TITLE
docs: align private eval report template with real100_v2

### DIFF
--- a/docs/evaluation/private_real_eval_baseline_report.template.md
+++ b/docs/evaluation/private_real_eval_baseline_report.template.md
@@ -6,9 +6,10 @@ This template is for redacted aggregate reporting only. Do not include raw priva
 
 - Run ID: `TBD`
 - System: Naive Dense RAG
-- Data boundary: private local data, aggregate-only report
-- Runner: `python3 -m eval.naive_rag.private_real_eval`
-- Status: not executed until local validation passes
+- Data boundary: private local `real100_v2` data, aggregate-only report under `reports/real100_v2/`
+- Runner: `python3 scripts/run_private_real_eval.py --config <ignored-local-real100_v2-config>`
+- Required guards: `make real-eval-v2-check`, `make real-eval-v2-inventory`, `make real-eval-v2-guard`
+- Status: not executed until current `real100_v2` local validation passes
 
 ## Dataset Summary
 
@@ -62,7 +63,8 @@ Ready for improvement experiments only if all are true:
 
 ## Known Limitations
 
-- Private aggregate only; raw cases and traces remain local.
+- Private `real100_v2` aggregate only; raw cases and traces remain local.
 - Answer metrics are deterministic contract checks, not an LLM judge.
 - Latency is runner wall-clock unless a narrower local profiler is added.
 - No retrieval, reranking, prompt, chunking, verifier, or self-correction improvement is included.
+- Legacy real100/v1/221/kordoc outputs are archive-only and must not be used as new report evidence.


### PR DESCRIPTION
## §1 Summary
- Align the private real-eval baseline report template with the current `real100_v2` aggregate-only workflow.
- Replace the legacy direct module runner reference with the current guarded runner shape and `real-eval-v2-*` guard commands.
- Mark legacy real100/v1/221/kordoc outputs archive-only for new report evidence.

## §2 Issue
Closes #2041

## §3 Changes
- Updated `docs/evaluation/private_real_eval_baseline_report.template.md` only.
- No private eval execution, report regeneration, or code changes.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_baseline_report.template.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only template alignment.
- No eval runner, config, dataset, report artifact, aggregate output, or runtime code changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2041-private-eval-template-real100v2`.
- Same-file open PR scan before editing: none for `docs/evaluation/private_real_eval_baseline_report.template.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only template change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
