### PR TITLE
test: lock kordoc manifest builder matching

### DIFF
--- a/tests/test_build_kordoc_manifest.py
+++ b/tests/test_build_kordoc_manifest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+import unicodedata
+
+from ingestion import _KORDOC_MANIFEST_SCHEMA_VERSION, _KORDOC_POSTPROCESS_VERSION
+from scripts.build_kordoc_manifest import build_manifest
+
+
+def test_build_manifest_matches_nfc_stems_and_skips_stale_cache(tmp_path, capsys):
+    source_dir = tmp_path / "files"
+    cache_dir = tmp_path / "files_kordoc"
+    source_dir.mkdir()
+    cache_dir.mkdir()
+
+    nfc_stem = unicodedata.normalize("NFC", "cafe\u0301")
+    nfd_stem = unicodedata.normalize("NFD", nfc_stem)
+    source_path = source_dir / f"{nfc_stem}.pdf"
+    source_bytes = b"private bytes are represented only by digest metadata"
+    source_path.write_bytes(source_bytes)
+    (cache_dir / f"{nfd_stem}.md").write_text("converted markdown", encoding="utf-8")
+    (cache_dir / "stale.md").write_text("stale markdown", encoding="utf-8")
+
+    manifest = build_manifest(source_dir, cache_dir)
+
+    stderr = capsys.readouterr().err
+    assert "cached .md had no matching source" in stderr
+    assert "stale.md" in stderr
+    assert manifest["schema_version"] == _KORDOC_MANIFEST_SCHEMA_VERSION
+    assert manifest["postprocess_version"] == _KORDOC_POSTPROCESS_VERSION
+    assert set(manifest["entries"]) == {nfc_stem}
+    assert manifest["entries"][nfc_stem] == {
+        "source_relpath": source_path.name,
+        "source_sha256": hashlib.sha256(source_bytes).hexdigest(),
+        "source_size": len(source_bytes),
+    }


### PR DESCRIPTION
## 1. Summary
- Add a direct characterization test for `scripts/build_kordoc_manifest.py`.
- Lock NFC-equivalent source/cache stem matching, stale cache exclusion, warning output, and digest-only manifest entry metadata.

## 2. Issue
Closes #2169

## 3. Changes
- Added `tests/test_build_kordoc_manifest.py`.
- No runtime code changes.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_build_kordoc_manifest.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — tests-only characterization; no ingestion, retrieval, answer, or eval behavior changed.

## 6. Risks / follow-ups
N/A.