### PR TITLE
test(smoke): preserve hook setup ordering

### DIFF
--- a/tests/test_smoke_hooks_dependency_regression.py
+++ b/tests/test_smoke_hooks_dependency_regression.py
@@ -33,6 +33,19 @@ class TestSmokeDependsOnInstallHooks(unittest.TestCase):
             "smoke target must depend on install-hooks so a fresh worktree "
             "activates .githooks/ before the first eval run.",
         )
+        hooks_index = r.stdout.find("git config core.hooksPath .githooks")
+        smoke_index = r.stdout.find("bash scripts/smoke.sh")
+        self.assertNotEqual(
+            smoke_index,
+            -1,
+            "`make -n smoke` must still dry-run the smoke script.",
+        )
+        self.assertLess(
+            hooks_index,
+            smoke_index,
+            "install-hooks must run before scripts/smoke.sh so the first "
+            "smoke execution in a fresh worktree is hook-instrumented.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make smoke` dry-run에서 `install-hooks` 레시피가 `scripts/smoke.sh`보다 먼저 실행되는 순서를 회귀 테스트로 고정했습니다. 기존 테스트는 hook setup 명령이 포함되는지만 확인했지만, fresh worktree 첫 smoke 실행의 hook instrumentation 보장을 위해 순서도 중요합니다.

Closes #2263

## 2. 영향 파일

- `tests/test_smoke_hooks_dependency_regression.py` — test-only regression coverage 추가

## 3. 리스크

- 리스크: `make -n smoke` 출력 형식이 바뀌면 테스트가 실패할 수 있음.
- 배제 근거: 테스트는 실제 target contract인 `git config core.hooksPath .githooks`와 `bash scripts/smoke.sh`의 상대 순서만 확인하며 production path는 변경하지 않음.

## 4. 테스트

- `python3 -m pytest -q tests/test_smoke_hooks_dependency_regression.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_smoke_hooks_dependency_regression.py` was CLEAR.

## 5. Eval 영향

RAG/load-bearing 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `Makefile` 동작 변경은 하지 않음 — 현재 dependency ordering을 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 regression test assertion이라 targeted pytest로 제한.
