### PR TITLE
Test verifier drift helper predicates

### DIFF
--- a/tests/test_verifier_drift_check.py
+++ b/tests/test_verifier_drift_check.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from scripts.component_eval.verifier_drift_check import doc_matched, gold_retrieved
+
+
+def test_gold_retrieved_is_true_when_any_gold_chunk_was_retrieved() -> None:
+    assert gold_retrieved({"gold_chunk_ids": ["g1", "g2"], "retrieved_chunk_ids": ["r0", "g2"]}) is True
+
+
+def test_gold_retrieved_is_false_for_missing_or_disjoint_gold_ids() -> None:
+    assert gold_retrieved({"gold_chunk_ids": ["g1"], "retrieved_chunk_ids": ["r1"]}) is False
+    assert gold_retrieved({"retrieved_chunk_ids": ["r1"]}) is False
+
+
+def test_doc_matched_requires_all_expected_docs_in_evidence() -> None:
+    assert doc_matched({"expected_doc_ids": ["d1", "d2"], "evidence_doc_ids": ["d0", "d1", "d2"]}) is True
+    assert doc_matched({"expected_doc_ids": ["d1", "d2"], "evidence_doc_ids": ["d1"]}) is False
+
+
+def test_doc_matched_is_false_without_expected_docs() -> None:
+    assert doc_matched({"expected_doc_ids": [], "evidence_doc_ids": ["d1"]}) is False
+    assert doc_matched({"evidence_doc_ids": ["d1"]}) is False


### PR DESCRIPTION
## Summary
- Add focused unit coverage for verifier drift helper predicates.
- Cover retrieved gold overlap and expected-doc subset semantics.

## Issue
Closes #2237

## Changes
- Add `tests/test_verifier_drift_check.py` with synthetic dictionaries only.

## Validation
- [x] `python3 -m pytest -q tests/test_verifier_drift_check.py`
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only component helper coverage; no eval artifacts or behavior changed.

## Risk
Low — deterministic unit tests only.
