### PR TITLE
test(ingestion): pin trimmed pii flag truthy values

### DIFF
--- a/tests/test_ingestion_pii_redaction.py
+++ b/tests/test_ingestion_pii_redaction.py
@@ -24,7 +24,7 @@ class PiiRedactionEnvFlagTest(unittest.TestCase):
     def test_true_values_enable(self) -> None:
         import os
 
-        for value in ("1", "true", "TRUE", "yes", "Yes"):
+        for value in ("1", "true", "TRUE", "yes", "Yes", " true ", "\tyes\n"):
             os.environ["BIDMATE_INGEST_REDACT_PII"] = value
             try:
                 self.assertTrue(_pii_redaction_enabled(), f"expected enabled for {value!r}")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`BIDMATE_INGEST_REDACT_PII` opt-in flag가 공백/탭/개행이 붙은 truthy 값을 받아도 redaction gate를 켜는 현재 계약을 테스트로 고정했습니다. 운영 환경에서 env var 값에 whitespace가 섞여도 ADR 0028 opt-in behavior가 흔들리지 않도록 하는 test-only regression guard입니다.

Closes #2266

## 2. 영향 파일

- `tests/test_ingestion_pii_redaction.py` — truthy env flag 케이스 보강(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 테스트는 `_pii_redaction_enabled()`의 기존 strip/lower 계약을 더 명시적으로 고정함.
- 배제 근거: 단일 테스트 데이터 추가만 포함했고 targeted pytest가 통과함.

## 4. 테스트

- `python3 -m pytest -q tests/test_ingestion_pii_redaction.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_ingestion_pii_redaction.py` was CLEAR.

## 5. Eval 영향

RAG/load-bearing production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `ingestion.py` 구현은 변경하지 않음 — 현재 동작을 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 test data addition이라 targeted pytest로 제한.
