### PR TITLE
Test naive RAG metrics helpers

### DIFF
--- a/tests/test_naive_rag_metrics_helpers.py
+++ b/tests/test_naive_rag_metrics_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from eval.naive_rag.metrics import (
+    contains_terms,
+    summarize_case_metrics,
+    summarize_latency,
+    summarize_metric,
+    unique_ids,
+)
+
+
+def test_unique_ids_strips_blanks_and_preserves_first_occurrence() -> None:
+    assert unique_ids(["  c1 ", "", "c2", "c1", "  ", "c3", "c2"]) == [
+        "c1",
+        "c2",
+        "c3",
+    ]
+
+
+def test_contains_terms_counts_case_insensitive_matches_and_missing_terms() -> None:
+    assert contains_terms("Alpha beta ALPHA", ["alpha", "BETA", "gamma"]) == 2 / 3
+    assert contains_terms("anything", ["", "  "]) is None
+
+
+def test_summarize_metric_reports_numeric_count_and_missing_values() -> None:
+    assert summarize_metric([1, None, 3.0, "skip"], total=5) == {
+        "mean": 2.0,
+        "n": 2,
+        "missing": 3,
+    }
+
+
+def test_summarize_case_metrics_and_latency_use_declared_totals() -> None:
+    cases = [{"score": 1.0}, {"score": None}, {"other": 5}]
+
+    assert summarize_case_metrics(cases, ("score",))["score"] == {
+        "mean": 1.0,
+        "n": 1,
+        "missing": 2,
+    }
+    assert summarize_latency([30, None, 10, "skip", 20]) == {
+        "mean": 20.0,
+        "p50": 20.0,
+        "p95": 20.0,
+        "n": 3,
+        "missing": 2,
+    }


### PR DESCRIPTION
## Summary
- Add focused helper-level coverage for `eval.naive_rag.metrics` normalization and summary contracts.
- Use deterministic synthetic inputs only; no private eval artifacts or legacy real100 evidence.

## Issue
Closes #2211

## Changes
- Covers duplicate/blank ID filtering in `unique_ids`.
- Covers case-insensitive term coverage and missing-term behavior.
- Covers numeric-only metric summaries and latency percentile/missing counts.

## Validation
- [x] `python3 -m pytest -q tests/test_naive_rag_metrics_helpers.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only helper contract coverage; no pipeline behavior or eval artifacts changed.

## Risk
Low — one new synthetic test file only.
