### PR TITLE
test: lock demo lane autotune output

### DIFF
--- a/tests/test_demo_lane_autotune.py
+++ b/tests/test_demo_lane_autotune.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from scripts import demo_lane_autotune as demo
+
+
+def test_demo_off_prints_inert_contract(capsys):
+    demo.demo_off()
+
+    out = capsys.readouterr().out
+
+    assert "AUTOTUNE OFF" in out
+    assert "ACTIVE_LANE_AUTOTUNE" in out
+    assert "effort_overrides : {}" in out
+    assert "recommendations  : []" in out
+    assert "cooldown_state   : {}" in out
+    assert "컨트롤러 미호출" in out
+
+
+def test_demo_on_prints_auditor_strengthen_contract(capsys):
+    demo.demo_on()
+
+    out = capsys.readouterr().out
+
+    assert "AUTOTUNE ON" in out
+    assert "agent=codex  median=10.3s" in out
+    assert "role=Auditor  agent=codex" in out
+    assert "fail_rate : 1.0 over 3 obs" in out
+    assert "direction : strengthen" in out
+    assert "effort    : high → xhigh  (actuated=True)" in out
+    assert "effort_overrides[('Auditor', 'codex')] = 'xhigh'" in out
+    assert "cooldown_state['Auditor||codex'] = 2" in out
+    assert "model_reasoning_effort=xhigh" in out


### PR DESCRIPTION
## 1. Summary
- Add a focused characterization test for `scripts/demo_lane_autotune.py`.
- Lock the OFF-path inert output and ON-path Auditor strengthen/xhigh/cooldown explanation.

## 2. Issue
Closes #2165

## 3. Changes
- Added `tests/test_demo_lane_autotune.py`.
- No runtime code changes.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_demo_lane_autotune.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — tests-only characterization; no retrieval, answer, ingestion, or eval behavior changed.

## 6. Risks / follow-ups
N/A.