### PR TITLE
test(reranker): pin default fresh instance contract

### DIFF
--- a/tests/test_reranker_protocol.py
+++ b/tests/test_reranker_protocol.py
@@ -22,6 +22,10 @@ def test_default_reranker_is_cross_encoder() -> None:
     assert isinstance(reranker, CrossEncoderReranker)
 
 
+def test_default_reranker_returns_fresh_instance() -> None:
+    assert default_reranker() is not default_reranker()
+
+
 def test_cross_encoder_reranker_delegates_under_stub_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`default_reranker()`가 매 호출마다 fresh `CrossEncoderReranker` instance를 반환한다는 문서화된 contract를 테스트로 고정했습니다. 이 contract는 테스트나 향후 plan-level override에서 module-level singleton/shared state가 끼어드는 회귀를 막기 위한 test-only guard입니다.

Closes #2268

## 2. 영향 파일

- `tests/test_reranker_protocol.py` — default reranker factory fresh-instance assertion 추가(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 테스트는 현재 `default_reranker()` contract를 고정함.
- 배제 근거: 단일 assertion 추가만 포함했고 targeted pytest가 통과함.

## 4. 테스트

- `python3 -m pytest -q tests/test_reranker_protocol.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_reranker_protocol.py` was CLEAR.
- Branch was re-synced to latest `origin/main` before commit after root advanced by another session (#2265).

## 5. Eval 영향

RAG/load-bearing production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `rag_reranker.py` 구현은 변경하지 않음 — 현재 factory behavior를 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 protocol assertion이라 targeted pytest로 제한.
