### PR TITLE
docs: mark HWP PDF PyMuPDF4LLM plan complete

### DIFF
--- a/docs/plans/T-2026-0004-hwp-pdf-pymupdf4llm-loader.md
+++ b/docs/plans/T-2026-0004-hwp-pdf-pymupdf4llm-loader.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0004 PDF/HWP PyMuPDF4LLM canonical citation loader
 
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0004`
-- Related issue / PR: N/A
+- Related issue / PR: implementation PR [#1494](https://github.com/hskim-solv/BidMate-DocAgent/pull/1494); refresh issue [#2118](https://github.com/hskim-solv/BidMate-DocAgent/issues/2118)
 - Related ADR: ADR 0078, ADR 0049, ADR 0001
 - Created: 2026-05-26
-- Last updated: 2026-05-26
+- Last updated: 2026-06-04
 
 ## Problem Statement
 


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0004 PDF/HWP PyMuPDF4LLM plan as `done` after merged PR #1494.
- Replace the stale `Related issue / PR: N/A` metadata with the implementation PR and this refresh issue.

## §2 Issue
Closes #2118

## §3 Changes
- Updated `docs/plans/T-2026-0004-hwp-pdf-pymupdf4llm-loader.md` only.
- No ingestion/runtime, loader tests, ADRs, queue entries, eval artifacts, or generated reports changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0004-hwp-pdf-pymupdf4llm-loader.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2118-hwp-pdf-pymupdf4llm-plan`.
- PR #1494 is merged and `tasks/queue.md` marks T-2026-0004 done.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0004-hwp-pdf-pymupdf4llm-loader.md`.
- Active/dirty worktree same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.
- Rebased on latest `origin/main` before push; branch head is `a3de816`.

## §7 Notes / risks
- Docs-only change; no loader behavior or citation contract changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
