### PR TITLE
docs: refresh XYZ parallelism plan status

### DIFF
--- a/docs/plans/xyz-parallelism-stack.md
+++ b/docs/plans/xyz-parallelism-stack.md
@@ -1,12 +1,19 @@
 # Plan: T-2026-0074 XYZ parallelism stack — 3-level 병렬화(X task-pool × Y omc multi-worker × Z roles) + 동시성 안전 substrate
 
-- Status: proposed
+- Status: running
 - Owner role: Planner
 - Related task: `tasks/queue.md::T-2026-0074`
-- Related issue / PR: #1762
+- Related issue / PR: closed scaffold issue #1762; status refresh #2156; implementation PR-D #1815, PR-E1 #1821, PR-E2 #1823
 - Related ADR: [ADR 0094](../adr/0094-concurrency-substrate-for-parallel-loop.md) (동시성 안전 substrate), [ADR 0095](../adr/0095-task-parallel-bounded-loop.md) (task-level 병렬 X + omc multi-worker Y)
 - Created: 2026-06-02
-- Last updated: 2026-06-02
+- Last updated: 2026-06-04
+
+> Current status (2026-06-04): PR-0 scaffolding, PR-D omc multi-worker, PR-E1
+> per-task path substrate, and PR-E2 dark X=1 task-pool substrate are on `main`.
+> The next implementation step remains PR-E3: remove the dark clamp, enable
+> real X>1 fan-out, and harden lease/artifact reconciliation. `tasks/queue.md`
+> is intentionally not updated in this refresh because active worktrees
+> currently own that file.
 
 ## Problem Statement
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0074 XYZ parallelism plan header still described the stack as PR-0 `proposed`, even though PR-D, PR-E1, and PR-E2 are already on `main`. This refreshes the non-overlapping plan file so the current state points future agents at PR-E3 instead of rediscovering or re-running landed substrate work.

Closes #2156

## 2. 영향 파일

- `docs/plans/xyz-parallelism-stack.md` — status/header/current-status note only.

## 3. 리스크

- Risk: queue row remains `ready` while plan now says `running`.
  - Mitigation: `tasks/queue.md` is explicitly out of scope because active Claude/Codex worktrees currently change it.
- Risk: implementation scope accidentally changes.
  - Mitigation: no code, ADR, queue, or runbook edits; this is a single plan-file docs/status refresh.
- Risk: cross-session overlap.
  - Mitigation: pre-commit scan found no open PR or worktree same-file hits for `docs/plans/xyz-parallelism-stack.md`.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/xyz-parallelism-stack.md`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- After concurrent main update: `python3 scripts/check_doc_links.py --check-all --paths docs/plans/xyz-parallelism-stack.md`; `git diff --check`; `make check-branch`

## 5. Eval 영향

All `N/A`: docs-only plan status refresh. No RAG/eval/runtime behavior changed and no private eval evidence changed.

## 6. 하위 호환

No CLI, schema, runtime, ADR, or doc-link contract change. The plan now more accurately routes the next implementation step to PR-E3.

## 7. 범위 외

- `tasks/queue.md` update deferred due active worktree overlap.
- No `agent_loop.py`, ADR, or runbook edits.
- No implementation of PR-E3.
