### PR TITLE
test(html-report): lock escaping contracts

### DIFF
--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,50 @@
+from scripts.html_report import (
+    html_text,
+    render_badge,
+    render_document,
+    render_status_card,
+    render_table,
+)
+
+
+def test_html_text_escapes_element_and_attribute_characters() -> None:
+    assert html_text("<tag attr='x'>&\"") == "&lt;tag attr=&#x27;x&#x27;&gt;&amp;&quot;"
+
+
+def test_badge_escapes_label_and_falls_back_to_neutral_tone() -> None:
+    html = render_badge("<script>alert('x')</script>", tone="unexpected")
+
+    assert 'class="badge neutral"' in html
+    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in html
+    assert "<script>" not in html
+
+
+def test_status_card_escapes_fields_and_preserves_known_tone() -> None:
+    html = render_status_card("A&B", "<5", detail="'quoted'", tone="danger")
+
+    assert 'class="status-card danger"' in html
+    assert "A&amp;B" in html
+    assert "&lt;5" in html
+    assert "&#x27;quoted&#x27;" in html
+
+
+def test_table_escapes_headers_rows_and_empty_message() -> None:
+    empty = render_table(["A&B", "C"], [], empty_message="<none>")
+    rows = render_table(["A"], [["<cell>"]])
+
+    assert 'colspan="2"' in empty
+    assert "A&amp;B" in empty
+    assert "&lt;none&gt;" in empty
+    assert "&lt;cell&gt;" in rows
+    assert "<cell>" not in rows
+
+
+def test_document_escapes_shell_fields_and_embeds_prebuilt_body() -> None:
+    body = '<section class="panel"><p>prebuilt body</p></section>'
+    html = render_document(title="<Title>", subtitle="A&B", body=body, footer="'footer'")
+
+    assert "<title>&lt;Title&gt;</title>" in html
+    assert "<h1>&lt;Title&gt;</h1>" in html
+    assert "A&amp;B" in html
+    assert body in html
+    assert "&#x27;footer&#x27;" in html


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/html_report.py` is a shared leaf helper used by multiple reviewer/report renderers, but its escaping/tone/table/document-wrapper contract did not have a direct focused test file. This adds characterization coverage without changing the helper implementation.

Closes #2159

## 2. 영향 파일

- `tests/test_html_report.py` — focused tests for shared HTML helper escaping, tone fallback, table empty-state rendering, and wrapper field escaping.

## 3. 리스크

- Risk: tests overfit incidental formatting.
  - Mitigation: assertions target contract-level behavior: escaping, safe tone fallback, empty-table colspan, and body passthrough boundary.
- Risk: cross-session overlap.
  - Mitigation: open PR/worktree scan found no same-file hits for `scripts/html_report.py` or `tests/test_html_report.py`.

## 4. 테스트

- `python3 -m pytest -q tests/test_html_report.py`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `N/A`: test-only helper contract coverage. No RAG/eval/runtime behavior changed.

## 6. 하위 호환

No implementation or public interface change.

## 7. 범위 외

- No changes to `scripts/html_report.py`.
- No full test suite; focused helper coverage only.
