### PR TITLE
test: pin threshold cli round trip

### DIFF
--- a/tests/test_governance_thresholds_regression.py
+++ b/tests/test_governance_thresholds_regression.py
@@ -53,6 +53,14 @@ class TestThresholdCli(unittest.TestCase):
         self.assertEqual(int(r.stdout.strip()), gov.THRESHOLDS["MEMORY_LINE_AWARE"])
         self.assertEqual(r.stderr, "")
 
+    def test_all_known_keys_round_trip_through_cli(self) -> None:
+        for key, value in gov.THRESHOLDS.items():
+            with self.subTest(key=key):
+                r = self._run(["--threshold", key])
+                self.assertEqual(r.returncode, 0)
+                self.assertEqual(int(r.stdout.strip()), value)
+                self.assertEqual(r.stderr, "")
+
     def test_unknown_key_exits_one_with_stderr(self) -> None:
         r = self._run(["--threshold", "NOPE_NOT_REAL"])
         self.assertEqual(r.returncode, 1)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/_governance.py --threshold`가 canonical `THRESHOLDS`의 모든 key를 CLI consumer에게 노출한다는 계약을 회귀 테스트로 고정했습니다.

Closes #2295

## 2. 영향 파일

- `tests/test_governance_thresholds_regression.py` — all-key threshold CLI round-trip regression test 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: threshold key 추가 시 CLI 출력 계약이 일부 key에서 깨지는 경우.
- 배제 근거: 신규 subTest가 `gov.THRESHOLDS.items()` 전체를 순회해 exit code/stdout/stderr를 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_governance_thresholds_regression.py` — 8 passed, 4 subtests passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_governance_thresholds_regression.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2295-threshold-cli-roundtrip` created from latest `origin/main`; pre-commit drift check `git rev-list --left-right --count HEAD...origin/main` = `0 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `scripts/_governance.py --threshold` 계약을 더 넓게 테스트할 뿐입니다.

## 7. 범위 외

`scripts/_governance.py` 구현 변경은 하지 않았습니다. 현재 CLI가 이미 모든 threshold key를 round-trip하므로 회귀 테스트만 추가했습니다.
