### PR TITLE
test(ingestion): dedup/redaction 순수 helper 커버리지

### DIFF
--- a/tests/test_ingestion_dedup_redaction.py
+++ b/tests/test_ingestion_dedup_redaction.py
@@ -1,0 +1,123 @@
+"""Unit coverage for ingestion.py dedup/redaction 순수 helper (issue #2329).
+
+``_redact_section_text`` / ``validate_fieldnames`` / ``_compute_next_unique_doc_id`` /
+``_looks_like_notice_id_doc`` 은 import-safe leaf(torch/chromadb/rag_core 미로드)인데
+직접 단위 테스트가 0건이었다(test-only, 소스 무수정).
+
+핵심 변별:
+- ``_redact_section_text`` — 각 section dict 를 copy 한 뒤 ``text`` 만 ``redact_pii``
+  로 치환. 원본 list/dict 는 불변, ``text`` 키 부재 시에도 빈 문자열로 채운다.
+- ``validate_fieldnames`` — ``REQUIRED_COLUMNS`` 누락 시 누락 컬럼을 원래 순서대로
+  담은 ``ValueError``, 전부 있으면 조용히 ``None``.
+- ``_compute_next_unique_doc_id`` — ``counts`` 를 시작점으로, ``seen`` 충돌은 skip 하며
+  ``<base>-N`` 후보와 N 을 함께 반환.
+- ``_looks_like_notice_id_doc`` — doc_id 가 파일명 stem slug 와 다르면(또는 비면) True.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ingestion import (
+    REQUIRED_COLUMNS,
+    IngestionRecord,
+    _DuplicateTracker,
+    _compute_next_unique_doc_id,
+    _looks_like_notice_id_doc,
+    _redact_section_text,
+    validate_fieldnames,
+)
+
+
+# ---- _redact_section_text ----
+
+def test_redact_section_text_masks_phone_and_preserves_other_keys() -> None:
+    out = _redact_section_text([{"section": "1", "text": "전화 010-1234-5678"}])
+    # redact_pii 호출 — 전화번호가 <phone> 으로 마스킹(미호출 시 원문 KILL).
+    assert out[0]["text"] == "전화 <phone>"
+    # text 외 다른 필드(section) 는 보존.
+    assert out[0]["section"] == "1"
+
+
+def test_redact_section_text_copies_and_does_not_mutate_input() -> None:
+    secs = [{"section": "1", "text": "010-1234-5678"}]
+    out = _redact_section_text(secs)
+    # 원본 dict 는 불변(dict copy 안 하고 in-place 치환하면 KILL).
+    assert secs[0]["text"] == "010-1234-5678"
+    assert out[0] is not secs[0]
+
+
+def test_redact_section_text_none_or_missing_text_becomes_empty() -> None:
+    # text=None / text 키 부재 모두 빈 문자열(str(... or "")), 문자열 "None" 아님.
+    out = _redact_section_text([{"text": None}, {"key": "x"}])
+    assert out[0]["text"] == ""
+    # text 키가 없던 dict 에도 text="" 가 채워진다.
+    assert out[1]["text"] == "" and out[1]["key"] == "x"
+
+
+# ---- validate_fieldnames ----
+
+def test_validate_fieldnames_passes_when_all_required_present() -> None:
+    # 전체 컬럼 present → 예외 없이 None 반환.
+    assert validate_fieldnames(list(REQUIRED_COLUMNS), Path("ok.csv")) is None
+
+
+def test_validate_fieldnames_raises_with_missing_columns_in_order() -> None:
+    with pytest.raises(ValueError) as ei:
+        validate_fieldnames(["공고 번호"], Path("data/x.csv"))
+    msg = str(ei.value)
+    # 경로 + 누락 컬럼(REQUIRED_COLUMNS 순서)이 메시지에 담긴다.
+    assert "data/x.csv" in msg
+    assert "사업명, 발주 기관, 파일형식, 파일명, 텍스트" in msg
+    # 이미 존재하는 '공고 번호' 는 누락 목록에서 빠진다(필터 KILL).
+    assert "공고 번호" not in msg.split("required columns:", 1)[1]
+
+
+# ---- _compute_next_unique_doc_id ----
+
+def test_compute_next_starts_at_two_on_empty_tracker() -> None:
+    # 빈 tracker: counts.get(base,1)=1, +1 → base-2 (base-1 이면 +1 KILL, default 1 KILL).
+    assert _compute_next_unique_doc_id("base", _DuplicateTracker()) == ("base-2", 2)
+
+
+def test_compute_next_uses_counts_as_starting_point() -> None:
+    # counts 시작점 사용 → base-6 (counts 무시 시 base-2 KILL).
+    t = _DuplicateTracker(counts={"base": 5})
+    assert _compute_next_unique_doc_id("base", t) == ("base-6", 6)
+
+
+def test_compute_next_skips_seen_collisions() -> None:
+    # seen 에 base-2,base-3 점유 → while loop 가 base-4 까지 skip(loop 없으면 base-2 KILL).
+    t = _DuplicateTracker(seen={"base-2": 0, "base-3": 0})
+    assert _compute_next_unique_doc_id("base", t) == ("base-4", 4)
+
+
+# ---- _looks_like_notice_id_doc ----
+
+def _rec(doc_id: str | None, file_name: str) -> IngestionRecord:
+    return IngestionRecord(
+        row_number=1,
+        status="ok",
+        doc_id=doc_id,
+        file_name=file_name,
+        file_format="pdf",
+        source_path="/x",
+    )
+
+
+def test_looks_like_notice_id_doc_compares_doc_id_to_stem_slug() -> None:
+    # doc_id 가 파일명 stem slug 와 같으면 file_name 기반 → False.
+    assert _looks_like_notice_id_doc(_rec("doc", "doc.pdf")) is False
+    # 다르면 notice_id 기반 → True.
+    assert _looks_like_notice_id_doc(_rec("N-1", "doc.pdf")) is True
+
+
+def test_looks_like_notice_id_doc_true_when_missing_id_or_name() -> None:
+    # doc_id None / file_name 빈 문자열 → stem 비교 전 early True.
+    assert _looks_like_notice_id_doc(_rec(None, "doc.pdf")) is True
+    assert _looks_like_notice_id_doc(_rec("doc", "")) is True
+    # guard 자체를 pin: doc_id="" 빈 + file_name 공백뿐 → fallback 이라면
+    # ""!=slug_part("")="" → False 였을 입력. 이 True 는 오직 early-return
+    # guard(`not record.doc_id`)에서 나온다(guard 제거 / `or`→`and` 시 KILL).
+    assert _looks_like_notice_id_doc(_rec("", "   ")) is True


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`ingestion.py` 의 dedup/redaction 순수 helper 4종(`_redact_section_text`/`validate_fieldnames`/`_compute_next_unique_doc_id`/`_looks_like_notice_id_doc`)이 직접 단위 테스트 0건이었다. PII redaction·필수컬럼 검증·중복 doc_id 채번이 조용히 깨지면 회귀로 안 잡힌다. oracle 기반 단위 테스트 10건 추가(test-only, 소스 무수정).

## 2. 어떻게 (How)

- `tests/test_ingestion_dedup_redaction.py` 신규 1파일, 10 테스트.
- `_redact_section_text`: phone→`<phone>` 마스킹·dict copy(원본 불변)·text 키 채움. `validate_fieldnames`: 누락 컬럼 REQUIRED 순서 ValueError / 전부 있으면 None. `_compute_next_unique_doc_id`: counts 시작점 + seen collision skip + (후보,N) 반환. `_looks_like_notice_id_doc`: doc_id vs 파일명 stem slug, 부재 시 early True.

## 3. 테스트 (Tests)

- `python3 -m pytest tests/test_ingestion_dedup_redaction.py -q` → **10 passed**.
- ruff/pyright clean. import-safe leaf 확인.

## 4. 스크린샷 / 로그 (Screenshots / Logs)

```
..........                                                               [100%]
10 passed in 3.80s
```

## 5. Eval 영향 (Eval Impact)

해당 없음 — test-only PR. 소스/계약/CI 설정/baseline 무변경(ADR 0001 무관), 동작 변경 없음. load-bearing 경로 미변경(`tests/` 신규 1파일).

## 6. 리스크 / 롤백 (Risk / Rollback)

리스크 최소 — 테스트 추가만. 별도 lane code-reviewer adversarial mutation 검증에서 **REQUEST CHANGES** 1건(early-True guard 가 fallback 우연 통과로 미-pin) 수신 → guard-distinguishing 입력 `_rec("", "   ")` 1줄 추가로 `or`→`and`·guard-removal·drop-doc_id-arm mutant KILL(나머지 9 테스트는 모든 mutation KILL 확인). drop-file_name-arm 은 file_name="" 시 doc_id truthy면 fallback 항상 True 라 semantic-equivalent(reachable 입력 없음).

## 7. 관련 이슈 (Related Issues)

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)