### PR TITLE
test: pin QueryParams BM25 defaults

### DIFF
--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -181,6 +181,8 @@ class QueryParamsShapeTest(unittest.TestCase):
             "comparison_balance",
             "rrf_k",
             "bm25_stopword_profile",
+            "bm25_tokenizer",
+            "bm25_backend",
         ):
             self.assertIsNone(
                 getattr(params, field_name),


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`QueryParams()` empty bundle의 default-none shape contract에 BM25 config fields(`bm25_tokenizer`, `bm25_backend`)도 포함되도록 regression fixture를 보강했습니다.

Closes #2318

## 2. 영향 파일

- `tests/test_query_params.py` — QueryParams default-none field list에 BM25 tokenizer/backend 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: bundled params refactor 때 BM25 fields만 non-None default를 갖게 되어 `QueryParams()`가 bare call no-op contract에서 벗어나는 경우.
- 배제 근거: 신규 테스트가 두 BM25 fields의 `None` default를 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_query_params.py` — 9 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18 and `tests/test_query_params.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2318-queryparams-bm25-defaults` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `rag_core.QueryParams` 구현 변경 없이 기존 default contract만 테스트로 고정했습니다.

## 7. 범위 외

`rag_core.py` 및 retrieval/BM25 구현 변경은 하지 않았습니다.
