### PR TITLE
test: pin KO axis alias abbreviation detection

### DIFF
--- a/tests/test_ko_axes_aggregation.py
+++ b/tests/test_ko_axes_aggregation.py
@@ -70,6 +70,13 @@ class TestDetectKoAxes(unittest.TestCase):
             with self.subTest(row=row):
                 self.assertIn(KO_AXIS_ABBREVIATION, detect_ko_axes(row))
 
+    def test_abbreviation_axis_scans_acceptable_aliases(self) -> None:
+        row = {
+            "question": "학습관리시스템의 연계 범위는?",
+            "acceptable_aliases": "LMS 시스템|Learning Management System",
+        }
+        self.assertIn(KO_AXIS_ABBREVIATION, detect_ko_axes(row))
+
     def test_no_axis(self) -> None:
         row = {
             "question": "이 사업의 추진목표는?",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`detect_ko_axes`가 `acceptable_aliases` 필드의 abbreviation 표현도 axis detection에 포함한다는 field coverage contract를 회귀 테스트로 고정했습니다.

Closes #2304

## 2. 영향 파일

- `tests/test_ko_axes_aggregation.py` — acceptable_aliases abbreviation axis regression test 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: KO-axis detector field list 변경 시 alias에만 존재하는 약칭이 누락되는 경우.
- 배제 근거: 신규 테스트가 `question`에는 약칭이 없고 `acceptable_aliases`에만 `LMS 시스템`이 있는 row에서 `KO_AXIS_ABBREVIATION` detection을 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_ko_axes_aggregation.py` — 9 passed, 13 subtests passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=19 and `tests/test_ko_axes_aggregation.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2304-ko-axis-alias-abbrev` created from latest `origin/main`; pre-commit drift check `git rev-list --left-right --count HEAD...origin/main` = `0 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. KO-axis detector 구현 변경 없이 field coverage contract만 테스트로 고정했습니다.

## 7. 범위 외

`eval/ko_axes.py` 구현 변경은 하지 않았습니다. 현재 구현이 이미 `acceptable_aliases`를 검사하므로 회귀 테스트만 추가했습니다.
