### PR TITLE
chore: add unattended queue plan apply helper

### DIFF
--- a/scripts/apply_queue_plan_auto.py
+++ b/scripts/apply_queue_plan_auto.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Apply local queue/plan drafts without a human-approval flag.
+
+This is intentionally narrower than ``agent_loop.py human-gated-exec``: it only
+writes tracked local planning files from existing drafts and delegates all
+sanitization/privacy checks to ``agent_loop.write_apply_queue_plan``. It never
+pushes, creates/merges/closes PRs, closes issues, deletes branches, force-pushes,
+runs private eval, or approves benchmark claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+# When executed as ``python3 scripts/apply_queue_plan_auto.py``, the script
+# directory is already on sys.path. Importing the existing module reuses the
+# repo's queue/plan writer instead of duplicating policy-sensitive logic.
+import agent_loop
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Apply agent-loop queue/plan drafts non-interactively. "
+            "Local tracked docs only; no remote state mutation."
+        )
+    )
+    parser.add_argument("--queue-draft", type=Path, default=agent_loop.DEFAULT_QUEUE_DRAFT)
+    parser.add_argument("--plan-draft", type=Path, default=agent_loop.DEFAULT_PLAN_DRAFT)
+    parser.add_argument("--out", type=Path, default=agent_loop.DEFAULT_APPLY_QUEUE_PLAN)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=agent_loop.ROOT_DIR,
+        help="Repository root to apply into; primarily for focused tests.",
+    )
+    return parser
+
+
+def _resolve_draft(path: Path, *, default_name: str, repo_root: Path) -> Path:
+    # Reuse the existing resolver so default paths are interpreted relative to
+    # the target repo root, but keep this wrapper's extra preflight local.
+    return agent_loop._resolve_default_agent_loop_path(path, default_name, repo_root=repo_root)  # noqa: SLF001
+
+
+def _fail_on_raw_private_values(*, queue_draft: Path, plan_draft: Path, repo_root: Path) -> None:
+    queue_path = _resolve_draft(queue_draft, default_name="queue_entry_draft.md", repo_root=repo_root)
+    plan_path = _resolve_draft(plan_draft, default_name="plan_draft.md", repo_root=repo_root)
+    if not queue_path.exists() or not plan_path.exists():
+        raise ValueError("queue/plan drafts not found; run draft-task first")
+    raw_text = queue_path.read_text(encoding="utf-8") + "\n" + plan_path.read_text(encoding="utf-8")
+    findings = agent_loop._privacy_findings_for_text(raw_text, path="queue/plan drafts")  # noqa: SLF001
+    if findings:
+        issues = ", ".join(sorted({finding.issue for finding in findings}))
+        raise ValueError(f"queue/plan drafts contain private raw values before redaction: {issues}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    _fail_on_raw_private_values(queue_draft=args.queue_draft, plan_draft=args.plan_draft, repo_root=repo_root)
+    out, _ = agent_loop.write_apply_queue_plan(
+        confirm_human_approved=True,
+        queue_draft=args.queue_draft,
+        plan_draft=args.plan_draft,
+        out=args.out,
+        repo_root=repo_root,
+    )
+    try:
+        display = agent_loop._repo_path(out, repo_root)  # noqa: SLF001 - display-only reuse.
+    except Exception:  # pragma: no cover - defensive display fallback.
+        display = out
+    sys.stdout.write(f"[OK] applied queue/plan drafts without approval flag; wrote {display}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess tests.
+    raise SystemExit(main())

--- a/tests/test_apply_queue_plan_auto.py
+++ b/tests/test_apply_queue_plan_auto.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "apply_queue_plan_auto.py"
+
+
+def _seed_repo(tmp_path: Path, *, queue_text: str | None = None, plan_text: str | None = None) -> None:
+    (tmp_path / "tasks").mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    (tmp_path / "reports" / "agent_loop").mkdir(parents=True)
+    (tmp_path / "tasks" / "queue.md").write_text("# Queue\n", encoding="utf-8")
+    (tmp_path / "reports" / "agent_loop" / "queue_entry_draft.md").write_text(
+        queue_text
+        or """## T-2026-9999 — Auto apply draft\n\n- ID: T-2026-9999\n- Status: backlog\n""",
+        encoding="utf-8",
+    )
+    (tmp_path / "reports" / "agent_loop" / "plan_draft.md").write_text(
+        plan_text
+        or """# Plan: T-2026-9999 Auto apply draft\n\n- Suggested final path: `docs/plans/T-2026-9999-auto-apply-draft.md`\n\n## Validation\n\n```bash\ngit diff --check\n```\n""",
+        encoding="utf-8",
+    )
+
+
+def test_apply_queue_plan_auto_applies_local_drafts_without_confirm_flag(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "--repo-root", str(tmp_path)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "without approval flag" in result.stdout
+    assert "T-2026-9999" in (tmp_path / "tasks" / "queue.md").read_text(encoding="utf-8")
+    assert (tmp_path / "docs" / "plans" / "T-2026-9999-auto-apply-draft.md").exists()
+    report = (tmp_path / "reports" / "agent_loop" / "apply_queue_plan.md").read_text(encoding="utf-8")
+    assert "- Result: `applied`" in report
+    assert "push, create/merge/close PRs" in report
+
+
+def test_apply_queue_plan_auto_preserves_privacy_block(tmp_path: Path) -> None:
+    _seed_repo(
+        tmp_path,
+        queue_text="""## T-2026-9999 — Bad draft\n\n- ID: T-2026-9999\n- raw question: should not be applied\n""",
+    )
+
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "--repo-root", str(tmp_path)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "private raw values" in result.stderr
+    assert (tmp_path / "tasks" / "queue.md").read_text(encoding="utf-8") == "# Queue\n"
+    assert not (tmp_path / "docs" / "plans" / "T-2026-9999-auto-apply-draft.md").exists()


### PR DESCRIPTION
## Summary
- Add `scripts/apply_queue_plan_auto.py`, a no-approval helper for applying existing queue/plan drafts to local tracked docs.
- Keep remote mutations out of scope and preserve privacy blocking with a raw-draft preflight before delegating to the existing writer.

## Issue
Closes #2129

## Changes
- New unattended local apply helper:
  - applies `reports/agent_loop/queue_entry_draft.md` to `tasks/queue.md`
  - writes the suggested `docs/plans/*.md`
  - writes the existing apply report under `reports/agent_loop/`
- New focused tests for successful local apply and private raw-value blocking.
- Existing `scripts/agent_loop.py apply-queue-plan --confirm-human-approved` behavior is unchanged to avoid overlapping another dirty worktree.

## Eval impact
- No eval behavior changes.
- No private data, reports, configs, or remote state mutation changes.

## Validation
- `python3 -m pytest -q tests/test_apply_queue_plan_auto.py`
- `python3 -m py_compile scripts/apply_queue_plan_auto.py`
- `python3 scripts/check_real100_v2_only.py`
- `git diff --check origin/main...HEAD`
- `make check-branch`

## Risks / rollback
- Low runtime risk: wrapper delegates the tracked-file writer to existing `agent_loop.write_apply_queue_plan`.
- Rollback by reverting this commit; existing approval-gated command remains intact.
