### PR TITLE
test: pin async bm25 backend forwarding

### DIFF
--- a/tests/test_async_rag_query_regression.py
+++ b/tests/test_async_rag_query_regression.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -62,6 +63,23 @@ class AsyncRagQueryParityTest(unittest.TestCase):
             sync_result["diagnostics"].get("pipeline"),
             async_result["diagnostics"].get("pipeline"),
         )
+
+    def test_arun_propagates_bm25_backend_kwarg(self) -> None:
+        calls: list[dict] = []
+
+        def fake_run_rag_query(index, query, **kwargs):
+            calls.append({"index": index, "query": query, "kwargs": kwargs})
+            return {"ok": True}
+
+        with patch("rag_core.run_rag_query", fake_run_rag_query):
+            result = self._run_async(
+                arun_rag_query(self.index, "bm25 backend probe", bm25_backend="bm25s")
+            )
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(calls[0]["index"], self.index)
+        self.assertEqual(calls[0]["query"], "bm25 backend probe")
+        self.assertEqual(calls[0]["kwargs"].get("bm25_backend"), "bm25s")
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`arun_rag_query`가 sync `run_rag_query`로 전달하는 retrieval knob가 늘어날 때 `bm25_backend` forwarding이 빠지는 회귀를 막기 위해 async wrapper regression test를 보강했습니다.

Closes #2285

## 2. 영향 파일

- `tests/test_async_rag_query_regression.py` — async wrapper kwarg forwarding test 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: fake sync entrypoint patch가 async thread wrapper와 충돌하는 경우.
- 배제 근거: targeted pytest에서 `asyncio.to_thread` 경유 호출이 fake를 실행하고 `bm25_backend="bm25s"` 캡처를 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_async_rag_query_regression.py` — 4 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=19 and `tests/test_async_rag_query_regression.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2285-async-bm25-backend` created from latest `origin/main`; pre-commit drift check `git rev-list --left-right --count HEAD...origin/main` = `0 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. ADR 0003 answer contract 변경 없음.

## 7. 범위 외

`arun_rag_query` production implementation 변경은 하지 않았습니다. 현재 구현이 이미 `bm25_backend`를 전달하므로 회귀 테스트만 추가했습니다.
