### PR TITLE
test(ingestion): 파싱 후처리 텍스트 정규화(numeric-page/bullet-demote) 커버리지

### DIFF
--- a/tests/test_ingestion_parse_postproc_norm.py
+++ b/tests/test_ingestion_parse_postproc_norm.py
@@ -1,0 +1,75 @@
+"""Unit coverage for ingestion.py 파싱 후처리 텍스트 정규화 helper (issue #2336).
+
+``_is_numeric_only_page_chunk`` / ``_demote_over_promoted_bullet_headings`` 은
+문서 파싱 출력의 노이즈를 정규화하는 import-safe leaf(torch/chromadb/rag_core
+미로드)인데 직접 단위 테스트가 0건이었다(test-only, 소스 무수정).
+
+핵심 변별:
+- numeric: separator(공백·하이픈·점·middot·bullet·언더스코어) 제거 후 전부 digit → True.
+- demote: ``_MIN_RUN_LENGTH_FOR_DEMOTION``(=3) 이상 연속 bullet heading run 만
+  ``#+`` 를 떼어 평문 강등(bullet glyph 는 보존).
+"""
+from __future__ import annotations
+
+from ingestion import (
+    _demote_over_promoted_bullet_headings,
+    _is_numeric_only_page_chunk,
+)
+
+
+# ---- _is_numeric_only_page_chunk ----
+
+def test_numeric_only_true_after_stripping_separators() -> None:
+    # 공백/하이픈/점/middot/bullet/언더스코어 제거 후 전부 digit → True.
+    assert _is_numeric_only_page_chunk("12") is True
+    assert _is_numeric_only_page_chunk("- 3 -") is True  # 하이픈·공백 strip → "3"
+    assert _is_numeric_only_page_chunk("1.2.3") is True  # 점 strip → "123"
+    assert _is_numeric_only_page_chunk("·• 5 _") is True  # middot·bullet·_ strip → "5"
+
+
+def test_numeric_only_false_when_letters_or_empty() -> None:
+    # 영문이 남으면 False(separator class 가 글자를 안 지움 → isdigit KILL).
+    assert _is_numeric_only_page_chunk("page 12") is False
+    assert _is_numeric_only_page_chunk("12a") is False
+    # separator 제거 후 빈 문자열 → False("".isdigit() == False).
+    assert _is_numeric_only_page_chunk("") is False
+    assert _is_numeric_only_page_chunk("  ") is False
+
+
+# ---- _demote_over_promoted_bullet_headings ----
+
+def test_demote_strips_hash_prefix_on_run_of_three() -> None:
+    # 3개 연속 bullet heading run → #+ 제거, bullet glyph('-')·빈 줄은 보존.
+    src = "# - 가\n\n# - 나\n\n# - 다"
+    assert _demote_over_promoted_bullet_headings(src) == "- 가\n\n- 나\n\n- 다"
+
+
+def test_demote_leaves_short_run_below_threshold() -> None:
+    # 2개(threshold 3 미만) run 은 무변경 — threshold 를 낮추면 강등돼 KILL.
+    src = "# - 가\n\n# - 나"
+    assert _demote_over_promoted_bullet_headings(src) == src
+
+
+def test_demote_body_content_breaks_run() -> None:
+    # 본문 줄이 run 을 끊어 각 조각이 3 미만 → 무변경(본문을 run 에 포함시키면 KILL).
+    src = "# - 가\n본문\n# - 나\n# - 다"
+    assert _demote_over_promoted_bullet_headings(src) == src
+
+
+def test_demote_is_idempotent_and_noop_without_bullets() -> None:
+    src = "# - 가\n\n# - 나\n\n# - 다"
+    once = _demote_over_promoted_bullet_headings(src)
+    # 이미 강등된 markdown 재실행은 no-op.
+    assert _demote_over_promoted_bullet_headings(once) == once
+    # bullet heading 이 아닌 일반 heading 은 run 이 아니므로 그대로.
+    plain = "# 제목\n본문\n## 소제목"
+    assert _demote_over_promoted_bullet_headings(plain) == plain
+
+
+def test_demote_preserves_run_of_plain_non_bullet_headings() -> None:
+    # bullet glyph 가 없는 일반 heading 3-run(빈 줄로만 구분) 은 강등 금지 —
+    # run-length 만이 아니라 _BULLET_HEADING_RE 의 glyph 요구 자체를 pin 한다.
+    # glyph class 를 '.'(아무 문자) 또는 optional 로 바꾸면 'A 사업 개요…' 로
+    # 잘못 강등돼 KILL. ('A' 는 bullet glyph class 에 없으므로 run 이 아님)
+    src = "# A 사업 개요\n\n# B 입찰 일정\n\n# C 평가 기준"
+    assert _demote_over_promoted_bullet_headings(src) == src


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`ingestion.py` 의 파싱 후처리 텍스트 정규화 helper 2종(`_is_numeric_only_page_chunk`/`_demote_over_promoted_bullet_headings`)이 직접 단위 테스트 0건이었다. 페이지번호 노이즈 스킵·과승격 bullet heading 강등이 조용히 깨지면 청킹·검색에 노이즈가 섞여도 회귀로 안 잡힌다. oracle 기반 단위 테스트 7건 추가(test-only, 소스 무수정).

## 2. 어떻게 (How)

- `tests/test_ingestion_parse_postproc_norm.py` 신규 1파일, 7 테스트.
- numeric: separator strip 후 전부 digit→True, 영문/빈→False. demote: `_MIN_RUN_LENGTH_FOR_DEMOTION`=3 threshold, `#+` 제거 bullet glyph 보존, body 가 run 끊음, idempotent, glyph-요구(`_BULLET_HEADING_RE`) pin.

## 3. 테스트 (Tests)

- `python3 -m pytest tests/test_ingestion_parse_postproc_norm.py -q` → **7 passed**.
- ruff/pyright clean. import-safe leaf 확인.

## 4. 스크린샷 / 로그 (Screenshots / Logs)

```
.......                                                                  [100%]
7 passed in 1.26s
```

## 5. Eval 영향 (Eval Impact)

해당 없음 — test-only PR. 소스/계약/CI 설정/baseline 무변경(ADR 0001 무관), 동작 변경 없음. load-bearing 경로 미변경(`tests/` 신규 1파일).

## 6. 리스크 / 롤백 (Risk / Rollback)

리스크 최소 — 테스트 추가만. 별도 lane code-reviewer adversarial mutation 검증에서 **REQUEST CHANGES** 1건(`_BULLET_HEADING_RE` glyph-요구 미-pin: `# A 사업 개요`-류 일반 heading 3-run 이 glyph class→`.`/optional mutation 에서 잘못 강등돼도 survive) 수신 → plain non-bullet heading run 보존 테스트 1건 추가로 IDEM-B/C mutant KILL. 나머지 6 테스트는 numeric separator·isdigit·threshold·run-break·strip 전부 KILL 확인. `bool(compact)` 가드는 `"".isdigit()==False` 라 semantic-equivalent(1813 입력 brute-force 0 distinguisher).

## 7. 관련 이슈 (Related Issues)

Closes #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)