### PR TITLE
test: pin naive golden query set

### DIFF
--- a/tests/test_naive_baseline_ranking_invariance.py
+++ b/tests/test_naive_baseline_ranking_invariance.py
@@ -37,6 +37,15 @@ class NaiveBaselineRankingInvarianceTest(unittest.TestCase):
         cls.golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
         cls.rebuilt = build_golden(cls.golden)
 
+    def test_rebuild_preserves_committed_query_set(self) -> None:
+        self.assertTrue(self.golden, "naive_baseline golden query set is empty")
+        self.assertEqual(
+            set(self.golden),
+            set(self.rebuilt),
+            "build_golden must preserve the committed query set; add/remove "
+            "queries by editing tests/data/naive_baseline_top_k.json deliberately.",
+        )
+
     def test_top_k_chunk_ids_match_golden(self) -> None:
         for query, golden_top in self.golden.items():
             with self.subTest(query=query):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`naive_baseline` golden rebuild가 committed query set을 그대로 보존해야 한다는 contract를 테스트로 고정했습니다. golden key 추가/삭제는 `tests/data/naive_baseline_top_k.json` 편집이라는 의도적 변경이어야 합니다.

Closes #2328

## 2. 영향 파일

- `tests/test_naive_baseline_ranking_invariance.py` — rebuild 결과 key set이 committed golden key set과 일치하고 golden query set이 비어 있지 않은지 검증 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: `build_golden` refactor 중 query set을 암묵적으로 추가/삭제해도 top-K 비교만으로는 의도가 흐려지는 경우.
- 배제 근거: 신규 테스트가 `set(self.golden) == set(self.rebuilt)`를 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_naive_baseline_ranking_invariance.py` — 2 passed, 4 subtests passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=19, worktrees=116, and `tests/test_naive_baseline_ranking_invariance.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2328-naive-golden-query-set` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `scripts/regen_naive_baseline_golden.py` 구현 변경 없이 existing ADR 0001 regeneration contract만 테스트로 고정했습니다.

## 7. 범위 외

Golden 데이터 갱신, retrieval/ranking 로직 변경, regenerator 구현 변경은 하지 않았습니다.
