### PR TITLE
test(cache): tolerate visual module without donut cache

### DIFF
--- a/tests/test_model_cache_isolation.py
+++ b/tests/test_model_cache_isolation.py
@@ -61,6 +61,19 @@ class TestClearModelCaches:
             "use sys.modules.get() lookup, not direct `import visual_ingestion`."
         )
 
+    def test_loaded_visual_ingestion_without_donut_cache_is_safe(self) -> None:
+        """Older/stubbed visual_ingestion modules without the cache attr are ignored."""
+        import types
+
+        stub = types.ModuleType("visual_ingestion")
+        sys.modules["visual_ingestion"] = stub
+        MODEL_CACHE[("dummy-model", False, None)] = object()
+        try:
+            clear_model_caches()
+            assert len(MODEL_CACHE) == 0
+        finally:
+            sys.modules.pop("visual_ingestion", None)
+
     def test_clears_donut_cache_when_module_loaded(self) -> None:
         """Once ``visual_ingestion`` is loaded, its donut cache is also cleared."""
         # Synthesize a minimal visual_ingestion-shaped module without


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`clear_model_caches()`가 `visual_ingestion`이 이미 로드되어 있어도 `_DONUT_MODEL_CACHE` attr이 없으면 안전하게 no-op하는 현재 contract를 테스트로 고정했습니다. optional visual surface/stub module 조합에서 cache cleanup hook이 깨지지 않도록 하는 test-only regression guard입니다.

Closes #2278

## 2. 영향 파일

- `tests/test_model_cache_isolation.py` — loaded visual module without donut cache attr 케이스 추가(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 테스트가 `sys.modules["visual_ingestion"]`에 stub을 넣지만 finally에서 제거함.
- 배제 근거: 단일 테스트 메서드 추가만 포함했고 targeted pytest가 통과함.

## 4. 테스트

- `python3 -m pytest -q tests/test_model_cache_isolation.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_model_cache_isolation.py` was CLEAR.

## 5. Eval 영향

RAG/load-bearing production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `rag_embedding.py`/`rag_core.py` 구현은 변경하지 않음 — 현재 tolerant getattr behavior를 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 cache cleanup assertion이라 targeted pytest로 제한.
