### PR TITLE
docs: mark human review surface plan complete

### DIFF
--- a/docs/plans/T-2026-0006-human-review-surface.md
+++ b/docs/plans/T-2026-0006-human-review-surface.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0006 Human Review Surface
 
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0006`
-- Related issue / PR: [#1506](https://github.com/hskim-solv/BidMate-DocAgent/issues/1506) / PR TBD
+- Related issue / PR: [#1506](https://github.com/hskim-solv/BidMate-DocAgent/issues/1506) / [#1509](https://github.com/hskim-solv/BidMate-DocAgent/pull/1509); refresh issue #2089
 - Related ADR: N/A - no decision-level change
 - Created: 2026-05-26
-- Last updated: 2026-05-26
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -96,9 +96,9 @@ over-claim.
 
 - Role: Implementer
 - Branch / worktree: chore/issue-1506-human-review-surface / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
-- Issue / PR: #1506 / PR TBD
+- Issue / PR: #1506 / PR #1509
 - Task: T-2026-0006
-- Current status: implementation complete, validation passing.
+- Current status: merged in PR #1509.
 - Files touched: scripts/ai_next_actions.py, tests/test_ai_next_actions.py, docs/operations/ai-codex-workflow.md, docs/reviews/README.md, tasks/queue.md, docs/plans/T-2026-0006-human-review-surface.md
 - Decisions made: local self-contained HTML, no JS/dependencies, non-evidence status board.
 - Commands run: python3 -m py_compile scripts/ai_next_actions.py; python3 -m pytest -q tests/test_ai_next_actions.py; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0006 human review surface plan as `done` after merged PR #1509.
- Link the original implementation PR without changing planner/review behavior.

## §2 Issue
Closes #2089

## §3 Changes
- Updated `docs/plans/T-2026-0006-human-review-surface.md` only.
- No planner code, tests, docs, queue entries, generated reports, or runtime behavior changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0006-human-review-surface.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2089-human-review-surface-plan`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0006-human-review-surface.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime, planner, review-surface, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
