### PR TITLE
docs: record overlap gate in architecture module map

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -4,6 +4,10 @@
 
 파이프라인: ingestion → 메타데이터 정규화 → 청킹 → 검색 → 재순위/계획 → 근거 집계 → 근거 기반 답변 → 검증 → 평가 → reviewer 문서.
 
+## 병행 작업 경계
+
+이 모듈 맵은 리뷰어용 진입점인 동시에 Codex/Claude 병행 세션의 **작업 표면 선택 기준**이다. 아래 표의 같은 단계·모듈·근거 문서를 수정하기 전에는 최신 `origin/main` 에서 별도 worktree 를 만든 뒤 [`overlap-preflight`](../operations/ai-codex-workflow.md#overlap-preflight)를 실행해 open PR, remote branch, 기존 worktree, issue 중복 여부를 먼저 남긴다.
+
 ## 단계별 모듈
 
 | 단계 | 주요 모듈 | 책임 |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

아키텍처 모듈 맵이 리뷰어 진입점이자 병행 Codex/Claude 세션의 작업 표면 선택 기준임을 명시하고, 같은 단계·모듈·근거 문서 편집 전 `overlap-preflight` 증거를 남기도록 canonical workflow 링크를 추가했습니다.

Closes #2092

## 2. 영향 파일

- `docs/architecture/module-map.md` — docs-only reviewer guidance; load-bearing path 아님.

## 3. 리스크

- 리스크: 새 링크가 깨지거나 module-map의 목적을 과도하게 확장할 수 있음.
- 배제: `check_doc_links.py`로 fragment 포함 링크를 검증했고, 변경은 병행 작업 경계 설명 1문단으로 제한했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 2092 --branch docs/issue-2092-module-map-overlap-gate --paths docs/architecture/module-map.md` → `Result: clear`, evidence path: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/architecture/module-map.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only reviewer guidance change. RAG/runtime/eval behavior does not change; real-eval not run.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link compatibility break. ADR 0003 `schema_version` unchanged.

## 7. 범위 외

- 기존 orphan worktree 정리는 별도 승인/작업 범위라 수행하지 않았습니다.
- 다른 module ownership 표나 pipeline 설명은 변경하지 않았습니다.
