### PR TITLE
docs: mark overlap preflight plan complete

### DIFF
--- a/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
+++ b/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0016 Agent worktree overlap preflight
 
-- Status: review
+- Status: done
 - Owner role: Maintainer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0016`
-- Related issue / PR: Issue #1541 / PR #1543
+- Related issue / PR: Issue #1541 / PR #1543; refresh issue #2097
 - Related ADR: ADR 0007; ADR 0079
 - Created: 2026-05-27
-- Last updated: 2026-05-27
+- Last updated: 2026-06-04
 
 ## Problem Statement
 


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0016 agent worktree overlap preflight plan as `done` after merged PR #1543.
- Preserve the read-only/fail-closed intent without changing agent-loop behavior.

## §2 Issue
Closes #2097

## §3 Changes
- Updated `docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md` only.
- No agent-loop code, tests, workflow docs, queue entries, generated reports, or runtime behavior changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2097-overlap-preflight-plan`.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md`.
- Dirty worktree same-file scan before editing: none.
- Active worktree branch-diff same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.
- Rebased on latest `origin/main` before push; branch head is `db757a49`.

## §7 Notes / risks
- Docs-only change; no runtime, overlap-preflight, workflow, or eval behavior changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
- No known overlap with active Codex/Claude worktree file sets.
