### PR TITLE
docs: clarify benchmark contamination real100_v2 boundary

### DIFF
--- a/docs/plans/T-2026-0001-benchmark-contamination-guard.md
+++ b/docs/plans/T-2026-0001-benchmark-contamination-guard.md
@@ -6,7 +6,7 @@
 - Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / [#1481](https://github.com/hskim-solv/BidMate-DocAgent/pull/1481)
 - Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
-- Last updated: 2026-05-25
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -24,7 +24,8 @@ that `index_build.input_path` equals `corpus_path`, the command builds from
 ## Constraints
 
 - Do not change benchmark scoring semantics.
-- Do not change retrieval, verifier, answer, or private real-eval behavior.
+- Do not change retrieval, verifier, answer, or current `real100_v2`
+  private-eval behavior.
 - Keep the surface classified as public synthetic benchmark only.
 
 ## Architecture Impact


### PR DESCRIPTION
## §1 Summary
- Clarify T-2026-0001 Benchmark Contamination Guard so public synthetic benchmark-only constraints explicitly exclude current `real100_v2` private-eval behavior changes.
- Preserve the completed contamination guard plan and avoid changing benchmark/eval code.

## §2 Issue
Closes #2069

## §3 Changes
- Updated `docs/plans/T-2026-0001-benchmark-contamination-guard.md` only.
- No benchmark code, tests, queue entries, eval runner, config, data, report artifact, or private-eval path changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0001-benchmark-contamination-guard.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan wording clarification.
- No public benchmark validator run, private eval run, metric update, or performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2069-benchmark-contamination-real100v2`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0001-benchmark-contamination-guard.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only plan wording change; no runtime, benchmark, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
