### PR TITLE
docs: mark rag challenge metrics archive-only

### DIFF
--- a/docs/rag-challenges-solved.md
+++ b/docs/rag-challenges-solved.md
@@ -1,6 +1,6 @@
 # RAG 시스템 개선 회고 — 3가지 핵심 문제와 해결
 
-> 이 문서는 BidMate-DocAgent 의 주요 RAG 개선 결정을 **STAR 형식** (Situation → Task → Action → Result) 으로 재서술한 포트폴리오 자산입니다. 모든 수치는 private internal eval 집계(historical, 100-doc 계열; raw 는 ADR 0005 경계로 미포함) 기준이며, harness 동작 확인 전용 smoke(5-case)와는 별개입니다. raw query·문서 원문은 [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) 경계를 준수해 포함하지 않습니다.
+> 이 문서는 BidMate-DocAgent 의 주요 RAG 개선 결정을 **STAR 형식** (Situation → Task → Action → Result) 으로 재서술한 포트폴리오 자산입니다. 여기의 historical private/internal 100-doc 계열 수치는 archive-only context 이며, 새 task·PR·claim 의 claim-bearing 근거는 현재 [`real100_v2` aggregate policy](evaluation/surface-map.md)를 따른다. harness 동작 확인 전용 smoke(5-case)와는 별개이고, raw query·문서 원문은 [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) 경계를 준수해 포함하지 않습니다.
 
 ---
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/rag-challenges-solved.md` 상단의 historical 100-doc metric 설명이 새 PR/task에서 claim-bearing 근거로 오해될 수 있어, 해당 수치가 archive-only context 이며 새 성능 주장은 현재 `real100_v2` aggregate policy를 따라야 한다는 경계를 명시했습니다. metric 값이나 eval artifact는 변경하지 않았습니다.

Closes #2108

## 2. 영향 파일

- `docs/rag-challenges-solved.md` — docs-only evidence-boundary clarification; load-bearing path 아님.

## 3. 리스크

- 리스크: historical metric 설명을 current `real100_v2` claim으로 오해하거나 링크가 깨질 수 있음.
- 배제: 문구를 archive-only/current policy 경계로 제한했고, `check_doc_links.py`로 `evaluation/surface-map.md`와 ADR 0005 링크를 검증했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 2108 --branch docs/issue-2108-rag-challenges-archive-boundary --paths docs/rag-challenges-solved.md` → `Result: clear`, evidence path: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/rag-challenges-solved.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `·` — docs-only boundary clarification. No metric value, eval artifact, RAG/runtime behavior, or aggregate evidence changed; real-eval not run.

## 6. 하위 호환

No schema, CLI, answer-contract, or doc-link compatibility break. ADR 0003 `schema_version` unchanged.

## 7. 범위 외

- Historical metric values and STAR examples were not rewritten.
- `real100_v2` aggregate regeneration was not run or needed.
- Existing orphan worktree cleanup remains out of scope.
