### PR TITLE
test(embedding): cover dimension guard opt-out

### DIFF
--- a/tests/test_embedding_provider_protocol.py
+++ b/tests/test_embedding_provider_protocol.py
@@ -51,3 +51,13 @@ def test_embedding_dimension_match_returns_original_result() -> None:
     )
 
     assert ensure_embedding_dimension(result, 4) is result
+
+
+def test_embedding_dimension_none_skips_validation() -> None:
+    result = EmbeddingResult(
+        vectors=np.zeros(4, dtype=np.float32),
+        backend="fake",
+        model="fake-model",
+    )
+
+    assert ensure_embedding_dimension(result, None) is result


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`ensure_embedding_dimension`의 opt-out 계약(`expected_dimension=None`)을 단위 테스트로 고정합니다. shape가 2D가 아니어도 opt-out이면 validation을 건너뛰고 원본 `EmbeddingResult`를 그대로 반환해야 합니다.

Closes #2249

## 2. 영향 파일

- `tests/test_embedding_provider_protocol.py` — test-only, non-load-bearing

## 3. 리스크

- 리스크: 테스트가 malformed vector shape를 허용하는 것처럼 보일 수 있음.
- 배제 근거: 이 테스트는 `expected_dimension=None` opt-out 분기만 고정하며, dimension mismatch raise 분기는 기존 테스트가 유지합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_embedding_provider_protocol.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main`에서 open PR changed files 및 `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery` dirty/ahead files를 스캔했고, `tests/test_embedding_provider_protocol.py` hit가 없음을 확인했습니다.

## 5. Eval 영향

RAG/embedding runtime 동작 변화 없음. test-only change이며 private real100_v2 eval은 실행하지 않았습니다. legacy real100/v1/kordoc surface 사용 없음.

## 6. 하위 호환

N/A — 테스트 추가만 수행했고 CLI/schema/answer-contract 변경 없음.

## 7. 범위 외

- `rag_embedding.py` 구현 변경
- 외부 embedding/model/API 호출
- private eval/index 재생성
