### PR TITLE
docs: bind question schema to real100_v2 surface

### DIFF
--- a/docs/evaluation/private_real_eval_question_schema.md
+++ b/docs/evaluation/private_real_eval_question_schema.md
@@ -1,8 +1,10 @@
 # Private Real-Eval Question Schema
 
-Private questions live in ignored local JSONL, normally
-`data/private/questions.jsonl`. The readiness validator reports counts only and
-does not print question text. Examples below are fake placeholders.
+Private questions live in ignored local JSONL under the current private-eval
+surface, normally `data/private/real100_v2/questions.jsonl`. The readiness
+validator reports counts only and does not print question text. Examples below
+are fake placeholders. Legacy real100/v1/221/kordoc question paths are
+archive-only for new tasks, PRs, claims, and handoffs.
 
 ## Required Fields
 


### PR DESCRIPTION
## §1 Summary
- Bind the private real-eval question schema doc to the current `real100_v2` local data surface.
- Keep schema fields unchanged while marking legacy real100/v1/221/kordoc question paths archive-only for new evidence.

## §2 Issue
Closes #2045

## §3 Changes
- Updated `docs/evaluation/private_real_eval_question_schema.md` only.
- No validator, config, report, private-data, or runtime changes.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/private_real_eval_question_schema.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only path/boundary clarification.
- No eval runner, config, dataset, report artifact, aggregate output, or runtime code changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2045-question-schema-real100v2`.
- Same-file open PR scan before editing: none for `docs/evaluation/private_real_eval_question_schema.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only schema wording change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
