### PR TITLE
fix(answer): aggregate substring fallback 활성화 — analyze_query resolved_query 키

### DIFF
--- a/rag_query.py
+++ b/rag_query.py
@@ -379,6 +379,10 @@ def analyze_query(
         "context_entities": context_entities or [],
         "context_used": context_used,
         "tokens": tokenize(normalized_query),
+        # Substring source for _is_aggregate_query's fallback (rag_answer.py):
+        # catches aggregate signals the tokenizer merges into a compound token
+        # (tokenize("전체일정 알려줘") == ["전체일정"], dropping bare "전체"). #2170
+        "resolved_query": normalized_query,
         "metadata_matches": metadata_matches,
         "matched_doc_ids": matched_doc_ids,
         "matched_agencies": matched_agencies,

--- a/tests/test_aggregate_evidence_selection_regression.py
+++ b/tests/test_aggregate_evidence_selection_regression.py
@@ -30,6 +30,7 @@ from rag_answer import (
     _is_aggregate_query,
     select_supporting_evidence,
 )
+from rag_query import analyze_query
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +202,38 @@ class TestProbe12AggregateRegression(unittest.TestCase):
         result = select_supporting_evidence(a, ev)
         chunk_ids = [r["chunk_id"] for r in result]
         self.assertIn(self._GOLD_CHUNK_ID, chunk_ids)
+
+
+# ---------------------------------------------------------------------------
+# analyze_query end-to-end integration: guards the #2170 test-reality drift
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeQueryAggregateIntegration(unittest.TestCase):
+    """End-to-end: the *real* analyze_query output must drive _is_aggregate_query.
+
+    The pool-size tests above build the analysis dict via the ``_analysis``
+    helper, which injects a ``resolved_query`` key.  Runtime ``analyze_query``
+    previously omitted that key, so ``_is_aggregate_query``'s substring fallback
+    was dead in production while these unit tests stayed green — a mock-vs-
+    reality drift (#2170).  These tests call ``analyze_query`` directly so the
+    key contract is pinned end-to-end.
+    """
+
+    def test_analyze_query_exposes_resolved_query(self) -> None:
+        analysis = analyze_query("전체일정 알려줘", [])
+        self.assertIn("resolved_query", analysis)
+
+    def test_compound_token_aggregate_detected_end_to_end(self) -> None:
+        # tokenize("전체일정 알려줘") == ["전체일정"]: the bare signal "전체" is
+        # merged into a compound token, so token matching alone cannot fire.
+        # The substring fallback over resolved_query must still flag aggregate.
+        analysis = analyze_query("전체일정 알려줘", [])
+        self.assertNotIn("전체", analysis["tokens"])  # precondition: token path blind
+        self.assertTrue(_is_aggregate_query(analysis))
+
+    def test_plain_query_not_flagged_end_to_end(self) -> None:
+        analysis = analyze_query("사업 예산은 얼마인가", [])
+        self.assertFalse(_is_aggregate_query(analysis))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을, 왜

`_is_aggregate_query` (`rag_answer.py:538`) 의 substring fallback 이 런타임 `analyze_query` 출력에 `resolved_query` 키 부재로 영구 dead. 한국어 교착어 특성상 aggregate signal 이 복합 토큰에 병합되면 (`tokenize("전체일정 알려줘")==["전체일정"]`) token 매칭이 실패하는데 substring fallback 까지 죽어 aggregate 미감지 → evidence pool 이 5 대신 2 로 제한, 다중 필드 나열 충실도 손실 (probe_12_citation_kosaf_aggregate 류).

수정: `analyze_query` 반환 dict 에 `resolved_query`(정규화 query) 키 추가 → substring fallback 활성화.

Closes #2170

## 2. 영향 파일

- `rag_query.py` (load-bearing): `analyze_query` 반환에 `resolved_query` 키 1개 + 계약 주석
- `tests/test_aggregate_evidence_selection_regression.py`: 실제 `analyze_query` 출력으로 검증하는 통합 테스트 3종

## 3. 리스크

- **test-reality drift 가 원인**: 기존 단위 테스트는 `_analysis` mock 이 `resolved_query` 키를 주입해 green 이었으나 런타임 dict 구조와 달라 프로덕션 dead. 통합 테스트로 봉인.
- **precision trade-off (Codex pre-commit freq 2/2 medium, 분리)**: substring fallback 이 signal text 포함 비-aggregate 복합어(`전체성`/`목록화`/`정리율`)를 false positive 분류 가능. 결과는 보수적(pool 확장 = 답변 충실도 무해) + RFP 도메인 등장 드묾. precision tuning 은 형태소 경계 인식 필요 → **follow-up #2179** 로 분리 (One PR one concern: 본 PR = recall fix).

## 4. 테스트

- pytest 17 passed (통합 3 + 기존 14) + 9 subtests
- **mutation (non-vacuous)**: `resolved_query` 블록 제거 → 통합 테스트 2 fail (`test_analyze_query_exposes_resolved_query` assertIn + `test_compound_token_aggregate_detected_end_to_end` assertTrue), 복원 → 3 passed

## 5. Eval 영향 (ADR 0001)

`select_supporting_evidence` 는 naive_baseline direct path 도 거치므로 (`rag_core.py:1414`) baseline 영향 가능성 검토. **eval 5 케이스 전부 aggregate 판정 before/after 불변** → pool 불변 → naive_baseline 포함 답변 byte-identical. CI "Fixture smoke eval vs base" 가 이중 확인.

real-eval-delta: 동작이 복합토큰 aggregate 쿼리에만 영향하고 eval 케이스가 불변이라 델타 0 예상. private real-eval 미실행 (측정 표면 무관, 동작 무변경 논증으로 대체).

## 6. 하위 호환

analysis dict 에 키 **추가**(additive) — 기존 소비자 영향 0 (`resolved_query` 를 읽는 유일 소비자 = `_is_aggregate_query`, 지금까지 dead). ADR 0003 답변 계약(`schema_version`) 무관.

## 7. 범위 외

- `build_extract_claims` 2-claim hardcap 이 aggregate pool 5 를 claim 단계에서 상쇄하는지 (evidence vs claim 레이어 구분 + 의도성, 별도 조사 필요)
- substring fallback precision tuning → #2179
