### PR TITLE
test: pin process warm comment adjacency

### DIFF
--- a/tests/test_process_warm_docstring_pinning.py
+++ b/tests/test_process_warm_docstring_pinning.py
@@ -61,6 +61,29 @@ class TestProcessWarmDocstringPinning(unittest.TestCase):
                 f"Last 30 lines before assignment:\n{last_n_lines}",
             )
 
+    def test_process_warm_comment_stays_adjacent_to_assignment(self) -> None:
+        """The caveat must stay attached to the state flag it documents."""
+        lines = inspect.getsource(rag_core).splitlines()
+        assignment_index = next(
+            (
+                i
+                for i, line in enumerate(lines)
+                if line.strip() == "_PROCESS_WARM = False"
+            ),
+            None,
+        )
+        self.assertIsNotNone(assignment_index, "_PROCESS_WARM assignment not found")
+        previous_nonblank = next(
+            line.strip()
+            for line in reversed(lines[:assignment_index])
+            if line.strip()
+        )
+        self.assertTrue(
+            previous_nonblank.startswith("# See issue #842"),
+            "_PROCESS_WARM caveat comment must remain adjacent to the assignment; "
+            f"last nonblank line before assignment was: {previous_nonblank!r}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`_PROCESS_WARM` long-tail caveat comment가 실제 `_PROCESS_WARM = False` assignment 바로 위에 붙어 있어야 한다는 regression guard를 추가했습니다. comment가 멀어져도 phrase-only test가 통과하는 상태를 막습니다.

Closes #2333

## 2. 영향 파일

- `tests/test_process_warm_docstring_pinning.py` — `_PROCESS_WARM` assignment 직전 nonblank line이 issue #842 caveat pointer인지 검증 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: future refactor가 caveat phrase는 남기지만 assignment와 분리해 문서 의미가 약해지는 경우.
- 배제 근거: 신규 테스트가 comment adjacency를 직접 확인합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_process_warm_docstring_pinning.py` — 2 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=18, worktrees=112, and `tests/test_process_warm_docstring_pinning.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2333-process-warm-adjacency` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `rag_core.py` 구현 변경 없이 issue #842 documentation contract만 테스트로 고정했습니다.

## 7. 범위 외

`_PROCESS_WARM` 동작 변경, TTL tracker 도입, latency aggregation 변경은 하지 않았습니다.
