### PR TITLE
test(embedding): hashing_embeddings 결정성·L2 정규화·zero-vector·signed-feature 단위 커버리지

### DIFF
--- a/tests/test_hashing_embeddings_unit.py
+++ b/tests/test_hashing_embeddings_unit.py
@@ -1,0 +1,93 @@
+"""Unit coverage for rag_embedding.hashing_embeddings (issue #2262).
+
+``hashing_embeddings(texts, dim)`` 는 ADR 0001 오프라인 baseline 의 핵심 결정적
+임베딩(md5 해싱 → signed feature → 행별 L2 정규화)이다. 기존 테스트는
+``embed_query_for_index`` 단일 쿼리 shape 와 openai 백엔드 정규화만 다뤄
+``hashing_embeddings`` 자체의 다중 텍스트 shape·결정성·행별 L2 정규화·
+zero-vector 가드·dtype 은 미커버였다 (test-only, 소스 무수정).
+
+negative assertion 으로 baseline byte-identical 불변(ADR 0001)을 떠받치는
+속성들이 실제로 성립하는지 못 박는다. leaf 모듈(hashlib/numpy +
+rag_text_processing.tokenize, rag_core back-edge 0 = ADR 0045).
+
+- ``expand_features`` 는 issue #2105 로 이미 완전 단위 커버 → 여기서 제외(중복 회피).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from rag_embedding import hashing_embeddings
+
+
+def test_shape_is_rows_by_dim() -> None:
+    # (len(texts), dim) — 행/열 순서를 못 박는다(전치면 (dim, len)이 되어 KILL)
+    v = hashing_embeddings(["가나", "다라", "마바"], 16)
+    assert v.shape == (3, 16)
+
+
+def test_dtype_is_float32() -> None:
+    v = hashing_embeddings(["예산"], 8)
+    assert v.dtype == np.float32
+
+
+def test_dim_argument_controls_columns() -> None:
+    assert hashing_embeddings(["예산 집행"], 64).shape[1] == 64
+    assert hashing_embeddings(["예산 집행"], 16).shape[1] == 16
+
+
+def test_nonzero_rows_are_l2_normalized() -> None:
+    # 토큰이 있는 행은 단위 L2 norm. 정규화(vectors/norms)를 제거하면 raw signed
+    # count 가 남아 norm != 1.0 → KILL.
+    v = hashing_embeddings(["예산 집행 내용 상세"], 32)
+    assert float(np.linalg.norm(v[0])) == pytest.approx(1.0)
+
+
+def test_deterministic_for_same_input() -> None:
+    # md5 기반이라 재호출이 byte-identical. 비결정(random) 구현이면 KILL.
+    a = hashing_embeddings(["예산 집행 내용"], 32)
+    b = hashing_embeddings(["예산 집행 내용"], 32)
+    assert np.array_equal(a, b)
+
+
+def test_distinct_texts_produce_distinct_vectors() -> None:
+    # 서로 다른 텍스트는 다른 벡터(상수/zero 반환 mutant 면 동일해져 KILL)
+    a = hashing_embeddings(["예산"], 32)
+    b = hashing_embeddings(["계약"], 32)
+    assert not np.array_equal(a, b)
+
+
+def test_negative_sign_token_is_preserved() -> None:
+    # signed-feature 속성: digest[8:10] 홀수면 sign=-1. "기한" 은 단일 토큰이고
+    # 부호 비트가 홀수라 정규화 후 유일 비-zero 성분 = -1.0. sign 분기를 항상
+    # +1.0 으로 바꾸면 그 성분이 +1.0 이 되어 min()=0.0 → KILL (부호를 못 박음).
+    assert float(hashing_embeddings(["기한"], 8).min()) == pytest.approx(-1.0)
+
+
+def test_same_index_collisions_accumulate() -> None:
+    # "예산 예산": 동일 unigram 2개가 같은 idx 로 충돌 → '+=' 누적으로 magnitude 2,
+    # bigram '예산_예산' 은 다른 idx 로 magnitude 1. 정규화 후 두 성분 비율 정확히
+    # 2.0. 누적을 대입('=')으로 바꾸면 unigram 도 magnitude 1 → 비율 1.0 → KILL.
+    v = hashing_embeddings(["예산 예산"], 32)[0]
+    nz = np.sort(np.abs(v[v != 0]))
+    assert len(nz) == 2
+    assert nz[1] == pytest.approx(2.0 * nz[0])
+
+
+def test_empty_text_is_zero_vector_without_nan() -> None:
+    # 토큰 없는 빈 텍스트 → 행 전체 0. norms[norms==0]=1.0 가드가 0/0 nan 을
+    # 막는다. 가드를 제거하면 nan 이 되어 all-zero(==0) 도 no-nan 도 위반 → KILL.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # 0/0 invalid-divide 경고를 에러로 격상
+        v = hashing_embeddings([""], 8)
+    assert bool(np.all(v[0] == 0.0))
+    assert not bool(np.any(np.isnan(v[0])))
+
+
+def test_mixed_empty_and_nonempty_rows_independent() -> None:
+    # 빈 행(norm 0)과 정상 행(norm 1)이 한 배치에서 독립적으로 정규화된다
+    v = hashing_embeddings(["", "예산 집행"], 16)
+    assert float(np.linalg.norm(v[0])) == 0.0
+    assert float(np.linalg.norm(v[1])) == pytest.approx(1.0)


### PR DESCRIPTION
## 1. 요약 (Summary)

`rag_embedding.hashing_embeddings(texts, dim)` 는 ADR 0001 오프라인 baseline 의 핵심 결정적 임베딩(md5 해싱 → signed feature → 행별 L2 정규화)인데 **직접 단위 테스트가 없었다** (기존엔 `embed_query_for_index` 단일 쿼리 shape·openai 백엔드 정규화만). test-only, 소스 무수정.

## 2. 변경 사항 (Changes)

- `tests/test_hashing_embeddings_unit.py` 신규 (10 tests). negative assertion 으로:
  - shape `(len,dim)` + dtype float32 + dim 반영
  - 행별 L2 정규화 (정규화 제거 시 norm≠1 → KILL)
  - **zero-vector 가드** (빈 텍스트 → all-zero, `norms[norms==0]=1.0` 로 0/0 nan 회피; 가드 제거 시 nan → KILL)
  - 결정성(md5) + 텍스트 구별성
  - **signed-feature** (digest 부호 비트가 -1 인 토큰 보존; sign→항상 +1 mutant KILL)
  - **충돌 누적** (같은 idx 충돌 시 `+=` 누적 magnitude; 대입 `=` mutant KILL)

## 3. 관련 이슈 (Related issue)

Closes #2262

## 4. 테스트 (Testing)

- `pytest -q` → **10 passed**, ruff/pyright clean
- 별도 lane code-reviewer adversarial mutation pass: 8 후보 + 구조 mutant 측정 → 초기 6/9 KILL + sign(M3)·충돌누적(M4) 2건 **vacuity 발견(REQUEST CHANGES)**. code-reviewer 가 반례 입력(`["기한"].min()==-1.0`, `"예산 예산"` magnitude 비율 2.0)으로 KILL 케이스 실측 제시 → 2 테스트 추가해 **mutation 10/10 KILL** 달성(oracle 자체 재검증 완료).

## 5. Eval 영향 (Eval impact)

N/A — `tests/` 추가 only, load-bearing 파일·동작 무변경.

## 6. 호환성 (Compatibility)

N/A — 신규 테스트 파일, 기존 계약/스키마 무변경.

## 7. 체크리스트 (Checklist)

- [x] 브랜치 `test/issue-2262-...` (ADR 0007)
- [x] `Closes #2262` body 참조
- [x] 동작 변경 없음 (test-only)
- [x] leaf 모듈 (hashlib/numpy + rag_text_processing.tokenize, rag_core back-edge 0, ADR 0045)
- [x] `expand_features` 는 #2105 로 이미 단위 커버 → 중복 회피로 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)