### PR TITLE
fix(text_normalize): stop bare-body numerals ending in 정 from parsing as money

### DIFF
--- a/tests/test_followup_entity_injection.py
+++ b/tests/test_followup_entity_injection.py
@@ -158,22 +158,28 @@ class FollowUpRetrievalAnchorRegressionTest(unittest.TestCase):
         # Pre-#71 the resolved_query was just the user's input.
         self.assertNotEqual(resolved_query, "그럼 일정은 어떻게 돼?")
 
-    def test_follow_up_still_resolves_to_correct_doc(self) -> None:
-        # Sanity: the metadata-first path still drives this case to
-        # the right agency on synthetic data. The fix is purely
-        # additive — it gives the entity anchor to dense/lexical
-        # scoring without changing what already worked.
+    def test_follow_up_abstains_when_doc_lacks_schedule(self) -> None:
+        # The smoke fixture (AI-quality RFP) carries no 일정(schedule)
+        # content, so a '일정' follow-up must honestly abstain — ADR 0003
+        # treats abstention as a first-class status, not an error.
+        #
+        # This previously asserted status == "supported" with evidence
+        # from rfp-agency-a-ai-quality, but that grounding was a #2228
+        # artefact: normalize_text('일정') == '1' injected '1' into
+        # expand_forms('일정'), so the verifier false-matched the
+        # document's bare digit '1' as schedule evidence. With the fix
+        # expand_forms('일정') == ['일정'] and the verifier correctly
+        # finds no grounding, clearing the evidence pool.
+        #
+        # The #71 entity-injection guard is covered independently by
+        # test_resolved_query_contains_entity_anchor above.
         result = run_rag_query(
             self.index,
             "그럼 일정은 어떻게 돼?",
             context_entities=["기관 A"],
         )
