### PR TITLE
docs: clarify benchmark example real100_v2 boundary

### DIFF
--- a/docs/plans/EXAMPLE-benchmark-hardening.md
+++ b/docs/plans/EXAMPLE-benchmark-hardening.md
@@ -6,7 +6,7 @@
 - Related issue / PR: example only
 - Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
-- Last updated: 2026-05-25
+- Last updated: 2026-06-03
 
 ## Problem Statement
 
@@ -21,7 +21,7 @@ Synthetic benchmark assets live under `data/eval/benchmark/` and
 must be built only from frozen corpus chunks and must not read questions, gold
 evidence, expected answers, or expected terms. The claim boundary is documented,
 but future agents can still weaken it by adding convenience code or docs that
-blur smoke, synthetic benchmark, and private real-eval.
+blur smoke, synthetic benchmark, and current `real100_v2` aggregate-only private eval.
 
 ## Desired Behavior
 
@@ -37,7 +37,7 @@ should make contamination and over-claiming harder to miss.
 - Eval/privacy constraints: ADR 0005 privacy and public/private split remain unchanged.
 - Tooling/CI constraints: generated run artifacts remain local unless explicitly allowed.
 - Non-goals: do not improve retrieval, reranking, answer generation, verifier behavior,
-  private real-eval scoring, or product-quality claims.
+  current `real100_v2` private eval scoring, or product-quality claims.
 
 ## Architecture Impact
 
@@ -61,7 +61,7 @@ should make contamination and over-claiming harder to miss.
 - Surface: public synthetic benchmark.
 - Data boundary: public synthetic corpus; generated run artifacts remain local.
 - Allowed claim: benchmark hardening improved contamination resistance.
-- Disallowed claim: RAG model quality improved on real RFPs.
+- Disallowed claim: RAG model quality improved on real RFPs or current `real100_v2` private-eval.
 - Baseline or control affected: no; `naive_baseline` remains the control.
 - Benchmark/eval auditor required: yes.
 
@@ -69,7 +69,7 @@ should make contamination and over-claiming harder to miss.
 
 1. Inspect benchmark index builder inputs and confirm it does not parse questions/gold.
 2. Add regression coverage if the invariant is not already tested.
-3. Tighten docs so synthetic result wording cannot be read as private real-eval evidence.
+3. Tighten docs so synthetic result wording cannot be read as current `real100_v2` private-eval evidence.
 4. Run validation and focused tests.
 
 ## Acceptance Criteria
@@ -98,7 +98,7 @@ Expected evidence:
 
 - validation report path and summary counts.
 - focused pytest result.
-- no real-world performance claim in changed docs.
+- no real-world or current `real100_v2` private-eval performance claim in changed docs.
 
 ## Rollback Strategy
 
@@ -134,7 +134,7 @@ questions, expected answers, expected terms, or gold evidence during index build
 - Task: T-EXAMPLE-001
 - Current status: proposed example plan
 - Files touched: N/A
-- Decisions made: Treat this as benchmark validity hardening, not model improvement.
+- Decisions made: Treat this as benchmark validity hardening, not model improvement or current `real100_v2` private-eval evidence.
 - Commands run: None; example only.
 - Results: N/A
 - Next safe command: python3 eval/naive_rag/validate_benchmark_dataset.py --help


### PR DESCRIPTION
## §1 Summary
- Clarify the benchmark hardening example so synthetic benchmark evidence cannot be mistaken for current `real100_v2` aggregate-only private-eval evidence.
- Keep the example scope docs-only and preserve the existing benchmark validation intent.

## §2 Issue
Closes #2051

## §3 Changes
- Updated `docs/plans/EXAMPLE-benchmark-hardening.md` only.
- No benchmark runner, config, data, report artifact, or private-eval path changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/EXAMPLE-benchmark-hardening.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only example wording clarification.
- No public synthetic benchmark run, private eval run, metric update, or performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2051-benchmark-example-real100v2`.
- Same-file open PR scan before editing: none for `docs/plans/EXAMPLE-benchmark-hardening.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only example-plan wording change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
