### PR TITLE
docs: mark phase4 eval-framework audit as legacy snapshot

### DIFF
--- a/docs/audits/eval-framework-phase4-audit.md
+++ b/docs/audits/eval-framework-phase4-audit.md
@@ -1,5 +1,11 @@
 # eval-framework-progressive-audit — Phase 4 (통계적 엄밀성)
 
+> **Historical snapshot note.** This audit records 2026-05 legacy `real100` /
+> n=221 statistical-rigor findings. Treat `reports/real100/*` references as
+> archive-only context; new task, PR, claim, and handoff evidence must use
+> `real100_v2` aggregate evidence plus `make real-eval-v2-check`,
+> `make real-eval-v2-inventory`, and `make real-eval-v2-guard`.
+
 | field | value |
 |---|---|
 | Skill | [`.claude/skills/eval-framework-progressive-audit/SKILL.md`](../../.claude/skills/eval-framework-progressive-audit/SKILL.md) (PR #889) |


### PR DESCRIPTION
## Summary
- Add a historical snapshot note to the Phase 4 eval-framework audit.
- Clarify that legacy `real100` / n=221 / `reports/real100/*` references are archive-only context, not new claim evidence.

## Issue
Closes #2121

## Changes
- Updated `docs/audits/eval-framework-phase4-audit.md` only.
- Preserved the original statistical audit evidence and conclusions.

## Eval impact
- Docs-only current-use boundary clarification.
- Future claim-bearing private eval work is directed to `real100_v2` aggregate evidence and v2 guards.

## Validation
- `python3 scripts/check_doc_links.py --check-all --paths docs/audits/eval-framework-phase4-audit.md`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check`
- `make check-branch`

## Risks / rollback
- Low risk: one audit note only.
- Rollback by reverting this commit if a consolidated audit header policy supersedes it.
