### PR TITLE
test: pin same-cost Pareto dominance

### DIFF
--- a/tests/test_pareto_frontier.py
+++ b/tests/test_pareto_frontier.py
@@ -57,6 +57,14 @@ class TestComputeParetoFrontier(unittest.TestCase):
             {"cheap", "good", "expensive"},
         )
 
+    def test_same_cost_higher_quality_dominates(self) -> None:
+        points = [
+            self._pt("same_cost_low", cost=5, quality=0.6),
+            self._pt("same_cost_high", cost=5, quality=0.8),
+        ]
+        frontier = compute_pareto_frontier(points)
+        self.assertEqual({p.name for p in frontier}, {"same_cost_high"})
+
     def test_ties_are_kept(self) -> None:
         # Two points with identical cost and quality should both stay —
         # neither strictly dominates the other.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Pareto frontier 계산에서 cost가 같고 quality만 더 높은 point가 낮은 quality point를 지배한다는 edge-case regression fixture를 추가했습니다.

Closes #2322

## 2. 영향 파일

- `tests/test_pareto_frontier.py` — same-cost higher-quality dominance fixture 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: frontier logic refactor 때 cheaper+higher-quality dominance는 유지되지만 equal-cost quality dominance가 조용히 깨지는 경우.
- 배제 근거: 신규 테스트가 같은 cost의 low/high quality point 중 high만 frontier에 남는지 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_pareto_frontier.py` — 11 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=19 and `tests/test_pareto_frontier.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2322-pareto-same-cost-quality` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `scripts/plot_pareto.py` 구현 변경 없이 기존 dominance contract만 테스트로 고정했습니다.

## 7. 범위 외

Pareto plotting/rendering/markdown 구현 변경은 하지 않았습니다.
