### PR TITLE
docs: add reviewer reading path to design background

### DIFF
--- a/docs/design-background.md
+++ b/docs/design-background.md
@@ -9,3 +9,9 @@
 
 ## 배경
 RFP QA는 단순 검색보다 비교/정합성/부재판별이 중요해, retrieve→generate 단일 체인 대신 analyzer/planner/verifier를 포함한 agentic 구조를 채택했다. 공개본은 원본 RFP 비공개 제약을 고려해 public fixture RFP와 결정적 평가셋으로 재현성을 우선한다.
+
+## 리뷰어 판독 경로
+
+- 모듈 책임과 호출 순서는 [모듈 맵](architecture/module-map.md)에서 먼저 확인한다.
+- "왜 이 설계인가"는 [실패 모드 케이스 스터디](case-studies/failure-modes.md)의 증상 → 설계 대응 → 회귀 가드 순서로 읽는다.
+- 성능·평가 주장은 [evaluation surface map](evaluation/surface-map.md)의 public fixture smoke / private `real100_v2` 경계를 먼저 적용한다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/design-background.md`가 핵심 의사결정만 나열하고 canonical reviewer 문서로 이어지는 판독 경로를 제공하지 않아, 모듈 책임·실패 모드·평가 surface 경계를 각각의 정본 문서로 연결했습니다. 상세 taxonomy/metric은 복제하지 않고 링크 라우팅만 추가했습니다.

Closes #2098

## 2. 영향 파일

- `docs/design-background.md` — docs-only reviewer routing; load-bearing path 아님.

## 3. 리스크

- 리스크: 새 링크가 깨지거나 canonical 문서 경계와 어긋날 수 있음.
- 배제: `check_doc_links.py`로 세 링크를 검증했고, 상세 주장은 module map / failure-mode case study / surface map에 남겨 중복을 피했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 2098 --branch docs/issue-2098-design-background-reading-path --paths docs/design-background.md` → `Result: clear`, evidence path: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/design-background.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only reviewer routing change. RAG/runtime/eval behavior does not change; real-eval not run.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link compatibility break. ADR 0003 `schema_version` unchanged.

## 7. 범위 외

- 실패 모드 taxonomy, README metric, eval aggregate 값은 변경하지 않았습니다.
- 기존 orphan worktree 정리는 별도 승인/작업 범위라 수행하지 않았습니다.
