### PR TITLE
docs: mark T-2026-0071 maintainer gated

### DIFF
--- a/docs/plans/T-2026-0071-p22-autonomous-merge-orchestration.md
+++ b/docs/plans/T-2026-0071-p22-autonomous-merge-orchestration.md
@@ -1,12 +1,18 @@
 # Plan: T-2026-0071 (P2.2) Staging self-ship autonomous merge orchestration
 
-- Status: proposed
+- Status: blocked
 - Owner role: Planner (this doc) → Implementer → Security Reviewer → Deep Reviewer → Reviewer
 - Related task: `tasks/queue.md::T-2026-0071`
-- Related issue / PR: issue [#1703](https://github.com/hskim-solv/BidMate-DocAgent/issues/1703) (P2.2 SSoT); this plan PR closes [#1707](https://github.com/hskim-solv/BidMate-DocAgent/issues/1707); builds on PR #1698 (D-minus), #1700 (codex-gate), #1702 (AR3 CODEOWNERS)
+- Related issue / PR: closed issue [#1703](https://github.com/hskim-solv/BidMate-DocAgent/issues/1703) (P2.2 SSoT); this plan PR closes [#1707](https://github.com/hskim-solv/BidMate-DocAgent/issues/1707); maintenance-gate refresh [#2152](https://github.com/hskim-solv/BidMate-DocAgent/issues/2152); builds on PR #1698 (D-minus), #1700 (codex-gate), #1702 (AR3 CODEOWNERS)
 - Related ADR: [0088](../adr/0088-opt-in-staging-self-ship-external-enforcement.md), [0090](../adr/0090-activate-staging-self-ship-lane-live-enforcement.md), [0091](../adr/0091-constitutional-guard-codeowners-trusted-signal.md) — all currently `proposed`. P2.2 needs **1 new ADR + 1 ADR 0090 amendment** (see Architecture Impact).
 - Created: 2026-06-01
-- Last updated: 2026-06-01
+- Last updated: 2026-06-04
+
+> Current status (2026-06-04): this plan is **not** an automatic
+> implementation-ready lane. Issue #1703 and the P2.2 follow-up set are closed,
+> but remaining work is gated on maintainer decisions, ADR reservation, and an
+> operator/live integration window. Resume only as a single-writer lane after
+> those gates are explicitly satisfied.
 
 > NOTE: ADR/issue numbers for the implementation PRs are NOT reserved by this plan. Reserve at ship time (`ls docs/adr/` + `gh pr list --search "ADR" --state open`). Inside this doc they appear as `ADR 00XX (reserve)`.
 
@@ -304,4 +310,4 @@ P2.2 security-critical 작업은 **단일 writer lane**으로 진행해야 한�
 3. **manifest seam** — PR-4(live merge)와 병합.
 4. **live merge e2e** — integration 레인 운영 시점 (Gate-3 한계: 워크플로 `autopilot/**` 전용).
 
-다음 안전 명령: ADR 0093+ 번호 예약(`ls docs/adr/` + `gh pr list --search ADR --state open`) 후 PR-1/PR-2(offline-testable, branch-protection 무의존)부터. **병렬 worktree agent 금지 — 단일 writer lane** (#1719 교훈, 위 §).
+다음 안전 명령: maintainer가 위 Open Questions 4건을 먼저 결정하고 integration 운영 창을 승인한 뒤, ADR 0093+ 번호 예약(`ls docs/adr/` + `gh pr list --search ADR --state open`)으로 재개한다. **병렬 worktree agent 금지 — 단일 writer lane** (#1719 교훈, 위 §).


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0071의 issue #1703과 후속 3건은 이미 닫혔지만 plan header는 여전히 `proposed`라 다음 세션이 P2.2를 자동 구현-ready로 오해할 수 있었습니다. 같은 파일 충돌이 없는 plan 문서만 갱신해 현재 상태를 maintainer/ops gated로 명확히 하고, `tasks/queue.md`는 다른 활성 worktree와 겹쳐 의도적으로 건드리지 않았습니다.

Closes #2152

## 2. 영향 파일

- `docs/plans/T-2026-0071-p22-autonomous-merge-orchestration.md` — status/header/current-status note and next-safe-command wording.

## 3. 리스크

- Risk: queue row still says ready while plan says blocked.
  - Mitigation: PR explicitly documents why `tasks/queue.md` is out of scope: active Claude/Codex worktrees currently change it.
- Risk: staging self-ship implementation guidance is accidentally changed.
  - Mitigation: no code, ADR, runbook, or task stack semantics changed; only header/current-state and next-safe-command wording were updated.
- Risk: cross-session overlap.
  - Mitigation: pre-commit scan found no open PR or worktree same-file hits for the touched plan file.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0071-p22-autonomous-merge-orchestration.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `N/A`: docs-only staging self-ship plan status refresh. No RAG/eval/runtime behavior changed and no private eval evidence changed.

## 6. 하위 호환

No CLI, schema, runtime, ADR, or doc-link contract change. This only prevents premature implementation by clarifying current plan gates.

## 7. 범위 외

- `tasks/queue.md` update deferred because active worktrees currently change it.
- No staging self-ship code or ADR edits.
- No ADR number reservation.
