### PR TITLE
test: lock private data audit utilities

### DIFF
--- a/tests/test_private_data_quality_audit_utils.py
+++ b/tests/test_private_data_quality_audit_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import private_data_quality_audit_utils as utils
+
+
+def test_hash_ref_is_deterministic_namespaced_redaction():
+    first = utils.hash_ref("doc-7", namespace="doc")
+    assert first == utils.hash_ref("doc-7", namespace="doc")
+    assert first.startswith("redacted_")
+    assert first != utils.hash_ref("doc-7", namespace="question")
+    assert "doc-7" not in first
+
+
+def test_token_overlap_helpers_use_ascii_and_korean_terms():
+    left = "AI 사업 요구사항 2026"
+    right = "사업 요구사항 검토 2026"
+    assert utils.tokens(left) == {"ai", "사업", "요구사항", "2026"}
+    assert utils.jaccard(left, right) == pytest.approx(3 / 5)
+    assert utils.containment("사업 2026 누락", right) == pytest.approx(2 / 3)
+
+
+def test_percentile_interpolates_and_handles_empty_input():
+    assert utils.percentile([], 0.5) is None
+    assert utils.percentile([10], 0.9) == 10.0
+    assert utils.percentile([10, 20, 30, 40], 0.25) == pytest.approx(17.5)
+    assert utils.percentile([10, 20, 30, 40], 0.5) == pytest.approx(25.0)
+
+
+def test_public_safety_flags_forbidden_keys_and_absolute_paths():
+    hits = utils.forbidden_output_hits(
+        {"safe": [{"doc_id": "PRIVATE-DOC"}], "note": "/Users/hskim/private/file.hwp"}
+    )
+    assert hits == {"absolute_path_value": 1, "doc_id": 1}
+    with pytest.raises(utils.AuditPrivacyError, match="doc_idx1"):
+        utils.assert_public_safe({"doc_id": "PRIVATE-DOC"})


### PR DESCRIPTION
## 1. Summary
- Add focused tests for pure helper behavior in `scripts/private_data_quality_audit_utils.py`.
- Lock redacted hash references, token overlap helpers, percentile interpolation, and public-output safety detection.

## 2. Issue
Closes #2183

## 3. Changes
- Added `tests/test_private_data_quality_audit_utils.py`.
- No runtime code changes.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_private_data_quality_audit_utils.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — tests-only helper characterization; no ingestion, retrieval, answer, or eval behavior changed.

## 6. Risks / follow-ups
N/A.