### PR TITLE
fix(retrieval): embed_query_for_index ST·openai 실패 시 raise (silent hashing fallback이 #784 가드 우회 + ADR 0061 위반)

### DIFF
--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -64,6 +64,7 @@ from typing import Any, Iterable
 
 import numpy as np
 
+from bidmate_data_boundary import ExternalPayloadBlocked
 from korean_lexicon import BM25_EXTRA_PARTICLE_SUFFIXES, BM25_EXTRA_STOPWORDS
 from rag_embedding import (
     DEFAULT_EMBEDDING_MODEL,
@@ -710,13 +711,45 @@ def embed_query_for_index(query: str, embedding_config: dict[str, Any]) -> np.nd
                 backend="sentence-transformers",
                 local_only=True,
             ).vectors[0]
-        except Exception:
-            return hashing_embeddings([query], dimension)[0]
+        except Exception as exc:
+            # Symmetric with embed_texts' build-time raise (rag_embedding.py).
+            # A silent hashing fallback here is unsafe: DEFAULT_HASH_DIM (384)
+            # collides with the default MiniLM dimension, so the hashing query
+            # vector passes dense_similarity's #784 shape guard and corrupts
+            # retrieval ranking against an ST-built index while the API still
+            # returns a "successful" answer. Fail loud at the call site.
+            # (The openai branch below stays a never-raise external-API
+            # fallback per ADR 0061; its dimension differs so #784 still fires.)
+            raise RuntimeError(
+                f"Failed to embed query with sentence-transformers model "
+                f"{model!r}: {exc}. Refusing to fall back to a hashing query "
+                f"vector (would silently corrupt retrieval ranking against an "
+                f"ST-built index — see #784). Rebuild with "
+                f"EMBEDDING_BACKEND=hashing or ensure the ST model loads."
+            ) from exc
     if backend == "openai":
         try:
             return embed_texts([query], model_name=model, backend="openai").vectors[0]
-        except Exception:
-            return hashing_embeddings([query], dimension)[0]
+        except ExternalPayloadBlocked:
+            # ADR 0005/0061 data-boundary block (assert_external_payload_allowed
+            # in _embed_with_openai). Propagate unchanged — masking it as the
+            # generic embedding RuntimeError below would hide a boundary
+            # violation from callers that catch ExternalPayloadBlocked.
+            raise
+        except Exception as exc:
+            # ADR 0061 mandates the openai embedding backend fail-closed
+            # ("openai 임베딩만 폴백 없는 백엔드라 raise 로 fail-closed"). A
+            # hashing query vector at the configured dimension can collide with
+            # an OpenAI-built index and pass dense_similarity's #784 shape
+            # guard, silently corrupting ranking — the same defect as the
+            # sentence-transformers branch above. embed_texts' openai path is
+            # already fail-closed at build time; keep query time symmetric.
+            raise RuntimeError(
+                f"Failed to embed query with OpenAI model {model!r}: {exc}. "
+                f"Refusing to fall back to a hashing query vector (would "
+                f"silently corrupt retrieval ranking against an OpenAI-built "
+                f"index — see #784). ADR 0061 mandates this backend fail-closed."
+            ) from exc
     return hashing_embeddings([query], dimension)[0]
 
 

--- a/tests/test_embedding_backends.py
+++ b/tests/test_embedding_backends.py
@@ -159,22 +159,96 @@ class EmbedQueryForIndexOpenAITest(unittest.TestCase):
                 )
         self.assertEqual(vec.shape, (4,))
 
-    def test_openai_falls_back_to_hashing_when_sdk_missing(self) -> None:
+    def test_openai_failure_raises_instead_of_silent_hashing_fallback(self) -> None:
+        # issue #2138 — ADR 0061 mandates the openai embedding backend
+        # fail-closed ("openai 임베딩만 폴백 없는 백엔드라 raise"). A hashing
+        # query fallback at the configured dimension can collide with an
+        # OpenAI-built index and bypass dense_similarity's #784 shape guard,
+        # silently corrupting ranking. So an openai query embedding failure must
+        # raise — symmetric with the sentence-transformers branch and with
+        # embed_texts' build-time fail-closed behavior.
         import rag_core
 
         # Public-surface attestation passes the ADR 0061 ③ guard so the
