### PR TITLE
test: pin hyphenated email PII redaction

### DIFF
--- a/tests/test_security_pii_redaction.py
+++ b/tests/test_security_pii_redaction.py
@@ -42,6 +42,7 @@ class RedactEmailTest(unittest.TestCase):
     CASES = (
         ("이메일 foo@bar.com 으로 문의", "이메일 <email> 으로 문의"),
         ("user.name+tag@example.co.kr", "<email>"),
+        ("담당자 ops-team@bid-mate.co.kr", "담당자 <email>"),
         ("multi: a@b.com, c@d.org", "multi: <email>, <email>"),
         # Non-matches.
         ("@not-an-email", "@not-an-email"),


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`redact_pii`가 vendor-style hyphenated domain 이메일도 `<email>`로 치환한다는 regression fixture를 추가했습니다.

Closes #2309

## 2. 영향 파일

- `tests/test_security_pii_redaction.py` — `ops-team@bid-mate.co.kr` email redaction fixture 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: email regex/fixture refactor 때 hyphenated domain 주소가 조용히 redaction 밖으로 빠지는 경우.
- 배제 근거: 신규 테스트가 hyphenated local-part/domain 조합을 직접 `<email>`로 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_security_pii_redaction.py` — 7 passed, 24 subtests passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_security_pii_redaction.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2309-hyphen-email-redaction` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `bidmate_security.py` 구현 변경 없이 기존 redaction contract만 테스트로 고정했습니다.

## 7. 범위 외

`bidmate_security.py` PII regex/policy 변경은 하지 않았습니다.
