### PR TITLE
test(query-expansion): default_expander 분기 + Identity/HyDE meta 계약 단위 커버리지

### DIFF
--- a/tests/test_query_expansion_protocol.py
+++ b/tests/test_query_expansion_protocol.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 from rag_query_expansion import (
+    DEFAULT_MAX_TOKENS,
     HyDEExpander,
     IdentityExpander,
     QueryExpander,
@@ -127,3 +128,184 @@ def test_hyde_expander_empty_response_falls_back(
     assert expanded == query
     assert meta["fell_back"] is True
     assert meta["fallback_reason"] == "empty_response"
+
+
+# --- default_expander 분기 매트릭스 (graceful-degradation 계약, line 246-253) ---
+# 기존 test_default_expander_hyde_dispatch_returns_hyde 가 hyde/HyDE/identity/
+# typo 분기를 덮으므로, 여기서는 그 테스트가 건드리지 않는 분기만 고정한다.
+
+
+def test_default_expander_none_value_is_identity() -> None:
+    """``query_expansion`` 키는 존재하나 값이 ``None`` 이면 identity.
+    ``if raw is not None`` 분기 — 키 자체가 없는 경로(기존 테스트)와는
+    다른 코드 경로다."""
+    assert isinstance(
+        default_expander({"query_expansion": None}), IdentityExpander
+    )
+
+
+def test_default_expander_empty_or_blank_value_is_identity() -> None:
+    """빈/공백 문자열 → ``strip()`` 후 ``"" or "identity"`` → identity.
+    eval/config.yaml 에 빈 값이 들어가도 crash 대신 graceful degrade."""
+    assert isinstance(default_expander({"query_expansion": ""}), IdentityExpander)
+    assert isinstance(
+        default_expander({"query_expansion": "   "}), IdentityExpander
+    )
+
+
+def test_default_expander_strips_and_lowercases_hyde() -> None:
+    """주변 공백 + 대소문자 혼용도 ``strip().lower()`` 후 hyde dispatch.
+    config 값에 우발적 공백/대문자가 있어도 opt-in 이 살아있어야 한다."""
+    assert isinstance(
+        default_expander({"query_expansion": "  hyde  "}), HyDEExpander
+    )
+    assert isinstance(
+        default_expander({"query_expansion": "  HYDE\n"}), HyDEExpander
+    )
+
+
+def test_default_expander_non_string_value_coerced_to_identity() -> None:
+    """비-문자열 값은 ``str(raw)`` 로 강제되어 unknown → identity.
+    YAML 이 정수/불리언을 주더라도 retrieval 을 crash 시키지 않는다."""
+    assert isinstance(
+        default_expander({"query_expansion": 123}), IdentityExpander
+    )
+    assert isinstance(
+        default_expander({"query_expansion": True}), IdentityExpander
+    )
+
+
+def test_default_expander_returns_fresh_instance() -> None:
+    """``default_reranker()`` 와 같은 idiom — 매 호출 새 인스턴스 반환.
+    호출자가 module-level state 없이 테스트에서 구현을 교체할 수 있어야
+    한다 (docstring 계약)."""
+    assert default_expander({"query_expansion": "hyde"}) is not default_expander(
+        {"query_expansion": "hyde"}
+    )
+    assert default_expander() is not default_expander()
+
+
+# --- IdentityExpander meta 계약 완전성 ---
+
+
+def test_identity_expander_meta_is_complete_and_ignores_plan() -> None:
+    """Identity meta 는 6개 키를 전부 채우고 plan 내용을 무시한다.
+    plan 에 ``query_expansion='hyde'`` 가 있어도 ``IdentityExpander.expand``
+    자체는 passthrough — dispatch 는 ``default_expander`` 의 책임이다."""
+    query = "사업비 산정 기준은?"
+    expanded, meta = IdentityExpander().expand(
+        query, plan={"query_expansion": "hyde", "top_k": 9}
+    )
+    assert expanded == query
+    assert meta == {
+        "backend": "identity",
+        "model": None,
+        "fell_back": False,
+        "fallback_reason": None,
+        "latency_ms": 0.0,
+        "expanded_length": len(query),
+    }
+
+
+def test_identity_expander_empty_query() -> None:
+    """빈 쿼리도 그대로 통과 — ``expanded_length == 0``, fallback 아님."""
+    expanded, meta = IdentityExpander().expand("", plan={})
+    assert expanded == ""
+    assert meta["expanded_length"] == 0
+    assert meta["fell_back"] is False
+
+
+# --- HyDEExpander 성공 경로 세부 계약 ---
+
+
+def test_hyde_expander_strips_surrounding_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """성공 응답에 앞뒤 공백이 있으면 ``strip`` 되어 반환되고
+    ``expanded_length`` 는 stripped 길이로 갱신된다 (padded raw 길이 아님)."""
+    core = "보안 통제 요구사항은 접근 통제를 포함합니다."
+    monkeypatch.setattr(
+        "rag_query_expansion._call_anthropic_hyde",
+        lambda **_: f"\n\n  {core}  \n",
+    )
+    expanded, meta = HyDEExpander().expand("질의", plan={})
+    assert expanded == core  # stripped, not the padded raw response
+    assert meta["fell_back"] is False
+    assert meta["expanded_length"] == len(core)
+
+
+def test_hyde_expander_ctor_model_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``__init__(model=..., max_tokens=...)`` 이 env / default 보다 우선하고
+    그 값이 ``_call_anthropic_hyde`` 와 meta 양쪽에 전파된다."""
+    seen = {}
+
+    def fake_call(*, model: str, max_tokens: int, **_: object) -> str:
+        seen["model"] = model
+        seen["max_tokens"] = max_tokens
+        return "passage"
+
+    monkeypatch.setattr("rag_query_expansion._call_anthropic_hyde", fake_call)
+    monkeypatch.setenv("BIDMATE_QUERY_EXPANSION_MODEL", "env-model")
+
+    _, meta = HyDEExpander(model="ctor-model", max_tokens=42).expand(
+        "질의", plan={}
+    )
+    assert seen["model"] == "ctor-model"  # ctor over env
+    assert seen["max_tokens"] == 42
+    assert meta["model"] == "ctor-model"
+
+
+def test_hyde_expander_env_model_wins_over_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ctor override 부재 시 env 가 default 모델보다 우선한다."""
+    seen = {}
+
+    def fake_call(*, model: str, **_: object) -> str:
+        seen["model"] = model
+        return "passage"
+
+    monkeypatch.setattr("rag_query_expansion._call_anthropic_hyde", fake_call)
+    monkeypatch.setenv("BIDMATE_QUERY_EXPANSION_MODEL", "env-model")
+
+    _, meta = HyDEExpander().expand("질의", plan={})
+    assert seen["model"] == "env-model"
+    assert meta["model"] == "env-model"
+
+
+def test_hyde_expander_invalid_max_tokens_falls_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """비정상 ``BIDMATE_QUERY_EXPANSION_MAX_TOKENS`` → ``DEFAULT_MAX_TOKENS``.
+    config 오타(``int()`` ValueError)가 expand 를 crash 시키지 않는다."""
+    seen = {}
+
+    def fake_call(*, max_tokens: int, **_: object) -> str:
+        seen["max_tokens"] = max_tokens
+        return "passage"
+
+    monkeypatch.setattr("rag_query_expansion._call_anthropic_hyde", fake_call)
+    monkeypatch.setenv("BIDMATE_QUERY_EXPANSION_MAX_TOKENS", "not-an-int")
+
+    HyDEExpander().expand("질의", plan={})
+    assert seen["max_tokens"] == DEFAULT_MAX_TOKENS
+
+
+def test_hyde_expander_fallback_reason_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """긴 예외 메시지는 ``fallback_reason`` 에서 본문 120자로 truncate 된다
+    (meta 가 비대해지지 않도록 — ``str(exc)[:120]``)."""
+    def boom(**_: object) -> str:
+        raise RuntimeError("X" * 500)
+
+    monkeypatch.setattr("rag_query_expansion._call_anthropic_hyde", boom)
+
+    _, meta = HyDEExpander().expand("질의", plan={})
+    assert meta["fell_back"] is True
+    reason = meta["fallback_reason"]
+    assert reason.startswith("backend_error:RuntimeError:")
+    assert "X" * 120 in reason  # exactly 120 chars of the message survive
+    assert "X" * 121 not in reason


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_query_expansion.default_expander` 의 graceful-degradation 분기와 `Identity/HyDEExpander` 의 never-raise meta 계약 중, 기존 6개 테스트가 덮지 않는 미커버 경로를 12개 단위 테스트로 고정한다. eval/config.yaml 의 `query_expansion` 값 오타(빈 문자열·정수·불리언·우발적 공백)가 retrieval 을 crash 시키지 않고 identity 로 degrade 하는 ADR 0023 계약이 회귀 시 조용히 깨질 수 있어, 그 분기를 명시 고정한다.

## 2. 영향 파일

- `tests/test_query_expansion_protocol.py` (+182, test-only) — 코드 변경 0

## 3. 리스크

낮음 — test-only. `rag_query_expansion.py` 동작·계약(ADR 0023) 무수정, ADR 0001 baseline 불변. 신규 테스트는 monkeypatch 로 `_call_anthropic_hyde` 를 대체해 SDK/network 미사용.

## 4. 테스트

- `python3 -m pytest tests/test_query_expansion_protocol.py -q` → **18 passed** (기존 6 + 신규 12)
- code-reviewer APPROVE: mutation test 로 5개 핵심 경로(strip / ctor-vs-env precedence / ValueError-비크래시 / `[:120]` 경계 / fresh-instance) 전부 falsifiable 입증 (non-vacuous), 기존 6개와 비중복, mock 시그니처 호환 확인, ruff clean, env 누출 0

커버한 미커버 분기:
- `default_expander`: None-값 / 빈·공백 문자열 / 주변공백+대문자 strip / non-string `str()` 강제 / fresh instance
- `IdentityExpander`: meta 6키 완전성(`==` dict) + plan 무시 passthrough + empty query
- `HyDEExpander`: 응답 strip 반환 + `expanded_length` 갱신 / `model`·`max_tokens` override precedence / `fallback_reason` `[:120]` truncate

## 5. Eval 영향

없음 — test-only, retrieval 동작 무변경. `rag_query_expansion.py` 미수정이라 real-eval 델타 해당 없음. ADR 0001 naive_baseline / ADR 0023 HyDE 계약 모두 무수정.

## 6. 하위 호환

N/A — 테스트 추가만. 기존 6개 테스트·공개 API 무변경.

## 7. 범위 외

- `_call_anthropic_hyde` live Anthropic SDK/network 경로 (monkeypatch 로 대체, 기존 패턴 유지)
- 기존 테스트(line 76/100)의 Pyright "not accessed" 진단 — 본 PR 범위 밖(별도 cleanup 대상)

Closes #2132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