-        # SDK-missing branch (not the boundary block) drives the graceful
-        # hashing fallback this test asserts (#1195).
+        # SDK-missing branch (not the boundary block) is exercised (#1195).
         with mock.patch.dict(
             os.environ, {"BIDMATE_DATA_SURFACE": "public_fixture"}, clear=False
         ), mock.patch.dict(sys.modules, {"openai": None}):
-            vec = rag_core.embed_query_for_index(
-                "안녕",
-                {"backend": "openai", "model": "text-embedding-3-large", "dimension": 8},
-            )
-        # Should silently fall back, matching the sentence-transformers branch's
-        # try/except path. Hashing returns dim=8 vectors.
-        self.assertEqual(vec.shape, (8,))
+            with self.assertRaises(RuntimeError) as ctx:
+                rag_core.embed_query_for_index(
+                    "안녕",
+                    {"backend": "openai", "model": "text-embedding-3-large", "dimension": 8},
+                )
+        msg = str(ctx.exception)
+        self.assertIn("OpenAI", msg)
+        self.assertIn("784", msg)
+
+    def test_openai_data_boundary_block_propagates_unchanged(self) -> None:
+        # ADR 0005/0061: a data-boundary violation must surface as
+        # ExternalPayloadBlocked, NOT be masked as the generic embedding
+        # RuntimeError the fix raises for other failures (issue #2138, Codex
+        # review). The query text would leave the process, so a private surface
+        # must block before any network call.
+        import rag_core
+        from bidmate_data_boundary import ExternalPayloadBlocked
+
+        with mock.patch.dict(
+            os.environ, {"BIDMATE_DATA_SURFACE": "private"}, clear=False
+        ):
+            # Hermetic: drop any approved egress override the host may export so
+            # the private-surface block is asserted deterministically (Codex
+            # review — test must not inherit BIDMATE_EGRESS_PROFILE).
+            os.environ.pop("BIDMATE_EGRESS_PROFILE", None)
+            with self.assertRaises(ExternalPayloadBlocked):
+                rag_core.embed_query_for_index(
+                    "안녕",
+                    {"backend": "openai", "model": "text-embedding-3-large", "dimension": 8},
+                )
+
+
+class EmbedQueryForIndexSentenceTransformersTest(unittest.TestCase):
+    """issue #2138 — a sentence-transformers query embedding failure must
+    raise, NOT silently fall back to a hashing vector.
+
+    ``DEFAULT_HASH_DIM`` (384) collides with the default MiniLM dimension, so a
+    hashing query vector would *pass* ``dense_similarity``'s #784 shape guard
+    and corrupt retrieval ranking against an ST-built index while the API still
+    returned a "successful" answer. The fix makes query-time symmetric with
+    ``embed_texts``' build-time raise.
+    """
+
+    def test_st_failure_raises_instead_of_silent_hashing_fallback(self) -> None:
+        import rag_core
+        import rag_embedding
+
+        rag_embedding.MODEL_CACHE.clear()
+        # Force the sentence-transformers import inside embed_texts to fail,
+        # mirroring the local BGE-M3 OOM / ST-load-failure environment.
+        with mock.patch.dict(sys.modules, {"sentence_transformers": None}):
+            with self.assertRaises(RuntimeError) as ctx:
+                rag_core.embed_query_for_index(
+                    "안녕",
+                    {
+                        "backend": "sentence-transformers",
+                        "model": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+                        "dimension": 384,
+                    },
+                )
+        msg = str(ctx.exception)
+        # Diagnostic must name the backend and reference the guard it would
+        # otherwise bypass, so the failure is actionable.
+        self.assertIn("sentence-transformers", msg)
+        self.assertIn("784", msg)
+
+    def test_hashing_backend_is_unaffected(self) -> None:
+        # ADR 0001 baseline: the default offline path (backend="hashing") never
+        # enters the sentence-transformers branch, so it stays byte-identical.
+        import rag_core
+
+        vec = rag_core.embed_query_for_index(
+            "안녕", {"backend": "hashing", "dimension": 384}
+        )
+        self.assertEqual(vec.shape, (384,))
 
 
 class _CapturingSentenceTransformer:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #2138

