### PR TITLE
Test desktop main sync skip guards

### DIFF
--- a/tests/test_sync_desktop_main.py
+++ b/tests/test_sync_desktop_main.py
@@ -112,3 +112,24 @@ def test_stop_ship_stage_5_invokes_desktop_sync() -> None:
     text = (REPO_ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
     assert "scripts/sync_desktop_main.py" in text
     assert "BIDMATE_DESKTOP_REPO" in text
+
+
+def test_sync_skips_missing_repo_path(tmp_path: Path) -> None:
+    missing_repo = tmp_path / "missing"
+
+    result = sync_desktop_main(missing_repo)
+
+    assert result.exit_code == 2
+    assert result.status == "skipped"
+    assert f"repo not found: {missing_repo}" == result.reason
+
+
+def test_sync_skips_non_git_directory(tmp_path: Path) -> None:
+    non_git_repo = tmp_path / "plain-directory"
+    non_git_repo.mkdir()
+
+    result = sync_desktop_main(non_git_repo)
+
+    assert result.exit_code == 2
+    assert result.status == "skipped"
+    assert f"not a git repository: {non_git_repo}" == result.reason


### PR DESCRIPTION
## Summary
- Add fail-soft skip coverage for `scripts.sync_desktop_main` when the target path is missing.
- Add skip coverage for a plain non-git directory target.

## Issue
Closes #2222

## Changes
- Extend `tests/test_sync_desktop_main.py` with deterministic temp-path guard cases.

## Validation
- [x] `python3 -m pytest -q tests/test_sync_desktop_main.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only automation helper coverage; no RAG behavior or eval artifacts changed.

## Risk
Low — local temp-directory tests only.
