### PR TITLE
docs: mark extended HTML review board plan complete

### DIFF
--- a/docs/plans/T-2026-0012-extended-html-review-boards.md
+++ b/docs/plans/T-2026-0012-extended-html-review-boards.md
@@ -1,12 +1,12 @@
 # Plan: T-2026-0012 Extended HTML Review Boards
 
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0012`
-- Related issue / PR: [#1522](https://github.com/hskim-solv/BidMate-DocAgent/issues/1522)
+- Related issue / PR: [#1522](https://github.com/hskim-solv/BidMate-DocAgent/issues/1522) / [#1523](https://github.com/hskim-solv/BidMate-DocAgent/pull/1523); refresh issue [#2142](https://github.com/hskim-solv/BidMate-DocAgent/issues/2142)
 - Related ADR: N/A - no decision-level change
 - Created: 2026-05-26
-- Last updated: 2026-05-26
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -163,15 +163,15 @@ navigation, not introduce a new measurement surface.
 ## Session Handoff - 2026-05-26 00:00 KST
 
 - Role: Implementer
-- Branch / worktree: chore/issue-1522-extended-html-boards / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
-- Issue / PR: #1522 / TBD
+- Branch / worktree: chore/issue-1522-extended-html-boards / PR #1523
+- Issue / PR: #1522 / #1523; refresh issue #2142
 - Task: T-2026-0012
-- Current status: implemented and validated; PR pending.
+- Current status: merged in PR #1523; queue marks T-2026-0012 done.
 - Files touched: scripts/render_priority_review_boards.py, tests/test_render_priority_review_boards.py, tasks/queue.md, docs/plans/T-2026-0012-extended-html-review-boards.md
 - Decisions made: extend the existing renderer to twenty-five boards.
 - Commands run: gh issue create; git switch; python3 -m pytest tests/test_render_priority_review_boards.py -q; python3 -m py_compile scripts/render_priority_review_boards.py; python3 scripts/render_priority_review_boards.py; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch; browser smoke via http://127.0.0.1:8765
 - Results: twenty-five local HTML boards generated; focused tests, py_compile, doc links, diff check, branch check, and browser smoke pass.
-- Next safe command: gh pr create
+- Next safe command: git status --short
 - Open questions: none
 - Risks: generated HTML files are ignored and must be regenerated in each checkout.
 ```


### PR DESCRIPTION
## §1 Summary
- Mark the completed T-2026-0012 extended HTML review board plan as `done` after merged PR #1523.
- Replace stale `#1522 / TBD` / “PR pending” handoff wording with the completed queue state.

## §2 Issue
Closes #2142

## §3 Changes
- Updated `docs/plans/T-2026-0012-extended-html-review-boards.md` only.
- No renderer code, tests, generated HTML, queue entries, eval artifacts, or reports changed.

## §4 Tests
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0012-extended-html-review-boards.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## §5 Eval impact
- Documentation-only completed-plan metadata refresh.
- No eval surface, metric update, private eval run, or performance claim.
- Extended HTML boards remain navigation surfaces, not a new measurement surface.

## §6 Overlap / multi-agent safety
- Started from latest `origin/main` in a separate worktree: `.codex/worktrees/issue-2142-extended-html-review-board-plan`.
- Issue #1522 is closed and PR #1523 is merged.
- Same-file open PR scan before editing: none for `docs/plans/T-2026-0012-extended-html-review-boards.md`.
- Active/dirty worktree same-file scan before editing: none.
- Rechecked same-file open PR scan before push: none.
- Rebased on latest `origin/main` before push; branch head is `0e547b7`.

## §7 Notes / risks
- Docs-only change; no renderer behavior or generated board artifact changed.
- Push hook reported only existing orphan worktree warnings; no branch deletion or worktree cleanup was performed.
