### PR TITLE
test(eval): cover naive RAG failure taxonomy classifier

### DIFF
--- a/tests/test_naive_rag_taxonomy.py
+++ b/tests/test_naive_rag_taxonomy.py
@@ -1,0 +1,47 @@
+from eval.naive_rag.taxonomy import classify_failure, count_failures
+
+
+def test_classify_failure_prioritizes_retrieval_then_secondary_answer_labels() -> None:
+    primary, labels = classify_failure(
+        question={"answerable": True},
+        gold_chunk_ids=["gold-1"],
+        retrieved_chunk_ids=["other-1"],
+        cited_chunk_ids=[],
+        retrieval_metrics={"recall_at_10": 0.0, "recall_at_5": 0.0},
+        answer_metrics={"citation_accuracy": 0.0, "answer_relevancy": 0.0, "hallucination_flag": 1},
+    )
+
+    assert primary == "retrieval_failure.gold_evidence_not_in_top_k"
+    assert labels == [
+        "retrieval_failure.gold_evidence_not_in_top_k",
+        "citation_failure.insufficient_citation",
+        "answer_failure.partial_answer",
+        "answer_failure.hallucinated_requirement",
+    ]
+
+
+def test_classify_failure_labels_failed_abstention_for_unanswerable_case() -> None:
+    primary, labels = classify_failure(
+        question={"answerable": False},
+        gold_chunk_ids=[],
+        retrieved_chunk_ids=[],
+        cited_chunk_ids=[],
+        retrieval_metrics={},
+        answer_metrics={"unanswerable_detection_flag": 0},
+    )
+
+    assert primary == "answer_failure.failed_to_abstain"
+    assert labels == ["answer_failure.failed_to_abstain"]
+
+
+def test_count_failures_ignores_unknown_and_none_labels() -> None:
+    counts = count_failures([
+        "retrieval_failure.query_wording_mismatch",
+        "retrieval_failure.query_wording_mismatch",
+        "unknown.label",
+        None,
+    ])
+
+    assert counts["retrieval_failure.query_wording_mismatch"] == 2
+    assert "unknown.label" not in counts
+    assert counts["answer_failure.failed_to_abstain"] == 0


### PR DESCRIPTION
## Summary
- Add focused tests for `eval/naive_rag/taxonomy.py` classifier/count behavior.
- Lock retrieval-primary label ordering, failed-abstention handling, and unknown-label ignore behavior.

## Issue
Closes #2207

## Scope
- Tests only: `tests/test_naive_rag_taxonomy.py`
- Synthetic deterministic inputs only; no private or legacy real100 evidence.

## Validation
- [x] `python3 -m pytest -q tests/test_naive_rag_taxonomy.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
Test-only coverage for public naive-rag taxonomy helper; no eval behavior changed.
