### PR TITLE
test(visual): pin ocr env provider resolution

### DIFF
--- a/tests/test_visual_donut_regression.py
+++ b/tests/test_visual_donut_regression.py
@@ -8,6 +8,7 @@ and the str-result wrap path are pure-python and runnable in CI.
 from __future__ import annotations
 
 import importlib.util
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -28,6 +29,13 @@ class GetOcrProviderFactoryTest(unittest.TestCase):
 
     def test_donut_resolves_without_loading_model(self) -> None:
         self.assertIs(get_ocr_provider("donut"), donut_ocr_provider)
+
+    def test_env_var_donut_resolves_without_loading_model(self) -> None:
+        os.environ["BIDMATE_VISUAL_OCR"] = "donut"
+        try:
+            self.assertIs(get_ocr_provider(), donut_ocr_provider)
+        finally:
+            os.environ.pop("BIDMATE_VISUAL_OCR", None)
 
     def test_unknown_name_lists_valid_options(self) -> None:
         with self.assertRaises(ValueError) as ctx:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`BIDMATE_VISUAL_OCR=donut` env-var 경로가 `get_ocr_provider()`에서 Donut provider로 resolve되며, factory 단계에서 실제 모델을 eager-load하지 않는 현재 contract를 테스트로 고정했습니다. 기존 explicit-name coverage에 env-var dispatch coverage를 추가하는 test-only regression guard입니다.

Closes #2276

## 2. 영향 파일

- `tests/test_visual_donut_regression.py` — env-var OCR provider resolution assertion 추가(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 테스트가 env var를 설정하지만 finally에서 제거함.
- 배제 근거: 단일 테스트 메서드 추가만 포함했고 targeted pytest가 통과함.

## 4. 테스트

- `python3 -m pytest -q tests/test_visual_donut_regression.py` (6 passed, existing pymupdf deprecation warnings)
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_visual_donut_regression.py` was CLEAR.

## 5. Eval 영향

RAG/load-bearing production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `visual_ingestion.py` 구현은 변경하지 않음 — 현재 env dispatch behavior를 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 factory assertion이라 targeted pytest로 제한.
