### PR TITLE
docs: clarify legacy eval negative guard in v2 refresh packet

### DIFF
--- a/docs/evaluation/real100_v2-baseline-refresh.md
+++ b/docs/evaluation/real100_v2-baseline-refresh.md
@@ -74,9 +74,13 @@ not support a performance-improvement claim.
 
 Executed:
 
+The final `make real-eval` command was a negative guard check, not a baseline
+run.
+
 ```bash
 REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-check
 make real-eval-v2-guard
+# Negative guard check: must fail while legacy real100/v1 targets are disabled.
 make real-eval
 ```
 


### PR DESCRIPTION
## Summary
- Clarify that the historical `make real-eval` command in the v2 refresh packet was a negative guard check, not a baseline run.
- Preserve the existing validation transcript and fail-closed legacy target result.

## Issue
Closes #2093

## Changes
- Added explicit prose before the validation command block.
- Added an inline shell comment before the legacy `make real-eval` probe.

## Eval impact
- Docs-only clarification; no pipeline, Makefile, report, or private data changes.
- Keeps legacy real100/v1 target references framed as fail-closed guard evidence only.

## Validation
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/real100_v2-baseline-refresh.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check origin/main...HEAD`
- `make check-branch`

## Risks / rollback
- Low risk: one documentation file only.
- Rollback by reverting this commit if the wording is unnecessary.
