### PR TITLE
docs: clarify T-2026-0021 real100_v2 no-claim boundary

### DIFF
--- a/docs/plans/T-2026-0021-pr-corpus-workset-planning.md
+++ b/docs/plans/T-2026-0021-pr-corpus-workset-planning.md
@@ -42,7 +42,8 @@ never reaches merge even when the agent has armed ready shipping.
 ## Non-Goals
 
 - Do not push, create/merge/close PRs, close issues, delete branches, force-push,
-  run private real-eval, or approve benchmark/performance claims.
+  run current `real100_v2` private eval, or approve benchmark/performance
+  claims.
 - Do not change retrieval, ingestion, eval scoring, answer contracts, or runtime
   behavior.
 - Do not expose private raw values or PR body/title text as required evidence.
@@ -112,4 +113,5 @@ artifacts are gitignored and do not need rollback.
 - Confirm `continue-loop` does not perform remote mutation.
 - Confirm batch/workset lanes preserve serial dependencies and gate-sensitive
   surfaces.
-- Confirm no benchmark, product quality, or private real-eval claim is implied.
+- Confirm no benchmark, product quality, or current `real100_v2` private-eval
+  claim is implied.


### PR DESCRIPTION
## §1 Summary
- Clarify T-2026-0021's PR-corpus workset planning no-claim wording with the current `real100_v2` private-eval boundary.
- Preserve the completed planning surface and avoid changing agent-loop behavior or shipping gates.

## §2 Issue
Closes #2063

## §3 Changes
- Updated `docs/plans/T-2026-0021-pr-corpus-workset-planning.md` only.
- No scripts, tests, queue entries, eval runner, config, data, report artifact, or private-eval path changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0021-pr-corpus-workset-planning.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan wording clarification.
- No private eval run, agent-loop test run, metric update, or benchmark/performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2063-t2026-0021-real100v2`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0021-pr-corpus-workset-planning.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only plan wording change; no runtime, shipping, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
