### PR TITLE
test(metadata): rag_metadata_processing 정규화 헬퍼 5종 단위 커버리지

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -1,0 +1,159 @@
+"""Unit coverage for rag_metadata_processing.py normalization helpers (issue #2168).
+
+``rag_metadata_processing.py`` (479 LOC)는 직접 단위 테스트 0이었다. 이 파일은
+1차로 순수 정규화 헬퍼 5종의 동작 계약을 oracle 로 고정한다 (test-only, 소스 무수정):
+
+- ``metadata_tokens`` — TOKEN_RE + 조사 정규화 + stopword 필터
+- ``normalize_regions`` — citation region 정규화(non-dict 스킵, bbox len 가드,
+  page_number None 보존, source/type/block_id str 강제)
+- ``normalize_page_span`` — [start,end] 직접 또는 regions min/max fallback
+- ``normalize_document_sections`` — 섹션 정규화(section_id 포맷, 빈 text 스킵)
+- ``document_has_section_structure`` — 섹션 구조 유무 bool(WEAK_SECTION_HEADINGS)
+
+leaf 3종(rag_text_processing/rag_conversation_state/korean_lexicon + stdlib 만
+의존, rag_core back-edge 0 = ADR 0045 보존). matching 파이프라인(match/dedupe/ambiguity)은
+별도 concern 이라 follow-up. negative assertion 으로 정규화/필터가 실제로 일어나는지
+(non-vacuous) 못 박는다.
+"""
+from __future__ import annotations
+
+from rag_metadata_processing import (
+    document_has_section_structure,
+    metadata_tokens,
+    normalize_document_sections,
+    normalize_page_span,
+    normalize_regions,
+)
+
+
+# --- metadata_tokens ---
+
+
+def test_metadata_tokens_strips_particles_and_stopwords() -> None:
+    out = metadata_tokens("행안부 사업을 한다")
+    assert out == ["행안부", "사업", "한다"]
+    # '사업을' 의 조사 '을' 이 실제로 떨어졌다 (붙은 원형이 남지 않음)
+    assert "사업을" not in out
+
+
+def test_metadata_tokens_empty_string() -> None:
+    assert metadata_tokens("") == []
+
+
+# --- normalize_regions ---
+
+
+def test_normalize_regions_keeps_geometry_and_stringifies_ids() -> None:
+    out = normalize_regions(
+        [{"page_number": 3, "bbox": [1, 2, 3, 4], "source": "pdf", "block_id": 7}]
+    )
+    # block_id 정수가 str 로 강제됨, page_number/bbox 는 그대로
+    assert out == [
+        {"page_number": 3, "bbox": [1, 2, 3, 4], "source": "pdf", "block_id": "7"}
+    ]
+
+
+def test_normalize_regions_non_list_returns_empty() -> None:
+    assert normalize_regions("nope") == []
+    assert normalize_regions(None) == []
+
+
+def test_normalize_regions_skips_non_dict_items() -> None:
+    out = normalize_regions(["x", {"page_number": 1}, 42])
+    # 문자열/정수 항목은 버려지고 dict 만 통과
+    assert out == [{"page_number": 1, "bbox": None}]
+    assert len(out) == 1
+
+
+def test_normalize_regions_drops_malformed_bbox() -> None:
+    # bbox 길이가 4가 아니면 bbox 키 자체가 빠진다 (page_number 키 부재 → None)
+    out = normalize_regions([{"bbox": [1, 2, 3]}])
+    assert out == [{"page_number": None}]
+    assert "bbox" not in out[0]
+
+
+def test_normalize_regions_preserves_explicit_none_page() -> None:
+    out = normalize_regions([{"page_number": None, "type": "fig"}])
+    assert out == [{"page_number": None, "bbox": None, "type": "fig"}]
+
+
+# --- normalize_page_span ---
+
+
+def test_normalize_page_span_uses_explicit_pair() -> None:
+    assert normalize_page_span([5, 9], []) == [5, 9]
+
+
+def test_normalize_page_span_falls_back_to_region_min_max() -> None:
+    regions = [{"page_number": 7}, {"page_number": 3}, {"page_number": 5}]
+    assert normalize_page_span(None, regions) == [3, 7]
+
+
+def test_normalize_page_span_returns_none_without_pages() -> None:
+    out = normalize_page_span(None, [{"bbox": [1, 2, 3, 4]}])
+    assert out is None  # 페이지 정보 없으면 span 없음
+
+
+def test_normalize_page_span_ignores_wrong_length_pair() -> None:
+    # len != 2 인 value 는 직접 경로를 타지 않고 regions fallback
+    assert normalize_page_span([1, 2, 3], [{"page_number": 4}]) == [4, 4]
+
+
+# --- normalize_document_sections ---
+
+
+def test_normalize_document_sections_formats_id_and_skips_empty_text() -> None:
+    doc = {
+        "doc_id": "D1",
+        "title": "제목",
+        "agency": "행안부",
+        "sections": [
+            {"heading": "1장", "text": "본문입니다"},
+            {"heading": "", "text": ""},  # 빈 text → 스킵
+        ],
+    }
+    out = normalize_document_sections(doc)
+    assert len(out) == 1  # 빈 text 섹션 제외
+    section = out[0]
+    assert section["section_id"] == "D1::section-001"
+    assert section["section"] == "1장"
+    assert section["doc_id"] == "D1"
+    assert section["agency"] == "행안부"
+
+
+def test_normalize_document_sections_empty_when_no_sections() -> None:
+    assert normalize_document_sections({"doc_id": "D", "title": "T", "sections": []}) == []
+
+
+# --- document_has_section_structure ---
+
+
+def test_document_has_section_structure_true_for_multiple_sections() -> None:
+    doc = {
+        "doc_id": "D",
+        "title": "T",
+        "sections": [
+            {"heading": "A", "text": "x"},
+            {"heading": "B", "text": "y"},
+        ],
+    }
+    assert document_has_section_structure(doc) is True
+
+
+def test_document_has_section_structure_false_for_weak_single_heading() -> None:
+    # 단일 섹션 + WEAK_SECTION_HEADINGS('본문') → 구조 없음
+    doc = {"doc_id": "D", "title": "T", "sections": [{"heading": "본문", "text": "x"}]}
+    assert document_has_section_structure(doc) is False
+
+
+def test_document_has_section_structure_false_when_empty() -> None:
+    assert (
+        document_has_section_structure({"doc_id": "D", "title": "T", "sections": []})
+        is False
+    )
+
+
+def test_document_has_section_structure_true_for_strong_single_heading() -> None:
+    # 단일 섹션이라도 heading 이 WEAK 목록에 없으면 구조 있음
+    doc = {"doc_id": "D", "title": "T", "sections": [{"heading": "제3조 계약", "text": "x"}]}
+    assert document_has_section_structure(doc) is True


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_metadata_processing.py` (479 LOC)는 직접 단위 테스트 0이었다. 1차로 순수 정규화 헬퍼 5종(citation geometry + section structure)의 동작 계약을 17개 oracle-backed 테스트로 고정한다. matching 파이프라인은 별도 concern 이라 follow-up(one-concern).

## 2. 영향 파일

- `tests/test_metadata_normalization.py` (신규 +159, test-only) — `rag_metadata_processing.py` 무수정

## 3. 리스크

낮음 — test-only. 소스 무수정. import 격리(code-reviewer 확인: torch/chromadb/numpy/rag_core 등 무거운 back-edge 0 = ADR 0045 leaf 보존, leaf 3종 rag_text_processing/rag_conversation_state/korean_lexicon + stdlib 만 의존, import 22ms).

## 4. 테스트

- `python3 -m pytest tests/test_metadata_normalization.py -q` → **17 passed** (0.12s)
- code-reviewer APPROVE: 17/17 assertion 을 `python3 -c` oracle 로 재현해 byte 단위 일치 확인, **negative assertion 4종**을 소스 mutant 5개(조사정규화/non-dict필터/bbox가드/len가드/WEAK무시 제거)로 5/5 사살 입증(non-vacuous), 격리·중복·toolchain clean, 함수/테스트 카운트 정확

커버 함수:
- `metadata_tokens` — TOKEN_RE + 조사 정규화 + stopword 필터
- `normalize_regions` — non-dict 스킵, bbox len≠4 가드, page_number None 보존, block_id str 강제
- `normalize_page_span` — [start,end] 직접 / regions min-max fallback / len≠2 fallback / 빈→None
- `normalize_document_sections` — section_id zero-pad 포맷, 빈 text 스킵
- `document_has_section_structure` — 멀티/strong heading True, WEAK 단일/빈 False

## 5. Eval 영향

없음 — test-only, `rag_metadata_processing.py` 미수정이라 메타데이터 정규화 경로 동작 무변경. real-eval 델타 해당 없음.

## 6. 하위 호환

N/A — 테스트 추가만.

## 7. 범위 외

- matching 파이프라인: `make_metadata_target`/`match_metadata_targets`/`match_metadata_target`/`best_metadata_phrase_similarity`/`make_metadata_match`/`dedupe_metadata_matches`/`metadata_matches_for_stage`/`metadata_filters_from_matches`/`best_metadata_doc_scores`/`metadata_ambiguity_details` (difflib 유사도·다단계 매칭 = 별도 concern) → follow-up
- `fixed_parent_section`/`split_section_text`/`make_metadata_target` 등 section/target 구성 헬퍼 → follow-up

Closes #2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
