### PR TITLE
docs: clarify reviewer real100_v2 evidence standard

### DIFF
--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -21,7 +21,9 @@ Reviewer는 PR 설명을 근거(evidence)로 취급하지 않는다. 승인 가�
 하나로 뒷받침되어야 한다.
 
 근거가 없으면 claim은 없는 것으로 처리한다. green CI, synthetic-only success,
-깔끔한 agent 요약은 private real-eval 또는 architecture safety 증거가 아니다.
+깔끔한 agent 요약은 현재 `real100_v2` aggregate-only private-eval 또는 architecture
+safety 증거가 아니다. Legacy real100/v1/221/kordoc aggregate wording은 새 reviewer
+근거로 쓰지 않는다.
 
 ## Fast Triage Surface
 


### PR DESCRIPTION
## §1 Summary
- Clarify the reviewer evidence standard so generic private real-eval is not ambiguous.
- Name current `real100_v2` aggregate-only private eval evidence and reject legacy real100/v1/221/kordoc wording as new reviewer evidence.

## §2 Issue
Closes #2047

## §3 Changes
- Updated `docs/reviews/README.md` only.
- No reviewer tooling, eval artifacts, or runtime changes.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/reviews/README.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only evidence-standard clarification.
- No eval runner, config, dataset, report artifact, aggregate output, or runtime code changed.
- No private eval run and no performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2047-reviewer-real100v2-evidence`.
- Same-file open PR scan before editing: none for `docs/reviews/README.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only review wording change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
