### PR TITLE
docs: link architecture deep dive to reviewer guides

### DIFF
--- a/docs/architecture-deep-dive.md
+++ b/docs/architecture-deep-dive.md
@@ -71,5 +71,7 @@ flowchart TD
 ## 더 읽을 거리
 
 - [README §평가 스토리](https://github.com/hskim-solv/BidMate-DocAgent#%ED%8F%89%EA%B0%80-%EC%8A%A4%ED%86%A0%EB%A6%AC)
+- [모듈 맵](architecture/module-map.md) — 파이프라인 단계별 코드 소유권과 호출 순서
+- [설계 배경](design-background.md) — 핵심 의사결정과 reviewer 판독 경로
 - [ADR 인덱스](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/README.md)
 - [Engineering governance](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/engineering-governance.md)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

아키텍처 deep-dive의 `더 읽을 거리`가 README/ADR/governance로만 이어져, 코드 소유권과 설계 배경을 찾는 reviewer가 canonical 문서로 바로 이동하기 어려웠습니다. `docs/architecture/module-map.md`와 `docs/design-background.md` 링크를 추가해 deep-dive는 high-level overview로 유지하고 상세 ownership/rationale은 정본 문서로 라우팅했습니다.

Closes #2103

## 2. 영향 파일

- `docs/architecture-deep-dive.md` — docs-only reviewer navigation; load-bearing path 아님.

## 3. 리스크

- 리스크: 새 링크가 깨지거나 deep-dive에 중복 ownership 설명이 쌓일 수 있음.
- 배제: 링크 검증을 통과했고, 상세 설명은 추가하지 않고 canonical 문서 링크 2개로만 제한했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 2103 --branch docs/issue-2103-architecture-deep-dive-reading-links --paths docs/architecture-deep-dive.md` → `Result: clear`, evidence path: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/architecture-deep-dive.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only navigation change. RAG/runtime/eval behavior does not change; real-eval not run.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link compatibility break. ADR 0003 `schema_version` unchanged.

## 7. 범위 외

- 모듈 ownership 표, 설계 배경 본문, README metric은 변경하지 않았습니다.
- 기존 orphan worktree 정리는 별도 승인/작업 범위라 수행하지 않았습니다.
