### PR TITLE
docs: mark priority HTML review board plan complete

### DIFF
--- a/docs/plans/T-2026-0010-priority-html-review-boards.md
+++ b/docs/plans/T-2026-0010-priority-html-review-boards.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0010 Priority HTML Review Boards
 
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0010`
-- Related issue / PR: [#1518](https://github.com/hskim-solv/BidMate-DocAgent/issues/1518)
+- Related issue / PR: [#1518](https://github.com/hskim-solv/BidMate-DocAgent/issues/1518) / [#1519](https://github.com/hskim-solv/BidMate-DocAgent/pull/1519); refresh issue [#2135](https://github.com/hskim-solv/BidMate-DocAgent/issues/2135)
 - Related ADR: N/A - no decision-level change
 - Created: 2026-05-26
-- Last updated: 2026-05-26
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -154,15 +154,15 @@ navigation only; they must not imply a fresh benchmark/eval run.
 ## Session Handoff - 2026-05-26 00:00 KST
 
 - Role: Implementer
-- Branch / worktree: chore/issue-1518-priority-html-boards / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
-- Issue / PR: #1518 / TBD
+- Branch / worktree: chore/issue-1518-priority-html-boards / PR #1519
+- Issue / PR: #1518 / #1519; refresh issue #2135
 - Task: T-2026-0010
-- Current status: review
+- Current status: merged in PR #1519; queue marks T-2026-0010 done.
 - Files touched: CLAUDE.md, tasks/queue.md, docs/plans/T-2026-0010-priority-html-review-boards.md, scripts/render_priority_review_boards.py, tests/test_render_priority_review_boards.py
 - Decisions made: Keep all six boards in one presentation-only renderer.
 - Commands run: gh issue create; git switch; python3 -m pytest tests/test_render_priority_review_boards.py -q; python3 scripts/render_priority_review_boards.py; git diff --check; python3 scripts/check_doc_links.py --check-all; browser smoke via http://127.0.0.1:8765
 - Results: issue and branch created; focused tests, doc links, diff check, and browser smoke pass.
-- Next safe command: gh pr create
+- Next safe command: git status --short
 - Open questions: none
 - Risks: generated HTML files are local ignored artifacts; renderer and markdown source-of-truth are committed.
 ```


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0010 priority HTML review board plan as `done` after merged PR #1519.
- Replace stale `#1518 / TBD` handoff wording with the completed queue state.

## §2 Issue
Closes #2135

## §3 Changes
- Updated `docs/plans/T-2026-0010-priority-html-review-boards.md` only.
- No renderer code, tests, generated HTML, queue entries, eval artifacts, or reports changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0010-priority-html-review-boards.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.
- HTML boards remain presentation/navigation surfaces, not fresh benchmark or private-eval evidence.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2135-priority-html-review-board-plan`.
- Issue #1518 is closed and PR #1519 is merged.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0010-priority-html-review-boards.md`.
- Active/dirty worktree same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.
- Rebased on latest `origin/main` before push; branch head is `5438d02`.

## §7 Notes / risks
- Docs-only change; no renderer behavior or generated board artifact changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
