### PR TITLE
test(answer): rag_answer 순수 포맷 helper(claim_target/citation_label/currency) 커버리지

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -1,0 +1,103 @@
+"""Unit coverage for rag_answer.py pure format helpers (issue #2155).
+
+rag_answer.py 의 순수 포맷 helper 가 직접 테스트 0 (기존
+``test_answer_contract_snapshot`` / ``test_answer_status_reason_enum`` 은
+답변 dict 계약·enum 만 커버). 이 파일은 외부 의존이 없는 3개 포맷 함수의
+RFP 도메인 계약을 고정한다:
+
+- ``claim_target``: agency→title→doc_id→"unknown" fallback chain
+- ``citation_label``: page_span 포맷 (None / basis prefix / single vs range)
+- ``format_metadata_claim_value``: budget 한국 통화 포맷
+
+``best_sentence`` / ``sentence_has_verification_topic`` 등
+``verification_topics`` / ``sentence_split`` / ``tokenize`` 의존 helper 는
+범위 외 (follow-up).
+"""
+from __future__ import annotations
+
+from rag_answer import (
+    citation_label,
+    claim_target,
+    format_metadata_claim_value,
+)
+
+
+# --- claim_target: agency → title → doc_id → "unknown" fallback chain ---
+
+
+def test_claim_target_prefers_agency() -> None:
+    assert (
+        claim_target({"agency": "행정안전부", "title": "T", "doc_id": "d"})
+        == "행정안전부"
+    )
+
+
+def test_claim_target_falls_back_to_title_then_doc_id() -> None:
+    assert claim_target({"title": "사업명", "doc_id": "d"}) == "사업명"
+    assert claim_target({"doc_id": "rfp-001"}) == "rfp-001"
+
+
+def test_claim_target_empty_item_is_unknown() -> None:
+    assert claim_target({}) == "unknown"
+
+
+def test_claim_target_skips_falsy_fields_in_chain() -> None:
+    """빈 문자열/None 은 falsy → or chain 이 다음 후보로 넘어간다."""
+    assert claim_target({"agency": "", "title": "T"}) == "T"
+    assert claim_target({"agency": None, "title": None, "doc_id": "d"}) == "d"
+
+
+def test_claim_target_coerces_to_str() -> None:
+    assert claim_target({"agency": 123}) == "123"
+
+
+# --- citation_label: page_span 포맷 ---
+
+
+def test_citation_label_none_when_no_page_span() -> None:
+    assert citation_label("source_pdf", None) is None
+    assert citation_label("source_pdf", []) is None
+
+
+def test_citation_label_basis_prefix() -> None:
+    assert (
+        citation_label("libreoffice_converted_pdf", [3, 3])
+        == "LibreOffice 변환 PDF p.3"
+    )
+    assert citation_label("source_pdf", [3, 3]) == "원본 PDF p.3"
+    # 알 수 없는 basis → 기본 "PDF"
+    assert citation_label("something_else", [3, 3]) == "PDF p.3"
+
+
+def test_citation_label_single_vs_range_page() -> None:
+    assert citation_label("source_pdf", [7, 7]) == "원본 PDF p.7"  # single
+    assert citation_label("source_pdf", [3, 5]) == "원본 PDF pp.3-5"  # range
+
+
+# --- format_metadata_claim_value: budget 한국 통화 포맷 ---
+
+
+def test_format_budget_int_thousands_separator() -> None:
+    assert format_metadata_claim_value("budget", 1000000) == "1,000,000원"
+    assert format_metadata_claim_value("budget", 0) == "0원"
+
+
+def test_format_budget_integer_float_drops_decimals() -> None:
+    """정수값 float(예: 1000.0)은 int 로 변환되어 소수점 없이 표시."""
+    assert format_metadata_claim_value("budget", 1000.0) == "1,000원"
+
+
+def test_format_budget_decimal_float_keeps_two_decimals() -> None:
+    assert format_metadata_claim_value("budget", 1234.5) == "1,234.50원"
+    assert format_metadata_claim_value("budget", 1234.56) == "1,234.56원"
+
+
+def test_format_budget_non_numeric_passthrough() -> None:
+    """budget 이라도 비-숫자값은 str() passthrough (예: '비공개')."""
+    assert format_metadata_claim_value("budget", "비공개") == "비공개"
+
+
+def test_format_non_budget_key_is_str() -> None:
+    """budget 이 아닌 키는 통화 포맷 없이 str()."""
+    assert format_metadata_claim_value("duration", 12) == "12"
+    assert format_metadata_claim_value("agency", "행안부") == "행안부"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_answer.py` 의 외부 의존 0 순수 포맷 helper 3개가 직접 테스트 0이었다(기존 `test_answer_contract_snapshot`/`test_answer_status_reason_enum` 은 답변 dict 계약·enum 만 커버). RFP 도메인 계약(인용 표기·한국 통화)을 13개 단위 테스트로 고정한다.

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` (신규 +103, test-only) — `rag_answer.py` 무수정

## 3. 리스크

낮음 — test-only. `rag_answer.py` 동작 무수정. import 부작용 0(code-reviewer 확인: torch/chromadb/transformers 0 로드, 0.02s), ADR 0001 baseline 무영향.

## 4. 테스트

- `python3 -m pytest tests/test_answer_format_helpers.py -q` → **13 passed** (0.09s)
- code-reviewer APPROVE: 22 assertion 을 모듈 함수로 in-vivo 재현 0-FAIL, **currency `is_integer()` 분기 경계**(1000.0→"1,000원" vs 1234.5→"1,234.50원" `.2f` pad) + **claim_target or-chain falsy skip**(빈문자열/None 타입별) non-vacuous 확인, import 부작용 0

커버 helper:
- `claim_target` — `agency→title→doc_id→"unknown"` fallback chain + `str()` 강제
- `citation_label` — page_span None/`[]`→None, basis prefix(`LibreOffice 변환 PDF`/`원본 PDF`/`PDF`), single(`p.N`) vs range(`pp.N-M`)
- `format_metadata_claim_value` — `budget` 통화(int `{:,}원` / integer-float→`int()` / decimal-float `{:,.2f}원` / non-numeric·non-budget→`str()`)

## 5. Eval 영향

없음 — test-only, `rag_answer.py` 미수정이라 답변 생성 동작 무변경. real-eval 델타 해당 없음.

## 6. 하위 호환

N/A — 테스트 추가만.

## 7. 범위 외

- `best_sentence` / `sentence_has_verification_topic` / `metadata_field_requested` / `metadata_claim_sentences` — `verification_topics`/`sentence_split`/`tokenize` 무거운 의존 → follow-up
- **follow-up 후보** (code-reviewer LOW, prod 도달 불가 + 코드 변경 필요라 본 PR 범위 밖): `format_metadata_claim_value("budget", True)` 가 `bool` 의 int-서브클래스성으로 `"1원"` 반환(`and not isinstance(value, bool)` 가드 검토), `citation_label(_, [3])` 단일 원소 page_span 이 `IndexError`(호출처 `normalize_page_span` 이 2-원소 보장하나 helper 자체 방어 부재)

Closes #2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)
