### PR TITLE
test: pin bm25 backend cache axis

### DIFF
--- a/tests/test_bm25_cache_invalidation.py
+++ b/tests/test_bm25_cache_invalidation.py
@@ -22,6 +22,7 @@ This test pins the new contract:
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -88,6 +89,28 @@ class TestBM25CacheInvalidation(unittest.TestCase):
         shared_regex = get_or_build_bm25(self.index, "shared", "regex")
         bm25_extra_regex = get_or_build_bm25(self.index, "bm25_extra", "regex")
         self.assertIsNot(shared_regex[0], bm25_extra_regex[0])
+
+    def test_backend_change_invalidates_cache(self) -> None:
+        built_backends: list[str] = []
+
+        def fake_make_bm25_instance(corpus, backend):
+            built_backends.append(backend)
+            return object()
+
+        with patch("rag_retrieval._make_bm25_instance", fake_make_bm25_instance):
+            okapi_first = get_or_build_bm25(
+                self.index, "shared", "regex", backend="okapi"
+            )
+            bm25s = get_or_build_bm25(
+                self.index, "shared", "regex", backend="bm25s"
+            )
+            okapi_second = get_or_build_bm25(
+                self.index, "shared", "regex", backend="okapi"
+            )
+
+        self.assertIsNot(okapi_first[0], bm25s[0])
+        self.assertIs(okapi_first[0], okapi_second[0])
+        self.assertEqual(built_backends, ["okapi", "bm25s"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

BM25 cache key가 backend 축(`okapi`/`bm25s`)을 분리한다는 ADR 0057/issue #988 계약이 회귀하지 않도록 cache invalidation regression test를 보강했습니다.

Closes #2288

## 2. 영향 파일

- `tests/test_bm25_cache_invalidation.py` — backend axis cache separation regression test 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: optional `bm25s` dependency가 없는 환경에서 테스트가 실패하는 경우.
- 배제 근거: `_make_bm25_instance`를 patch해 backend 인자만 캡처하므로 실제 `bm25s` 설치 여부와 무관합니다. 기존 module-level `rank_bm25` skip 정책은 그대로 둡니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_bm25_cache_invalidation.py` — 5 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_bm25_cache_invalidation.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2288-bm25-backend-cache-axis` created from latest `origin/main`; pre-commit drift check `git rev-list --left-right --count HEAD...origin/main` = `0 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. ADR 0003 answer contract 변경 없음.

## 7. 범위 외

`rag_retrieval.get_or_build_bm25` 구현 변경은 하지 않았습니다. 현재 구현이 이미 backend를 cache key에 포함하므로 회귀 테스트만 추가했습니다.
