### PR TITLE
eval: rerun context packing screening on page-aware v2 index

### DIFF
--- a/docs/evaluation/real100_v2-context-packing.md
+++ b/docs/evaluation/real100_v2-context-packing.md
@@ -1,15 +1,10 @@
 # real100_v2 Context Packing Experiment
 
-> Invalidated for optimization claims by `T-2026-0047`: this screening used a
-> hashing-backed `real100_v2` index with 0.0 chunk page metadata coverage. Do
-> not use its `latency_regression` result as context-packing evidence until
-> rerun on a MiniLM page-aware v2 index.
-
 This report is aggregate-only. It contains no raw case prompts, generated responses, evidence text, filenames, local paths, document identifiers, chunk identifiers, or per-case rows. Legacy `real100`, v1, 221, and kordoc evidence is not used.
 
 ## Decision
 
-- Overall classification: `latency_regression`
+- Overall classification: `no_material_change`
 - Selected variant: `-`
 - Paired delta valid: `False`
 - Subset run: `True`
@@ -20,8 +15,8 @@ This report is aggregate-only. It contains no raw case prompts, generated respon
 
 | Variant | Accuracy | Groundedness | Citation precision | Claim alignment | Token status | p95 ms | Classification |
 |---|---:|---:|---:|---:|---|---:|---|
-| control_context_default | 0.0000 | 0.6667 | 0.0000 | 0.8333 | not_observable_from_prediction_diagnostics | 46589.6620 | control |
-| context_evidence_first | 0.0000 | 0.6667 | 0.0000 | 0.8333 | not_observable_from_prediction_diagnostics | 12946.1880 | latency_regression |
+| control_context_default | 0.0000 | 1.0000 | 0.0000 | 0.8333 | not_observable_from_prediction_diagnostics | 11495.4450 | control |
+| context_evidence_first | 0.0000 | 1.0000 | 0.0000 | 0.8333 | not_observable_from_prediction_diagnostics | 4119.8960 | no_material_change |
 
 ## Notes
 

