### PR TITLE
test(retrieval): pin dense similarity clamp bounds

### DIFF
--- a/tests/test_dense_similarity_shape_validation.py
+++ b/tests/test_dense_similarity_shape_validation.py
@@ -41,6 +41,12 @@ class TestDenseSimilarityShapeValidation(unittest.TestCase):
         anti = -v
         self.assertAlmostEqual(dense_similarity(v, anti), 0.0, places=6)
 
+    def test_out_of_range_dot_product_is_clamped(self) -> None:
+        high = np.array([2.0, 0.0], dtype=np.float32)
+        low = np.array([-2.0, 0.0], dtype=np.float32)
+        self.assertEqual(dense_similarity(high, high), 1.0)
+        self.assertEqual(dense_similarity(high, low), 0.0)
+
     def test_shape_mismatch_raises_with_both_shapes(self) -> None:
         # The bug we are fixing: previously this returned 0.0
         # silently, corrupting retrieval ranking. Now it raises so


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`dense_similarity()`가 non-unit vector 입력으로 dot product가 `[−1, 1]` 밖으로 나가도 최종 score를 `[0, 1]`로 clamp하는 현재 contract를 테스트로 고정했습니다. shape mismatch 회귀 테스트에 더해 happy-path score bound가 깨지는 회귀를 빠르게 잡기 위한 test-only guard입니다.

Closes #2272

## 2. 영향 파일

- `tests/test_dense_similarity_shape_validation.py` — out-of-range dot product clamp assertion 추가(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 테스트는 현재 `dense_similarity()` score bound contract를 명시함.
- 배제 근거: 단일 테스트 메서드 추가만 포함했고 targeted pytest가 통과함.

## 4. 테스트

- `python3 -m pytest -q tests/test_dense_similarity_shape_validation.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_dense_similarity_shape_validation.py` was CLEAR.
- Branch was re-synced to latest `origin/main` before commit after root advanced by another session (#2269).

## 5. Eval 영향

RAG/load-bearing production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `rag_retrieval.py` 구현은 변경하지 않음 — 현재 clamp behavior를 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 regression assertion이라 targeted pytest로 제한.