-        self.assertEqual(result["answer"]["status"], "supported")
-        evidence = result.get("evidence", [])
-        self.assertTrue(evidence)
-        self.assertEqual(
-            evidence[0]["doc_id"], "rfp-agency-a-ai-quality"
-        )
+        self.assertEqual(result["answer"]["status"], "insufficient")
+        self.assertEqual(result.get("evidence", []), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_text_normalize_regression.py
+++ b/tests/test_text_normalize_regression.py
@@ -136,6 +136,17 @@ class FalsePositiveGuardTest(unittest.TestCase):
         "오전 10시",
         "2024년",  # year alone is not money
         "약 30%",  # percent, not amount
+        # issue #2228: a bare-body Korean numeral ending in an envelope glyph
+        # ('정') is an ordinary noun, not money. Before the fix the bare-body
+        # branch accepted a lone 정 suffix, so parse_amounts('일정') returned
+        # [ParsedAmount(value=1)] and normalize_text('일정')=='1'.
+        "일정",  # 일(1) + 정(envelope strip) — a very common RFP word
+        "추진일정",
+        "세부일정",
+        "일정표",
+        "삼정",
+        "구정",  # 설날(舊正)
+        "이정표",  # 이(2) + 정
     ]
 
     DATE_NEGATIVES = [
@@ -288,6 +299,21 @@ class EndToEndVerifyEvidenceTest(unittest.TestCase):
         # topics must NOT match.
         item = _evidence_item("기관 A 예산은 5천만원이다.")
         self.assertFalse(evidence_has_topic(item, ["완전히다른토픽xyz"]))
+
+    def test_jeong_noun_topic_does_not_false_match_bare_digit(self) -> None:
+        # issue #2228: a '일정'(schedule) topic must NOT be grounded by
+        # evidence that merely contains a bare digit '1'. Before the fix
+        # normalize_text('일정')=='1' injected '1' into expand_forms('일정'),
+        # so any document with a '1' (1차/1명/12월/제1조) false-matched and
+        # the #1008 single-doc grounding floor was bypassed for this very
+        # common RFP term.
+        self.assertEqual(["일정"], expand_forms("일정"))
+        item = _evidence_item("담당자는 1명이며 12월에 시작합니다.")  # no '일정', has '1'
+        self.assertFalse(evidence_has_topic(item, ["일정"]))
+        verified, reasons = verify_evidence(self._analysis(["일정"]), [item])
+        self.assertFalse(
+            verified, f"expected not grounded, got reasons={reasons}"
+        )
 
     def test_canonical_iso_date_matches_korean_date_evidence(self) -> None:
         # Query topic "2026-03-15" (canonical) must match evidence written

--- a/text_normalize.py
+++ b/text_normalize.py
@@ -80,13 +80,20 @@ _HANGUL_NUMBER_SECTIONED = (
 )
 # Trailing money-unit suffix. 정 must NOT be followed by 도 (그것은 '정도' approximation marker).
 _HANGUL_MONEY_SUFFIX = r"(?:\s*원\s*정|\s*원|\s*정(?!도))"
+# Bare-body suffix (issue #2228): the bare-body branch carries no section marker
+# (만/억/조), so allowing a lone 정 anchor lets pure digit-words be misread as
+# money — `일정`(일=1, 정=envelope strip) → `1`, which poisons verifier topic
+# grounding (`expand_forms('일정')==['일정','1']` then false-matches any document
+# containing a `1`). Require an explicit 원 unit here; the sectioned branch keeps
+# 정 so real amounts like `일금일억정`=100000000 are preserved.
+_HANGUL_MONEY_SUFFIX_BARE = r"(?:\s*원\s*정|\s*원)"
 
 _HANGUL_MONEY_RE = re.compile(
     r"(?:일금\s*)?"
     r"(?:"
     rf"{_HANGUL_NUMBER_SECTIONED}{_HANGUL_MONEY_SUFFIX}?"  # sectioned (anchor = section)
     r"|"
-    rf"{_HANGUL_MYRIAD_BODY}{_HANGUL_MONEY_SUFFIX}"        # bare body (anchor = 원/정)
+    rf"{_HANGUL_MYRIAD_BODY}{_HANGUL_MONEY_SUFFIX_BARE}"   # bare body (anchor = 원, #2228)
     r")"
 )
 


### PR DESCRIPTION
## 요약

`normalize_text('일정') == '1'` 버그를 수정한다. bare-body money regex가 `정` 단독을 화폐 종결 suffix로 허용해 `일`(=1) + `정`(envelope strip) = `1`로 오정규화했고, 이것이 `expand_forms('일정') == ['일정', '1']`을 거쳐 verifier topic grounding을 오염시켰다.

## 배경 / 측정 (선행)

`일정`은 RFP 초빈출 단어(추진일정/세부일정/사업일정). 측정으로 확인한 전파:

| 항목 | 결과 |
|---|---|
| 오변환 범위 | `일정` 계열 + 한글숫자 명사(`삼정`→3, `구정`→9, `이정표`→2표, `일조`→10^12) |
| **verifier 전파** | **확정** — `일정` topic이 `1`만 든 무관 근거를 `verified=True`. 대조군 `예산`/`목록`은 정상 `topic_not_grounded` |
| 근본 원인 | `_HANGUL_MONEY_RE` bare-body 브랜치 `정` 단독 suffix |
| ADR 0001 baseline | eval fixture 케이스 topic/query 영향 **0** |

`'1' in doc_text`는 RFP 문서(1차/1명/12월/제1조)에서 사실상 항상 참 → `일정` topic에서 #1008 single-doc grounding floor 무력화.

## 변경 내용

- `text_normalize.py`: bare-body 전용 suffix `_HANGUL_MONEY_SUFFIX_BARE`(= `원`/`원정`, **`정` 단독 제외**) 도입. bare-body 브랜치만 사용. sectioned 브랜치(억/만/조 단위)는 기존 `_HANGUL_MONEY_SUFFIX`(정 포함) 유지 → `일금일억정`=100000000 보존.
- `tests/test_text_normalize_regression.py`: `AMOUNT_NEGATIVES`에 일정 계열 7개(저수준 `parse_amounts==[]` 가드) + `EndToEndVerifyEvidenceTest`에 전파 해소 회귀(`일정` topic이 bare digit `1` 근거를 grounding하지 않음 + `expand_forms('일정')==['일정']`).

## 테스트

- 회귀: 19 passed (48 subtests)
- blast-radius(verifier grounding/partial-topic/aggregate/query/compare): 94 passed (57 subtests)
- **mutation test**: 수정을 버그 상태로 되돌리면 8 케이스 FAIL(`['일정','1']` 차이 + 전파) — non-vacuous 증명
- money 보존 9/9, 일정 계열 교정

## §5 Eval 영향 (load-bearing transitive)

`text_normalize.py`는 LOAD_BEARING_PATHS 직접 미등록이나 `rag_core`/`rag_query`/`rag_verifier`가 import. eval fixture 케이스의 query/expected_terms/topic에 한글숫자+정/조 토큰 **0건** → fixture smoke byte-identical 기대(CI "Fixture smoke eval vs base"로 확인). 동작 변경은 `일정`류 topic 한정(false-verify 제거 = 더 엄격한 grounding). private real-eval은 maintainer-gated 표면 밖(미측정) — 동작이 "무관 근거 차단" 방향이라 회귀 위험 낮음.

## 리스크 / 롤백

- 리스크: bare-body에서 `정`을 제거했으나 sectioned가 단위 있는 진짜 money를 커버하므로 money 회귀 없음(9/9 측정 + mutation 확인). Codex adversarial review로 반례 탐색 중.
- 범위 밖(follow-up): `일원화`→`1화`(`원`=진짜 화폐단위라 bare 분기로 안 풀림, 별도 모호성, 빈도 낮음).
- pre-existing dead code `_APPROX_PREFIX`/`_APPROX_SUFFIX`(line 58/59)는 이 PR 범위 밖(origin/main 기존).
- 롤백: 단일 커밋 revert.

Closes #2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
