### PR TITLE
test: pin pre-push non-load-bearing quiet path

### DIFF
--- a/tests/test_hook_pre_push_test_coverage.py
+++ b/tests/test_hook_pre_push_test_coverage.py
@@ -99,6 +99,13 @@ class TestPrePushTestCoverage(unittest.TestCase):
         self.assertEqual(0, r.returncode, r.stderr)
         self.assertEqual("", r.stderr.strip(), r.stderr)
 
+    def test_non_load_bearing_code_path_is_quiet(self) -> None:
+        self._pin_origin_main()
+        self._commit("scripts/non_loadbearing_helper.py")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
     def test_no_origin_main_ref_is_quiet(self) -> None:
         # No origin/main ref and no upstream → base diff is empty → quiet.
         self._commit("rag_core.py")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

pre-push test-coverage soft-warn hook이 `scripts/_governance.py` 기준 load-bearing path에만 경고하고, 코드처럼 보이는 비 load-bearing path에는 조용해야 한다는 regression guard를 추가했습니다.

Closes #2338

## 2. 영향 파일

- `tests/test_hook_pre_push_test_coverage.py` — `scripts/non_loadbearing_helper.py` 변경만 있는 경우 hook stderr가 비어 있는지 검증 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: future hook refactor가 모든 code-like path를 behavior change로 오인해 false-positive reminder를 내는 경우.
- 배제 근거: 신규 테스트가 governance SSoT에 매칭되지 않는 `scripts/non_loadbearing_helper.py` 변경에서 quiet contract를 직접 확인합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_hook_pre_push_test_coverage.py` — 5 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=11, worktrees=111, and `tests/test_hook_pre_push_test_coverage.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2338-prepush-nonloadbearing-quiet` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `.githooks/_pre-push-test-coverage.sh` 구현 변경 없이 existing soft-warn boundary만 테스트로 고정했습니다.

## 7. 범위 외

Hook 구현 변경, governance path list 변경, branch/issue gate 변경은 하지 않았습니다.
