### PR TITLE
test(eval): pin multiturn parent sentinel trimming

### DIFF
--- a/tests/test_multiturn_eval.py
+++ b/tests/test_multiturn_eval.py
@@ -20,9 +20,14 @@ class TestBuildQidParentMap(unittest.TestCase):
             {"qid": "Q2", "parent_qid": None},
             {"qid": "Q3", "parent_qid": "null"},
             {"qid": "Q4", "parent_qid": "None"},
+            {"qid": "Q5", "parent_qid": " null "},
+            {"qid": "Q6", "parent_qid": " None "},
         ]
         mapping = build_qid_parent_map(rows)
-        self.assertEqual(mapping, {"Q1": None, "Q2": None, "Q3": None, "Q4": None})
+        self.assertEqual(
+            mapping,
+            {"Q1": None, "Q2": None, "Q3": None, "Q4": None, "Q5": None, "Q6": None},
+        )
 
     def test_real_parent_chain(self) -> None:
         rows = [


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`build_qid_parent_map()`이 `" null "`/`" None "`처럼 주변 공백이 있는 parent sentinel을 root turn으로 정규화하는 현재 contract를 테스트로 고정했습니다. Multi-turn eval rows가 CSV/JSON 변환 과정에서 whitespace를 포함해도 turn-depth derivation이 흔들리지 않게 하는 test-only guard입니다.

Closes #2282

## 2. 영향 파일

- `tests/test_multiturn_eval.py` — whitespace-padded parent sentinel 케이스 추가(test-only)

## 3. 리스크

- 리스크: production 동작 변화 없음. 기존 sentinel normalization 테스트 데이터만 확장함.
- 배제 근거: targeted pytest가 통과했고 변경은 단일 assertion fixture 확장에 한정됨.

## 4. 테스트

- `python3 -m pytest -q tests/test_multiturn_eval.py`
- `git diff --check`
- `make check-branch`
- Overlap preflight: open PR files + `.codex/worktrees`, `.claude/worktrees`, `/Users/hskim/.codex/worktrees`, `/Users/hskim/Desktop/projects/bidmate-wt`, `/Users/hskim/issueF_recovery/wt` dirty/ahead files checked; `tests/test_multiturn_eval.py` was CLEAR.

## 5. Eval 영향

Eval production 파일 변경 없음. Test-only change라 public/private eval metric 영향 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. Answer-contract 변경 없음.

## 7. 범위 외

- `eval/multiturn_eval.py` 구현은 변경하지 않음 — 현재 strip behavior를 테스트로만 고정.
- 전체 test suite는 실행하지 않음 — 변경 범위가 단일 normalization fixture extension이라 targeted pytest로 제한.
