### PR TITLE
docs: clarify T-2026-0046 real100_v2 boundary

### DIFF
--- a/docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+++ b/docs/plans/T-2026-0046-rag-experiment-task-expansion.md
@@ -6,7 +6,7 @@
 - Related issue / PR: [#1627](https://github.com/hskim-solv/BidMate-DocAgent/issues/1627) / PR TBD
 - Related ADR: N/A - no runtime or eval contract change
 - Created: 2026-05-28
-- Last updated: 2026-05-28
+- Last updated: 2026-06-03
 
 ## Problem Statement
 
@@ -47,8 +47,8 @@ The queue should guide performance work through measured rounds:
   runtime, or index behavior changes.
 - Compatibility constraints: preserve existing task IDs and existing experiment
   scopes.
-- Eval/privacy constraints: no private real-eval run; no raw private content,
-  filenames, local paths, `doc_id`, or `chunk_id`.
+- Eval/privacy constraints: no current `real100_v2` private-eval run; no raw
+  private content, filenames, local paths, `doc_id`, or `chunk_id`.
 - Tooling/CI constraints: doc-link check, whitespace check, and branch/issue
   check only.
 - Non-goals: do not create implementation issues for every future task now.
@@ -119,8 +119,8 @@ Expected evidence:
 - Generated or updated artifact: docs and queue entries only.
 - Reviewer checklist or manual inspection: task ordering, replanning gates,
   private boundary, and no-claim wording.
-- Explicitly not validated, with reason: no private real-eval because this PR
-  only creates task structure.
+- Explicitly not validated, with reason: no current `real100_v2` private eval
+  because this PR only creates task structure.
 
 ## Rollback Strategy
 
@@ -147,8 +147,8 @@ reports, private local runs, or prior plan docs.
 
 - `tasks/queue.md` ready/backlog/blocked statuses.
 - `docs/evaluation/rag-performance-experiment-stack.md` cadence and gates.
-- Future aggregate-only synthesis reports from `T-2026-0049`,
-  `T-2026-0053`, and `T-2026-0055`.
+- Future current `real100_v2` aggregate-only synthesis reports from
+  `T-2026-0049`, `T-2026-0053`, and `T-2026-0055`.
 
 ## Reviewer Notes
 


### PR DESCRIPTION
## §1 Summary
- Clarify T-2026-0046's task-expansion wording with the current `real100_v2` aggregate-only synthesis boundary.
- Preserve the task-structure plan and avoid changing queue priorities or eval/runtime behavior.

## §2 Issue
Closes #2061

## §3 Changes
- Updated `docs/plans/T-2026-0046-rag-experiment-task-expansion.md` only.
- No queue entries, scripts, eval runner, config, data, report artifact, or private-eval path changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0046-rag-experiment-task-expansion.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan wording clarification.
- No private eval run, task creation, queue reprioritization, metric update, or performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2061-t2026-0046-real100v2`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0046-rag-experiment-task-expansion.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only plan wording change; no runtime or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
