### PR TITLE
docs: clarify eval artifact guard real100_v2 boundary

### DIFF
--- a/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+++ b/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
@@ -6,14 +6,14 @@
 - Related issue / PR: [#1487](https://github.com/hskim-solv/BidMate-DocAgent/issues/1487) / PR TBD
 - Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
-- Last updated: 2026-05-25
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
 Multiple files named `eval_summary.json` exist across public fixture smoke,
-public synthetic benchmark, private real-eval, and harness runs. The default
-delta comparator did not identify the surface being compared, so incompatible
-artifact comparisons could look legitimate.
+public synthetic benchmark, current `real100_v2` private eval, and harness
+runs. The default delta comparator did not identify the surface being compared,
+so incompatible artifact comparisons could look legitimate.
 
 ## Desired Behavior
 
@@ -28,7 +28,8 @@ are warned by default and can fail closed with opt-in CLI flags.
 ## Constraints
 
 - Do not change metric calculation or regression thresholds.
-- Do not require private raw data or make private real-eval a CI dependency.
+- Do not require private raw data or make current `real100_v2` private eval a
+  CI dependency.
 - Keep existing PR fixture smoke workflow backward compatible.
 
 ## Architecture Impact
@@ -50,8 +51,9 @@ git diff --check
 
 ## Reviewer Notes
 
-Attack claim boundary wording first: smoke, synthetic benchmark, private
-real-eval, and harness summaries must not be silently treated as interchangeable.
+Attack claim boundary wording first: smoke, synthetic benchmark, current
+`real100_v2` private eval, and harness summaries must not be silently treated
+as interchangeable.
 
 ## Session Handoff
 


### PR DESCRIPTION
## §1 Summary
- Clarify T-2026-0002 Eval Artifact Surface Guard so surface labels name the current `real100_v2` private-eval boundary explicitly.
- Preserve the completed comparator-governance plan and avoid changing comparator/eval code.

## §2 Issue
Closes #2071

## §3 Changes
- Updated `docs/plans/T-2026-0002-eval-artifact-surface-guard.md` only.
- No comparator code, tests, queue entries, eval runner, config, data, report artifact, or private-eval path changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0002-eval-artifact-surface-guard.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan wording clarification.
- No comparator test run, private eval run, metric update, or performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2071-eval-artifact-real100v2`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0002-eval-artifact-surface-guard.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only plan wording change; no runtime, comparator, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
