### PR TITLE
test(real100-v2): cover LLM baseline config fallback guards

### DIFF
--- a/tests/test_real100_v2_llm_baseline_config.py
+++ b/tests/test_real100_v2_llm_baseline_config.py
@@ -28,3 +28,42 @@ def test_build_config_adds_stub_control_and_llm_primary() -> None:
     assert all(run["retrieval_backend"] == "dense" for run in runs)
     assert runs[0]["prompt_profile"] == "minimal_grounded_extractive"
     assert runs[1]["prompt_profile"] == "llm_synthesis"
+    assert source["ablation_runs"][0]["vector_store_backend"] == "memory"
+
+
+def test_build_config_falls_back_when_naive_row_is_missing() -> None:
+    source = {
+        "mode": "rag",
+        "primary_run": "full",
+        "ablation_runs": [{"name": "full", "pipeline": "agentic_full"}],
+        "cases": [{"id": "c1"}],
+    }
+
+    derived = build_config(source)
+
+    runs = derived["ablation_runs"]
+    assert [run["name"] for run in runs] == ["naive_stub_control", "naive_baseline_llm"]
+    assert all(run["pipeline"] == "naive_baseline" for run in runs)
+    assert all(run["retrieval_mode"] == "flat" for run in runs)
+    assert all(run["query_expansion"] == "identity" for run in runs)
+    assert all(run["vector_store_backend"] == "chroma" for run in runs)
+
+
+def test_build_config_uses_independent_run_copies() -> None:
+    source = {
+        "cases": [{"id": "c1"}],
+        "ablation_runs": [
+            {
+                "name": "naive_baseline",
+                "pipeline": "naive_baseline",
+                "metadata": {"owner": "source"},
+            }
+        ],
+    }
+
+    derived = build_config(source)
+    stub, llm = derived["ablation_runs"]
+    stub["metadata"]["owner"] = "stub"
+
+    assert llm["metadata"]["owner"] == "source"
+    assert source["ablation_runs"][0]["metadata"]["owner"] == "source"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

real100_v2 local LLM baseline config helper의 순수 `build_config` 계약을 작은 단위 테스트로 고정합니다. 명시적 naive row가 없을 때 fallback row를 강제 naive retrieval surface로 파생하는지, 파생 run들이 source/서로를 오염시키지 않는 independent copy인지 확인합니다.

Closes #2241

## 2. 영향 파일

- `tests/test_real100_v2_llm_baseline_config.py` — test-only, non-load-bearing

## 3. 리스크

- 리스크: 테스트 fixture가 실제 private config 형태를 과하게 가정할 수 있음.
- 배제 근거: private data/real eval 실행 없이 synthetic dict만 사용했고, 대상은 public helper의 순수 `build_config` 출력 계약입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_real100_v2_llm_baseline_config.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main`에서 open PR changed files 및 `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery` dirty/ahead files를 스캔했고, 이 PR은 `tests/test_real100_v2_llm_baseline_config.py` 한 파일만 변경하여 open PR/Claude Code/Codex worktree 변경 파일과 겹치지 않습니다.

## 5. Eval 영향

RAG/eval runtime 동작 변화 없음. test-only change이며 private real100_v2 eval은 실행하지 않았습니다. legacy real100/v1/kordoc surface 사용 없음.

## 6. 하위 호환

N/A — 테스트 추가만 수행했고 CLI/schema/answer-contract 변경 없음.

## 7. 범위 외

- private real100_v2 aggregate 재생성
- runtime config builder 변경
- legacy real100/v1/kordoc 관련 경로
