### PR TITLE
test(rag_embedding): add direct unit coverage for expand_features bigram utility

### DIFF
--- a/tests/test_embedding_backends.py
+++ b/tests/test_embedding_backends.py
@@ -262,5 +262,59 @@ def _repo_scripts_dir() -> "object":
     return Path(__file__).resolve().parent.parent / "scripts"
 
 
+class ExpandFeaturesTest(unittest.TestCase):
+    """Direct unit coverage for rag_embedding.expand_features (issue #2105).
+
+    expand_features is only exercised transitively via hashing_embeddings;
+    these lock the unigram + bigram expansion contract and its edge cases.
+    """
+
+    def test_empty_returns_empty(self) -> None:
+        import rag_embedding
+
+        self.assertEqual(rag_embedding.expand_features([]), [])
+
+    def test_single_token_has_no_bigram(self) -> None:
+        import rag_embedding
+
+        self.assertEqual(rag_embedding.expand_features(["a"]), ["a"])
+
+    def test_pair_appends_one_bigram(self) -> None:
+        import rag_embedding
+
+        self.assertEqual(
+            rag_embedding.expand_features(["a", "b"]), ["a", "b", "a_b"]
+        )
+
+    def test_triple_appends_adjacent_bigrams(self) -> None:
+        import rag_embedding
+
+        self.assertEqual(
+            rag_embedding.expand_features(["a", "b", "c"]),
+            ["a", "b", "c", "a_b", "b_c"],
+        )
+
+    def test_unigrams_precede_bigrams(self) -> None:
+        import rag_embedding
+
+        result = rag_embedding.expand_features(["x", "y", "z"])
+        self.assertEqual(result[:3], ["x", "y", "z"])
+        self.assertTrue(all("_" in bigram for bigram in result[3:]))
+
+    def test_duplicate_adjacent_tokens(self) -> None:
+        import rag_embedding
+
+        self.assertEqual(
+            rag_embedding.expand_features(["a", "a"]), ["a", "a", "a_a"]
+        )
+
+    def test_does_not_mutate_input(self) -> None:
+        import rag_embedding
+
+        tokens = ["a", "b"]
+        rag_embedding.expand_features(tokens)
+        self.assertEqual(tokens, ["a", "b"])
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #2105

`expand_features` (rag_embedding.py:370) 는 unigram + bigram(인접 토큰 `left_right`) feature expansion 유틸리티로 `hashing_embeddings` (rag_embedding.py:360) 내부에서만 transitive 하게 호출되며 **직접 단위 테스트가 없었다** (`grep -rln expand_features tests/` → 결과 없음). 엣지 동작(빈/단일/중복 토큰, unigram-before-bigram 순서, 입력 불변성)이 회귀 가드 없이 방치돼 있어 직접 커버리지를 추가한다.

## 2. 영향 파일

- `tests/test_embedding_backends.py` — `ExpandFeaturesTest` 클래스 7개 메서드 추가 (test-only, **load-bearing 아님**)

런타임 코드(`rag_embedding.py`) 무변경.

## 3. 리스크

없음. 테스트만 추가하며 프로덕션 코드 경로를 건드리지 않는다. 신규 테스트는 실제 `rag_embedding.expand_features` 산출을 assert 하므로 함수 시그니처/동작이 바뀌면 실패해 회귀를 잡는다. (Pyright 가 같은 파일 line 96/99/188/244 에 경고를 내지만 전부 **pre-existing** mock 미사용 변수 + 동적 import noise — 본 PR 범위 밖, 18 passed 로 무관함 입증.)

## 4. 테스트

신규 `ExpandFeaturesTest` 7개:
- `test_empty_returns_empty`: `[]` → `[]`
- `test_single_token_has_no_bigram`: `["a"]` → `["a"]`
- `test_pair_appends_one_bigram`: `["a","b"]` → `["a","b","a_b"]`
- `test_triple_appends_adjacent_bigrams`: `["a","b","c"]` → `["a","b","c","a_b","b_c"]`
- `test_unigrams_precede_bigrams`: unigram 먼저, bigram 나중 순서
- `test_duplicate_adjacent_tokens`: `["a","a"]` → `["a","a","a_a"]`
- `test_does_not_mutate_input`: 입력 리스트 불변 (`features = list(tokens)` copy 검증)

`python3 -m pytest tests/test_embedding_backends.py -q` → **18 passed** (기존 11 + 신규 7, 회귀 없음). overlap-preflight: `[OK]` (stale base 아님, 활성 worktree 와 무충돌 — `reports/agent_loop/overlap_preflight.md`).

## 5. Eval 영향

All `·` — RAG 런타임/eval/retrieval/answer 미변경 (test-only 추가). load-bearing path 무수정 → real-data 동작 변화 없음. `rag_embedding.py` byte-identical, ADR 0001 baseline 무영향.

## 6. 하위 호환

영향 없음. additive 테스트로 기존 계약/스키마/CLI/doc link 무변경.

## 7. 범위 외

같은 파일의 pre-existing Pyright noise (line 96/99/188/244) 는 본 PR 과 무관해 의도적으로 손대지 않는다 (별도 정리 대상).