### PR TITLE
Test gold annotation survey categories

### DIFF
--- a/tests/test_gold_annotation_survey.py
+++ b/tests/test_gold_annotation_survey.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.component_eval.gold_annotation_survey import survey_case
+
+
+@pytest.mark.parametrize(
+    ("case", "yaml_terms", "cid_to_text", "expected"),
+    [
+        ({"id": "q1", "gold_chunk_ids": []}, {"q1": ["alpha"]}, {}, "no_gold"),
+        (
+            {"id": "q1", "gold_chunk_ids": ["missing"]},
+            {"q1": ["alpha"]},
+            {"chunk-1": "alpha beta"},
+            "gold_not_in_index",
+        ),
+        ({"id": "q1", "gold_chunk_ids": ["chunk-1"]}, {}, {"chunk-1": "alpha beta"}, "gold_no_terms"),
+        (
+            {"id": "q1", "gold_chunk_ids": ["chunk-1", "chunk-2"]},
+            {"q1": ["alpha", "gamma"]},
+            {"chunk-1": "alpha beta", "chunk-2": "gamma delta"},
+            "gold_valid",
+        ),
+        (
+            {"id": "q1", "gold_chunk_ids": ["chunk-1"]},
+            {"q1": ["alpha", "missing-term"]},
+            {"chunk-1": "alpha beta"},
+            "gold_drift",
+        ),
+    ],
+)
+def test_survey_case_classifies_gold_annotation_health(case, yaml_terms, cid_to_text, expected) -> None:
+    assert survey_case(case, yaml_terms, cid_to_text) == expected


### PR DESCRIPTION
## Summary
- Add focused unit coverage for `survey_case` category classification.
- Cover no-gold, stale/missing gold IDs, missing terms, valid terms, and drift.

## Issue
Closes #2231

## Changes
- Add `tests/test_gold_annotation_survey.py` with synthetic dictionaries only.

## Validation
- [x] `python3 -m pytest -q tests/test_gold_annotation_survey.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only component helper coverage; no eval artifacts or behavior changed.

## Risk
Low — deterministic unit tests only.
