### PR TITLE
test(indexing): cover raw document sibling skip guards

### DIFF
--- a/tests/test_rag_indexing_raw_documents.py
+++ b/tests/test_rag_indexing_raw_documents.py
@@ -15,3 +15,15 @@ def test_load_raw_documents_skips_local_export_manifest(tmp_path):
     docs = load_raw_documents(tmp_path)
 
     assert [doc["doc_id"] for doc in docs] == ["doc_001"]
+
+
+def test_load_raw_documents_skips_metadata_siblings_and_hidden_files(tmp_path):
+    (tmp_path / ".hidden.md").write_text("# Hidden\n\nNot a corpus doc\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Local corpus notes\n", encoding="utf-8")
+    (tmp_path / "manifest.json").write_text("{not valid json if loaded", encoding="utf-8")
+    (tmp_path / "doc_001.md").write_text("# Doc 1\n\nBody\n", encoding="utf-8")
+    (tmp_path / "doc_002.TXT").write_text("Doc 2\n\nMore body\n", encoding="utf-8")
+
+    docs = load_raw_documents(tmp_path)
+
+    assert [doc["doc_id"] for doc in docs] == ["doc_001", "doc_002"]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_indexing.load_raw_documents`가 raw corpus directory에서 local metadata sibling(`README.md`, `manifest.json`)과 hidden file을 문서로 오인하지 않는 계약을 작은 단위 테스트로 고정합니다. 실제 문서(`.md`, 대문자 `.TXT`)는 정렬된 doc_id로 계속 로드되는지도 함께 확인합니다.

Closes #2245

## 2. 영향 파일

- `tests/test_rag_indexing_raw_documents.py` — test-only, non-load-bearing

## 3. 리스크

- 리스크: fixture가 loader filtering 계약을 과하게 고정할 수 있음.
- 배제 근거: 이미 코드에 명시된 skip list/hidden-file behavior만 synthetic tmp_path로 검증하며 runtime code는 변경하지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_rag_indexing_raw_documents.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main`에서 open PR changed files 및 `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery` dirty/ahead files를 스캔했고, `tests/test_rag_indexing_raw_documents.py` hit가 없음을 확인했습니다.

## 5. Eval 영향

RAG/indexing runtime 동작 변화 없음. test-only change이며 private real100_v2 eval은 실행하지 않았습니다. legacy real100/v1/kordoc surface 사용 없음.

## 6. 하위 호환

N/A — 테스트 추가만 수행했고 CLI/schema/answer-contract 변경 없음.

## 7. 범위 외

- `rag_indexing.py` 구현 변경
- private eval/index 재생성
- load-bearing 경로 변경
