### PR TITLE
test(ingestion): CSV/텍스트/예산 정규화 순수 helper 커버리지

### DIFF
--- a/tests/test_ingestion_normalize_helpers.py
+++ b/tests/test_ingestion_normalize_helpers.py
@@ -1,0 +1,87 @@
+"""Unit coverage for ingestion.py CSV/텍스트/예산 정규화 순수 helper (issue #2323).
+
+``parse_budget`` / ``clean_cell`` / ``normalize_body_text`` / ``slug_part`` /
+``normalize_file_format`` 은 import-safe leaf(torch/chromadb/rag_core 미로드)인데
+직접 단위 테스트가 0건이었다(test-only, 소스 무수정).
+
+핵심 변별:
+- ``parse_budget`` — comma 제거 후 정수면 int, 소수면 float, 파싱 실패면 원문 문자열,
+  None/빈 → None. int/float 타입 구별까지 고정.
+- ``slug_part`` — 연속 공백을 하이픈 1개로 collapse(NFC).
+- ``normalize_file_format`` — value 가 있으면 우선, 없을 때만 파일명 suffix.
+"""
+from __future__ import annotations
+
+import unicodedata
+
+from ingestion import (
+    clean_cell,
+    normalize_body_text,
+    normalize_file_format,
+    parse_budget,
+    slug_part,
+)
+
+
+# ---- parse_budget ----
+
+def test_parse_budget_int_float_text_and_empty() -> None:
+    # comma 제거 + 정수 → int (타입까지 구별; float 이면 KILL).
+    out_int = parse_budget("1,000")
+    assert out_int == 1000 and isinstance(out_int, int)
+    # 소수 → float.
+    out_float = parse_budget("1,234.5")
+    assert out_float == 1234.5 and isinstance(out_float, float)
+    # "100.0" 은 is_integer() → int 로 다운캐스트.
+    out_round = parse_budget("100.0")
+    assert out_round == 100 and isinstance(out_round, int)
+    # 숫자가 아니면 원문(clean_cell) 문자열 그대로 반환.
+    assert parse_budget("약 5억") == "약 5억"
+    # None / 공백 → None.
+    assert parse_budget(None) is None
+    assert parse_budget("   ") is None
+
+
+# ---- clean_cell ----
+
+def test_clean_cell_handles_none_and_strips() -> None:
+    assert clean_cell(None) == ""  # None → 빈 문자열("None" 아님)
+    assert clean_cell("  x  ") == "x"  # 양끝 공백 제거
+    assert clean_cell("   ") == ""  # 공백만 → 빈 문자열
+
+
+# ---- normalize_body_text ----
+
+def test_normalize_body_text_unifies_newlines() -> None:
+    # CRLF·CR 모두 LF 로 통일.
+    assert normalize_body_text("a\r\nb\rc") == "a\nb\nc"
+    assert normalize_body_text(None) == ""
+
+
+# ---- slug_part ----
+
+def test_slug_part_collapses_whitespace_to_single_hyphen() -> None:
+    # 연속 공백(스페이스/탭) → 하이픈 1개. "가--나" 같은 다중 하이픈이면 KILL.
+    assert slug_part("가  나   다") == "가-나-다"
+    assert slug_part(" a\tb ") == "a-b"
+    assert slug_part("") == ""
+
+
+def test_slug_part_nfc_normalizes_decomposed() -> None:
+    # NFC 정규화로 분해형(NFD) 한글이 결합형과 같은 slug 가 된다 — doc_id 안정성 보장.
+    # NFC 를 제거하면 NFD 입력이 분해된 코드포인트로 남아 결합형과 달라져 KILL.
+    nfd = unicodedata.normalize("NFD", "가 나")
+    assert len(nfd) != len("가 나")  # 분해형은 코드포인트 수가 다름(전제 확인)
+    assert slug_part(nfd) == slug_part("가 나") == "가-나"
+
+
+# ---- normalize_file_format ----
+
+def test_normalize_file_format_prefers_value_then_suffix() -> None:
+    # value 가 있으면 lower + 선행 "." 제거 후 우선(파일명 suffix 보다 앞섬).
+    assert normalize_file_format(".PDF", "x.hwp") == "pdf"
+    # value 가 비면 파일명 suffix 로 fallback.
+    assert normalize_file_format("", "doc.HWP") == "hwp"
+    assert normalize_file_format(None, "a.pdf") == "pdf"
+    # 둘 다 비면 빈 문자열.
+    assert normalize_file_format("", "noext") == ""


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`ingestion.py` 의 CSV 셀/텍스트/예산 정규화 순수 helper 5종이 직접 단위 테스트 0건이었다. 예산 int/float 판별·CRLF 정규화·slug 공백 collapse·NFC 정규화·파일 포맷 fallback 이 조용히 깨져도 회귀가 안 잡혔다. oracle 기반 단위 테스트 6건 추가(test-only, 소스 무수정).

- `parse_budget`(comma 제거 + int/float 타입 + 원문 fallback), `clean_cell`(None→""+strip), `normalize_body_text`(CRLF/CR→LF), `slug_part`(NFC + 연속 공백→하이픈 collapse), `normalize_file_format`(value 우선 + suffix fallback).

## 2. 어떻게 (How)

- `tests/test_ingestion_normalize_helpers.py` 신규 1파일, 6 테스트.
- 핵심 변별(vacuity 방지): parse_budget int/float 타입 구별(isinstance), slug_part 연속 공백 collapse + **NFC 정규화(분해형 NFD 입력이 결합형과 같은 slug — doc_id 안정성)**, normalize_file_format value 우선, CRLF 순서.
- 모든 oracle 은 실제 함수 실행으로 캡처·self-verify.

## 3. 테스트 (Tests)

- `python3 -m pytest tests/test_ingestion_normalize_helpers.py -q` → **6 passed**.
- ruff/pyright clean. import-safe leaf 확인(torch/chromadb/rag_core 미로드).

## 4. 스크린샷 / 로그 (Screenshots / Logs)

```
......                                                                   [100%]
6 passed in 0.74s
```

## 5. Eval 영향 (Eval Impact)

해당 없음 — test-only PR. 소스/계약/CI 설정/baseline 무변경(ADR 0001 무관), 동작 변경 없음. load-bearing 경로 미변경(`tests/` 신규 1파일).

## 6. 리스크 / 롤백 (Risk / Rollback)

리스크 최소 — 테스트 추가만. 롤백 시 파일 1개 삭제로 원복. 별도 lane code-reviewer adversarial mutation(21 mutant): comma/int-downcast/CRLF 순서/공백 collapse/value 우선 등 20 KILL; slug_part NFC 미테스트 gap(SP2, 모든 입력이 이미 NFC) 발견 → 분해형(NFD) discriminator 추가로 KILL. (리뷰가 함께 플래그한 test_pareto_frontier.py "삭제" 는 worktree base 가 #2324 머지 전이라 발생한 stale-base diff illusion — rebase 후 deletion 0, 본 PR 은 신규 1파일만 변경.)

## 7. 관련 이슈 (Related Issues)

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)