### PR TITLE
test(adr-map): cover empty decision board

### DIFF
--- a/tests/test_render_adr_decision_map.py
+++ b/tests/test_render_adr_decision_map.py
@@ -40,6 +40,19 @@ def test_build_board_counts_status_and_recent() -> None:
     assert board["proposed"][0].number == 69
 
 
+def test_build_board_handles_empty_index() -> None:
+    board = build_board([])
+
+    assert board["total"] == 0
+    assert board["latest"] is None
+    assert board["status_counts"] == {}
+    assert board["area_counts"] == {}
+    assert board["recent"] == []
+    assert board["proposed"] == []
+    assert board["superseded"] == []
+    assert board["accepted_count"] == 0
+
+
 def test_html_has_sections_and_escapes_title() -> None:
     entries = parse_adr_index(
         ADR_README


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR decision map renderer의 empty-index 계약을 단위 테스트로 고정합니다. ADR README에서 파싱된 row가 없어도 `build_board([])`는 안전한 empty board를 반환해야 하며, latest/status/area/recent/proposed/superseded 값이 빈 상태로 유지되어야 합니다.

Closes #2253

## 2. 영향 파일

- `tests/test_render_adr_decision_map.py` — test-only, non-load-bearing

## 3. 리스크

- 리스크: empty board contract가 renderer 구현을 과하게 고정할 수 있음.
- 배제 근거: 구현 변경 없이 existing public helper의 안전한 빈 입력 behavior만 synthetic input으로 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_render_adr_decision_map.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main`에서 open PR changed files 및 `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery` dirty/ahead files를 스캔했고, `tests/test_render_adr_decision_map.py` hit가 없음을 확인했습니다.

## 5. Eval 영향

RAG/eval runtime 동작 변화 없음. test-only change이며 private real100_v2 eval은 실행하지 않았습니다. legacy real100/v1/kordoc surface 사용 없음.

## 6. 하위 호환

N/A — 테스트 추가만 수행했고 CLI/schema/answer-contract 변경 없음.

## 7. 범위 외

- ADR markdown/index 수정
- `scripts/render_adr_decision_map.py` 구현 변경
- generated HTML artifact 커밋
