### PR TITLE
test(ship): cover ship env secret stripping helper

### DIFF
--- a/tests/test__ship_env.py
+++ b/tests/test__ship_env.py
@@ -1,0 +1,29 @@
+from scripts._ship_env import SHIP_SECRET_ENV_PREFIX, strip_ship_secret_env
+
+
+def test_strip_ship_secret_env_removes_only_ship_prefixed_keys() -> None:
+    env = {
+        "BIDMATE_SHIP_TOKEN": "secret",
+        "BIDMATE_SHIP_MANIFEST_DIR": "/private/ship",
+        "BIDMATE_SHIPPING_LABEL": "not-secret-prefix",
+        "BIDMATE_SHIP": "not-prefix-with-underscore",
+        "PATH": "/usr/bin",
+        "GITHUB_TOKEN": "preserved-auth",
+    }
+
+    assert strip_ship_secret_env(env) == {
+        "BIDMATE_SHIPPING_LABEL": "not-secret-prefix",
+        "BIDMATE_SHIP": "not-prefix-with-underscore",
+        "PATH": "/usr/bin",
+        "GITHUB_TOKEN": "preserved-auth",
+    }
+
+
+def test_strip_ship_secret_env_returns_copy_without_mutating_input() -> None:
+    env = {f"{SHIP_SECRET_ENV_PREFIX}KILL_SWITCH": "1", "HOME": "/home/runner"}
+
+    stripped = strip_ship_secret_env(env)
+
+    assert stripped == {"HOME": "/home/runner"}
+    assert env == {f"{SHIP_SECRET_ENV_PREFIX}KILL_SWITCH": "1", "HOME": "/home/runner"}
+    assert stripped is not env


### PR DESCRIPTION
## Summary
- Add focused tests for `scripts/_ship_env.py` ship-lane environment stripping.
- Lock prefix-only removal and input non-mutation behavior.

## Issue
Closes #2191

## Scope
- Tests only: `tests/test__ship_env.py`
- No runner behavior change.

## Validation
- [x] `python3 -m pytest -q tests/test__ship_env.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only coverage for ship env helper; no retrieval/answer/eval behavior changed.