--- a/docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
+++ b/docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md
@@ -3,10 +3,10 @@
 - Status: review
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0033`
-- Related issue / PR: plan [#1638](https://github.com/hskim-solv/BidMate-DocAgent/issues/1638), implementation [#1641](https://github.com/hskim-solv/BidMate-DocAgent/issues/1641) / PR TBD
+- Related issue / PR: plan [#1638](https://github.com/hskim-solv/BidMate-DocAgent/issues/1638), implementation [#1641](https://github.com/hskim-solv/BidMate-DocAgent/issues/1641), page-aware rerun [#2149](https://github.com/hskim-solv/BidMate-DocAgent/issues/2149) / PR TBD
 - Related ADR: [ADR 0003](../adr/0003-structured-answer-citation-contract.md), [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0054](../adr/0054-conditional-on-answer-scorer-semantics.md)
 - Created: 2026-05-28
-- Last updated: 2026-05-28
+- Last updated: 2026-06-04
 
 ## Problem Statement
 
@@ -133,6 +133,21 @@ Expected evidence:
   latency/cost, and privacy checks pass.
 - Explicitly not validated, with reason: no paired full-run delta because the
   implementation run is a 3-case screening artifact.
+
+
+## Session Handoff - 2026-06-04 07:32 KST
+
+- Role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Lifecycle stage: review
+- Branch / worktree: `eval/issue-2149-t2026-0033-context-packing-pageaware` / `.codex/worktrees/issue-2149-t2026-0033-context-packing-pageaware`
+- Issue / PR: page-aware rerun issue #2149 / PR TBD
+- Task: T-2026-0033 page-aware rerun
+- Current status: 3-case `real100_v2` context-packing screening rerun against `data/index/real100_v2_checkpoint_minilm_pageaware`; evidence-first remains unselected and is classified `no_material_change`, not a winner.
+- Files touched: `reports/real100_v2/context_packing.aggregate.json`, `docs/evaluation/real100_v2-context-packing.md`, `docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md`.
+- Decisions made: remove the old hashing-index invalidation banner only after rerunning on the MiniLM page-aware checkpoint; do not update `tasks/queue.md` in this PR because other active sessions currently own that file.
+- Eval surface: private `real100_v2`, aggregate-only 3-case screening; no full paired delta and no headline improvement claim.
+- Validation evidence: focused context-packing tests passed; local private screening completed; follow-up validation commands are recorded in the PR.
+- Open risks: subset-only result; cost telemetry remains not observable from prediction diagnostics.
 
 ## Rollback Strategy
 

--- a/reports/real100_v2/context_packing.aggregate.json
+++ b/reports/real100_v2/context_packing.aggregate.json
@@ -1,23 +1,23 @@
 {
   "decision": {
-    "overall_classification": "latency_regression",
+    "overall_classification": "no_material_change",
     "selected_variant": null,
     "variants": [
       {
         "classifications": [
-          "latency_regression"
+          "no_material_change"
         ],
         "deltas_vs_control": {
           "citation_worst": 0.0,
-          "latency_p95_ms": -33643.473999999995,
+          "latency_p95_ms": -7375.548999999998,
           "response_quality_best": 0.0
         },
         "name": "context_evidence_first",
-        "primary_classification": "latency_regression"
+        "primary_classification": "no_material_change"
       }
     ]
   },
-  "generated_at_utc": "2026-05-28T04:47:51.187239+00:00",
+  "generated_at_utc": "2026-06-03T22:32:07.231272+00:00",
   "known_limits": [
     "This is aggregate-only private-local measurement, not a global response quality improvement claim.",
     "Legacy real100, v1, 221, and kordoc evidence is not used."
@@ -30,10 +30,10 @@
   "privacy_boundary": "aggregate_only_no_private_payloads_ids_paths_or_filenames",
   "profile_type": "private_real100_v2_context_packing",
   "provenance": {
-    "eval_config_sha256": "168147eb51a599161733524bd11d515f15a4d2fe2085c81a4c68a4da133687ef",
-    "git_commit": "8f7a124abf81",
-    "git_dirty": true,
-    "index_fingerprint_sha256": "7ddb84e3cf430e4de3dcb994fa3c5f3b10622d5d77780d32d23a5ee7e761a277",
+    "eval_config_sha256": "be6e5dc606418192506f219aa8725de6d12b460e7a97d8218d175ce175aad50b",
+    "git_commit": "ba5bdbe8bce5",
+    "git_dirty": false,
+    "index_fingerprint_sha256": "c505c2e5eca74b4cd4644f1e996f5ec008de51d98de0f7ec0db0ff8126d38bc4",
     "input_labels": {
       "config": "external_private_real100_v2_config",
       "index": "external_private_real100_v2_index",
@@ -66,13 +66,13 @@
         },
         "latency_ms": {
           "count": 3,
-          "p50": 10425.43,
-          "p95": 46589.662
+          "p50": 2366.79,
+          "p95": 11495.444999999998
         },
         "response_quality": {
           "accuracy": 0.0,
-          "answer_format_compliance": 0.6666666666666666,
-          "groundedness": 0.6666666666666666
+          "answer_format_compliance": 0.0,
+          "groundedness": 1.0
         },
         "token_cost": {
           "cost_estimate_usd_mean": null,
@@ -102,13 +102,13 @@
         },
         "latency_ms": {
           "count": 3,
-          "p50": 12583.02,
-          "p95": 12946.188000000002
+          "p50": 3550.52,
+          "p95": 4119.896
         },
         "response_quality": {
           "accuracy": 0.0,
-          "answer_format_compliance": 0.6666666666666666,
-          "groundedness": 0.6666666666666666
+          "answer_format_compliance": 0.0,
+          "groundedness": 1.0
         },
         "token_cost": {
           "cost_estimate_usd_mean": null,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0033 context-packing screening evidence was still marked invalid because it came from a hashing/page-blind `real100_v2` index. This reruns the same aggregate-only 3-case screening on the local MiniLM page-aware v2 checkpoint, refreshes the committed aggregate/report, and records a non-overlap handoff without touching `tasks/queue.md` because other active sessions currently change that file.

Closes #2149

## 2. 영향 파일

- `reports/real100_v2/context_packing.aggregate.json` — aggregate-only private `real100_v2` context-packing screening refresh.
- `docs/evaluation/real100_v2-context-packing.md` — reviewer-facing aggregate summary refresh.
- `docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md` — issue #2149 handoff and non-overlap note.

## 3. 리스크

- Risk: subset-only private screening could be overclaimed as a full optimization result.
  - Mitigation: report keeps `paired_delta_valid=false`, `subset_run=true`, selected variant `null`, and plan notes no full paired delta/headline improvement claim.
- Risk: private payload/path leakage in committed artifacts.
  - Mitigation: runner privacy checks, `make real-eval-v2-guard`, `privacy-audit-output`, and aggregate/report inspection keep outputs aggregate-only/redacted.
- Risk: cross-session overlap.
  - Mitigation: pre-commit scan found no open PR or worktree same-file hits for the three touched files; `tasks/queue.md`, `.gitignore`, and `.githooks/pre-commit` were deliberately left untouched due active worktree ownership.

## 4. 테스트

- `python3 -m py_compile scripts/run_real100_v2_context_packing_experiment.py`
- `python3 -m pytest -q tests/test_real100_v2_context_packing_experiment.py`
- `python3 scripts/run_real100_v2_context_packing_experiment.py --config <root real100_v2 config> --index-dir <root page-aware MiniLM index> --cases-subset-n 3 --variant evidence_first`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0033-context-packing-citation-ordering-experiment.md docs/evaluation/real100_v2-context-packing.md reports/real100_v2/README.md`
- `make real-eval-v2-guard`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

Private `real100_v2` aggregate-only evidence changed: `context_packing.aggregate.json` now reflects a 3-case screening on the MiniLM page-aware checkpoint instead of the invalidated hashing/page-blind artifact. This is not a runtime behavior change and not a headline performance claim; evidence-first remains unselected with overall classification `no_material_change` and no full paired delta.

## 6. 하위 호환

No runtime contract, CLI flag, answer schema, or doc-link compatibility change. ADR 0003 answer schema remains unchanged; report schema remains additive/current aggregate evidence only.

## 7. 범위 외

- No `tasks/queue.md` status update because active Claude/Codex worktrees currently change that file.
- No `.gitignore` or `.githooks/pre-commit` edits for the same non-overlap reason.
- No full 300-case paired rerun.
- No promotion of `evidence_first` context packing.
