### PR TITLE
docs: mark agent loop continuation plan complete

### DIFF
--- a/docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+++ b/docs/plans/T-2026-0019-agent-loop-continuation-repair.md
@@ -1,9 +1,10 @@
 # Plan: T-2026-0019 Agent loop continuation repair
 
-- Status: review
+- Status: done
 - Owner role: Maintainer -> CI Reviewer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0019`
-- Issue: #1549
+- Issue / PR: #1549 / #1550; refresh issue #2081
+- Last updated: 2026-06-04
 
 ## Problem
 
@@ -30,7 +31,7 @@ dashboard should render the same status for human review.
 ## Non-Goals
 
 - Do not execute push, PR creation, merge, branch deletion, force-push, or
-  private real-eval from `loop-state`.
+  current `real100_v2` private eval from `loop-state`.
 - Do not remove `make ship-arm` single-shot behavior.
 - Do not hide task/plan linkage gaps.
 


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0019 agent-loop continuation repair plan as `done` after merged PR #1550.
- Clarify that `loop-state` must not execute current `real100_v2` private eval as part of continuation recovery.

## §2 Issue
Closes #2081

## §3 Changes
- Updated `docs/plans/T-2026-0019-agent-loop-continuation-repair.md` only.
- No agent-loop code, tests, operations docs, queue entries, private artifacts, or shipping behavior changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0019-agent-loop-continuation-repair.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan wording/status refresh.
- No agent-loop test run, private eval run, metric update, or performance claim.
- Current claim-bearing private eval surface remains `real100_v2` aggregate-only.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2081-agent-loop-continuation-plan`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0019-agent-loop-continuation-repair.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime, loop-state, shipping, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
