### PR TITLE
test: pin lowercase logging level env

### DIFF
--- a/tests/test_bidmate_logging.py
+++ b/tests/test_bidmate_logging.py
@@ -98,6 +98,12 @@ def test_level_env_var_respected(monkeypatch: pytest.MonkeyPatch) -> None:
     assert logger.getEffectiveLevel() == logging.WARNING
 
 
+def test_level_env_var_accepts_lowercase(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(bidmate_logging.ENV_LEVEL, "warning")
+    logger = bidmate_logging.get_logger("rag_core")
+    assert logger.getEffectiveLevel() == logging.WARNING
+
+
 def test_invalid_level_falls_back_to_info(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(bidmate_logging.ENV_LEVEL, "NOT_A_LEVEL")
     logger = bidmate_logging.get_logger("rag_core")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`bidmate_logging.get_logger`가 `BIDMATE_LOG_LEVEL=warning`처럼 소문자 env 값을 받아도 `logging.WARNING`으로 해석한다는 regression fixture를 추가했습니다.

Closes #2314

## 2. 영향 파일

- `tests/test_bidmate_logging.py` — lowercase log-level env fixture 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: logger setup refactor 때 uppercase env fixture는 통과하지만 lowercase 운영 env 값이 조용히 INFO fallback으로 떨어지는 경우.
- 배제 근거: 신규 테스트가 `warning`을 `logging.WARNING`으로 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_bidmate_logging.py` — 8 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_bidmate_logging.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2314-lowercase-log-level` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `bidmate_logging.py` 구현 변경 없이 기존 env normalization contract만 테스트로 고정했습니다.

## 7. 범위 외

`bidmate_logging.py` logger setup 구현 변경은 하지 않았습니다.
