### PR TITLE
docs: mark embedding ablation real100 phase as archive-only

### DIFF
--- a/docs/eval/embedding-ablation.md
+++ b/docs/eval/embedding-ablation.md
@@ -316,6 +316,12 @@ Runner: `scripts/run_routed_measurement.py --backend sentence-transformers`. 결
 
 ## Phase 2.0 — real100 retrieval-surface (issue #1359, 2026-05-23): 5-model Korean embedding ablation
 
+> **Current-use boundary.** Phase 2.0의 `real100` / `reports/real100/*`
+> references are historical v1 aggregate-only snapshots. They are not current
+> private-eval claim evidence; new task, PR, and handoff claims must use
+> `real100_v2` aggregate evidence plus `make real-eval-v2-check`,
+> `make real-eval-v2-inventory`, and `make real-eval-v2-guard`.
+
 Phase 1.x는 전부 **public-fixture-smoke** corpus + **end-to-end answer-quality**(accuracy/groundedness) 측정이었다. 두 가지 구조적 한계가 누적됐다:
 
 1. **합성 corpus saturation** — Phase 1.4 falsifier([ADR 0032](../adr/0032-eval-saturation-routed-subset.md))가 routed subset에서 측정 천장을 입증.


### PR DESCRIPTION
## Summary
- Add a current-use boundary note to the Phase 2.0 embedding ablation section.
- Clarify that legacy `real100` / `reports/real100/*` artifacts there are historical v1 aggregate-only snapshots, not new claim evidence.

## Issue
Closes #2101

## Changes
- Updated `docs/eval/embedding-ablation.md` only.
- Preserved historical Phase 2.0 measurements and links.

## Eval impact
- Docs-only clarification; no scripts, eval configs, reports, or private data changed.
- Future claim-bearing private eval work is directed to `real100_v2` aggregate evidence and v2 guards.

## Validation
- `python3 scripts/check_doc_links.py --check-all --paths docs/eval/embedding-ablation.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check origin/main...HEAD`
- `make check-branch`
- Pre-commit Codex adversarial review: passed (0 blocking findings)

## Risks / rollback
- Low risk: documentation-only boundary note.
- Rollback by reverting this commit if the note duplicates future consolidated guidance.
