### PR TITLE
docs: mark ADR decision map plan complete

### DIFF
--- a/docs/plans/T-2026-0009-adr-decision-map.md
+++ b/docs/plans/T-2026-0009-adr-decision-map.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0009 ADR Decision Map
 
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0009`
-- Related issue / PR: [#1516](https://github.com/hskim-solv/BidMate-DocAgent/issues/1516) / PR TBD
+- Related issue / PR: [#1516](https://github.com/hskim-solv/BidMate-DocAgent/issues/1516) / [#1517](https://github.com/hskim-solv/BidMate-DocAgent/pull/1517); refresh issue #2091
 - Related ADR: N/A - no decision-level change
 - Created: 2026-05-26
-- Last updated: 2026-05-26
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -97,9 +97,9 @@ format and escaping of title/status text.
 
 - Role: Implementer
 - Branch / worktree: chore/issue-1516-adr-decision-map / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
-- Issue / PR: #1516 / PR TBD
+- Issue / PR: #1516 / PR #1517
 - Task: T-2026-0009
-- Current status: implementation complete, focused validation passing.
+- Current status: merged in PR #1517.
 - Files touched: scripts/render_adr_decision_map.py, tests/test_render_adr_decision_map.py, tasks/queue.md, docs/plans/T-2026-0009-adr-decision-map.md
 - Decisions made: local self-contained HTML generated from docs/adr/README.md only.
 - Commands run: python3 scripts/render_adr_decision_map.py; python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py; python3 -m pytest -q tests/test_render_adr_decision_map.py; git diff --check


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0009 ADR decision map plan as `done` after merged PR #1517.
- Link the original implementation PR without changing ADR records or renderer behavior.

## §2 Issue
Closes #2091

## §3 Changes
- Updated `docs/plans/T-2026-0009-adr-decision-map.md` only.
- No ADR files, renderer code, tests, queue entries, generated reports, or governance behavior changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0009-adr-decision-map.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2091-adr-decision-map-plan`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0009-adr-decision-map.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.

## §7 Notes / risks
- Docs-only change; no runtime, ADR source, renderer, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