`embed_query_for_index`의 sentence-transformers / openai 분기가 백엔드 실패 시 조용히 hashing 벡터로 폴백했다. `DEFAULT_HASH_DIM`(384) 또는 config `dimension`이 인덱스 차원과 일치하면 hashing 쿼리벡터가 `dense_similarity`의 #784 shape 가드를 통과 → 해당 backend로 빌드한 인덱스 대비 retrieval ranking이 조용히 오염되지만 API는 "성공" 답변을 반환한다. build-time `embed_texts`는 이미 ST/openai 둘 다 fail-closed(loud raise)이므로 query-time을 대칭으로 raise로 전환. 특히 openai는 ADR 0061이 *"openai 임베딩만 폴백 없는 백엔드라 raise로 fail-closed"*를 명문화했으므로 기존 silent 폴백은 ADR 0061 위반이었다.

## 2. 영향 파일

- `rag_retrieval.py` **(load-bearing)** — `embed_query_for_index` ST·openai 분기 raise + `ExternalPayloadBlocked` import/전파
- `tests/test_embedding_backends.py` — 회귀 테스트 3종 + 기존 openai 폴백 테스트를 raise 검증으로 교체

## 3. 리스크

가장 가능성 높은 깨짐: ST/openai 인덱스를 쿼리하던 경로가 이제 백엔드 실패 시 raise → 기존에 silent 폴백 답변을 받던 호출처가 에러를 보게 됨. 배제 근거:
- CI(`pr-eval.yml`)/Dockerfile은 `EMBEDDING_BACKEND=hashing` → 이 분기 비진입(영향 0).
- 기본 오프라인 경로(`backend="hashing"`)는 분기를 안 타므로 ADR 0001 baseline byte-identical.
- silent 폴백 답변은 #784가 막으려던 corrupt ranking이었으므로 "에러로 전환"이 의도된 fix.

## 4. 테스트

변경 전 fail / 변경 후 pass 테스트 (각 mutation으로 코드 되돌리면 정확히 FAIL = non-vacuous 확인):
- `test_st_failure_raises_instead_of_silent_hashing_fallback` — ST 실패→RuntimeError(#784 언급)
- `test_openai_failure_raises_instead_of_silent_hashing_fallback` — openai 실패→RuntimeError
- `test_openai_data_boundary_block_propagates_unchanged` — 경계 차단→ExternalPayloadBlocked 전파(generic wrapping 금지, hermetic env)
- `test_hashing_backend_is_unaffected` — hashing byte-identical

overlap-preflight: `reports/agent_loop/overlap_preflight.md` (stale base 없음, embedding 경로 PR 겹침 0).

## 5. Eval 영향

> Load-bearing(`rag_retrieval.py`) 변경.

- **동작 변화**: ST/openai backend 인덱스 쿼리에서 백엔드 로드/encode 실패 시 silent hashing 폴백 → raise. **기본 hashing 경로는 무변화(byte-identical)** — 분기 비진입.
- **real-eval**: 로컬 BGE-M3 OOM으로 미실행. 변경이 hashing(기본) 경로를 안 건드리므로 fixture smoke / synthetic benchmark 수치 불변. real-eval(real100_v2)에서 ST 인덱스 쿼리 중 ST 로드 실패가 있었다면 기존엔 조용히 오염된 수치였고, 이제 raise로 표면화(측정 신뢰성 향상).
- README metric sync 무관(측정 표면 변경 없음).

## 6. 하위 호환

- 답변 계약(ADR 0003) 무관 — `schema_version` 변경 없음.
- ST/openai backend로 silent 폴백에 의존하던 호출처는 동작 변경(폴백→raise). 단 그 폴백은 corrupt ranking이라 의존 자체가 버그. 마이그레이션: ST/openai 인덱스를 쓰려면 해당 backend가 로드 가능해야 하고, 아니면 `EMBEDDING_BACKEND=hashing`로 인덱스 재빌드.

## 7. 범위 외

- openai 외 다른 never-raise 백엔드(rerank cohere, hyde, planner)는 ADR 0061대로 폴백 유지 — 폴백해도 유효 결과(원순서/원쿼리/StaticPlanner)라 corruption 아님.
- `rag_retrieval.py:295/304/613`의 기존 Pyright 경고(`Any|None` add, `_raw` unused)는 이 PR 범위 밖 — 건드리지 않음.

---
_Codex adversarial pre-commit review 3-pass self-catch: 1차 openai 분기 누락(freq 6/8, high)→openai도 raise, 2차 ExternalPayloadBlocked generic wrapping(freq 2/2, medium)→경계 전파, 3차 boundary 테스트 non-hermetic(freq 2/2, medium)→egress override 격리. 모두 같은 PR에서 반영._
