### PR TITLE
test: pin 일금-prefixed currency digits

### DIFF
--- a/tests/test_ko_normalize.py
+++ b/tests/test_ko_normalize.py
@@ -18,6 +18,7 @@ class TestNormalizeCurrency(unittest.TestCase):
         cases = [
             ("10000000원", Decimal("10000000")),
             ("10,000,000원", Decimal("10000000")),
+            ("일금 10,000원", Decimal("10000")),
             ("10,000,000", Decimal("10000000")),
             ("0", Decimal(0)),
         ]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_currency`가 `일금` prefix가 붙은 pure-digit 원화 금액도 정상 파싱한다는 regression fixture를 추가했습니다.

Closes #2311

## 2. 영향 파일

- `tests/test_ko_normalize.py` — `일금 10,000원` currency normalization fixture 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: currency parser refactor 때 scale-word fixture는 통과하지만 `일금` + pure-digit 조합이 조용히 누락되는 경우.
- 배제 근거: 신규 테스트가 `일금 10,000원`을 `Decimal("10000")`로 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_ko_normalize.py` — 11 passed, 36 subtests passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_ko_normalize.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2311-currency-ilgeum-digits` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `rag_normalize.py` 구현 변경 없이 기존 parsing contract만 테스트로 고정했습니다.

## 7. 범위 외

`rag_normalize.py` parser 구현 변경은 하지 않았습니다.
