### PR TITLE
docs: mark Chroma vector baseline plan complete

### DIFF
--- a/docs/plans/T-2026-0026-chroma-vector-baseline.md
+++ b/docs/plans/T-2026-0026-chroma-vector-baseline.md
@@ -1,9 +1,10 @@
 # Plan: T-2026-0026 Chroma-Backed Naive Baseline
 
-- Status: in_progress
+- Status: done
 - Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0026`
-- Related issue / PR: [#1580](https://github.com/hskim-solv/BidMate-DocAgent/issues/1580) / PR TBD
+- Related issue / PR: [#1580](https://github.com/hskim-solv/BidMate-DocAgent/issues/1580) / [#1635](https://github.com/hskim-solv/BidMate-DocAgent/pull/1635); refresh issue [#2123](https://github.com/hskim-solv/BidMate-DocAgent/issues/2123)
+- Last updated: 2026-06-04
 
 ## Problem
 
@@ -71,18 +72,21 @@ REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-
 ## Session Handoff
 
 - Role: Planner
-- Lifecycle stage: todo
-- Branch / worktree: `docs/issue-1580-chroma-vector-baseline-plan` / Codex worktree
-- Current status: implementation in progress for the canonical Chroma-backed
-  `naive_baseline` contract.
+- Lifecycle stage: done
+- Branch / worktree: `feat/issue-1580-chroma-canonical-baseline` / PR #1635
+- Current status: merged in PR #1635; issue #1580 is closed and the queue marks
+  T-2026-0026 done.
 - Files touched: implementation, tests, ADR/docs, queue.
 - Commands run: `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0026-chroma-vector-baseline.md`; `git diff --check`; `make check-branch`.
-- Results: pending validation in implementation PR.
-- Blockers: none known.
-- Open risks: Chroma ranking/tie-break may differ from the in-memory backend;
-  Chroma dependency cost may affect CI or local setup.
-- Next action: complete validation and record PR evidence without refreshing
-  private baseline aggregates.
+- Results: focused tests and docs/branch gates passed; private v2 path check and
+  guard passed; full Chroma run completed against the checkpoint MiniLM
+  page-aware index.
+- Blockers: none for the completed T-2026-0026 scope.
+- Open risks: local OpenAI-compatible model/server availability remains a
+  separate follow-up for optional Chroma LLM synthesis, not a blocker for this
+  completed baseline switch.
+- Next action: run optional `make real-eval-v2-chroma-llm` only as a separate
+  follow-up when a local loopback model is available.
 - Next safe command: `git status --short`
 - Reviewer focus: backend axis separation, parity guard, no mixed embedding
   claim.


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0026 Chroma vector baseline plan as `done` after merged PR #1635.
- Replace stale `in_progress` / `PR TBD` handoff wording with closed issue and completed queue state.

## §2 Issue
Closes #2123

## §3 Changes
- Updated `docs/plans/T-2026-0026-chroma-vector-baseline.md` only.
- No vector-store runtime, eval scripts, tests, ADRs, queue entries, private eval artifacts, or generated reports changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0026-chroma-vector-baseline.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.
- Optional Chroma LLM synthesis remains a separate follow-up gated by a local loopback model.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2123-chroma-vector-baseline-plan`.
- Issue #1580 is closed and PR #1635 is merged.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0026-chroma-vector-baseline.md`.
- Active/dirty worktree same-file scan before editing: no real same-file diff observed; a stale missing worktree path was ignored.
- Rechecked same-file open PR scan before push: none.
- Rebased on latest `origin/main` before push; branch head is `cfbc886`.

## §7 Notes / risks
- Docs-only change; no Chroma backend behavior or eval contract changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
