### PR TITLE
test(gold): cover duplicated content phrase skip

### DIFF
--- a/tests/test_content_grounded_gold.py
+++ b/tests/test_content_grounded_gold.py
@@ -75,6 +75,17 @@ class GenerateCasesContractTest(unittest.TestCase):
         self.assertNotIn("boiler-1", produced_docs)
         self.assertGreaterEqual(skipped, 1, "boilerplate candidate must be skipped")
 
+    def test_duplicated_content_phrase_yields_no_case(self) -> None:
+        chunks = [
+            _chunk("dup-1", "위험관리플랫폼 통합관제 고도화 요구사항을 설명한다"),
+            _chunk("dup-2", "위험관리플랫폼 통합관제 고도화 요구사항을 설명한다"),
+        ]
+
+        cases, skipped = generate_cases(chunks, n=10)
+
+        self.assertEqual(cases, [])
+        self.assertEqual(skipped, 0)
+
     def test_deterministic_and_respects_n_cap(self) -> None:
         first, _ = generate_cases(_CHUNKS, n=1)
         second, _ = generate_cases(_CHUNKS, n=1)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

content-grounded gold generator의 unique-bigram 계약을 단위 테스트로 고정합니다. 동일한 content phrase가 두 문서에 중복될 때는 해당 phrase가 특정 doc에 고유하지 않으므로 gold case를 생성하지 않아야 합니다.

Closes #2256

## 2. 영향 파일

- `tests/test_content_grounded_gold.py` — test-only, non-load-bearing

## 3. 리스크

- 리스크: synthetic phrase가 generator tokenizer/stopword 규칙 변화에 민감할 수 있음.
- 배제 근거: 두 문서의 text를 완전히 동일하게 두어 unique bigram set이 비도록 만든 최소 fixture이며, private data를 사용하지 않습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_content_grounded_gold.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main`에서 open PR changed files 및 `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery` dirty/ahead files를 스캔했고, `tests/test_content_grounded_gold.py` hit가 없음을 확인했습니다.

## 5. Eval 영향

RAG/eval runtime 동작 변화 없음. test-only synthetic change이며 private real100_v2 eval은 실행하지 않았습니다. legacy real100/v1/kordoc surface 사용 없음.

## 6. 하위 호환

N/A — 테스트 추가만 수행했고 CLI/schema/answer-contract 변경 없음.

## 7. 범위 외

- `scripts/gen_content_grounded_gold.py` 구현 변경
- private eval/gold artifact 생성 또는 갱신
- legacy real100/v1/kordoc 경로 실행
