### PR TITLE
test: pin verifier feedback bullet order

### DIFF
--- a/tests/test_verifier_feedback_regression.py
+++ b/tests/test_verifier_feedback_regression.py
@@ -56,6 +56,13 @@ def test_reasons_are_included_in_output():
         assert r in result, f"reason '{r}' not found in feedback"
 
 
+def test_reasons_are_bulleted_in_order():
+    reasons = ["low_top_score", "topic_not_grounded", "missing_comparison_doc:d1"]
+    result = format_verifier_feedback(reasons=reasons, evidence=[])
+    bullet_lines = [line for line in result.splitlines() if line.startswith("- ")]
+    assert bullet_lines == [f"- {reason}" for reason in reasons]
+
+
 def test_chunk_count_is_mentioned():
     evidence: list[dict[str, Any]] = [
         {"chunk_id": "c1", "text": "테스트1"},


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Verifier feedback가 planner에게 failure reason을 순서 보존 bullet list로 전달한다는 formatting contract를 회귀 테스트로 고정했습니다.

Closes #2300

## 2. 영향 파일

- `tests/test_verifier_feedback_regression.py` — ordered bullet-line regression test 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: feedback message formatting 변경 시 planner가 reason 순서를 잃는 경우.
- 배제 근거: 신규 테스트가 `format_verifier_feedback` 출력의 `- ` bullet lines를 추출해 입력 reasons 순서와 정확히 비교합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_verifier_feedback_regression.py` — 9 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=19 and `tests/test_verifier_feedback_regression.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2300-verifier-feedback-bullets` created from latest `origin/main`; pre-commit drift check `git rev-list --left-right --count HEAD...origin/main` = `0 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. ADR 0003 answer contract 변경 없음.

## 7. 범위 외

`rag_verifier.format_verifier_feedback` 구현 변경은 하지 않았습니다. 현재 구현이 이미 ordered bullet formatting을 제공하므로 회귀 테스트만 추가했습니다.
