### PR TITLE
feat(agent-evals): operator-skill eval core + content scanner + smoke surface (PR2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,9 +23,9 @@ BLOCKED_PATTERNS=(
   '^eval/.*\.local\.yaml$'
   '^reports/real[^/]*/'
   # ADR 0100 operator-skill eval surface: deny-by-default. Every agent-evals/ path is
-  # blocked here (local force-add guard) and only README is allowlisted below — code, mined
-  # task.yaml, playbooks, splits, and reports all wait for the PR2 content scanner. Mirrors
-  # the .gitignore agent-evals/ boundary.
+  # blocked here (local force-add guard), and only the PR2 scanner-backed exact surface is
+  # allowlisted below. The content scanner runs before this path boundary so any force-added
+  # raw/private data sink is rejected even if the path shape is committable.
   '^agent-evals/'
 )
 
@@ -114,9 +114,16 @@ ALLOWED_PATTERNS=(
   '^reports/real100_v2/judge\.aggregate\.json$'
   '^reports/real100_v2/judge_ragas\.aggregate\.json$'
   '^reports/real100_v2/rationality\.aggregate\.json$'
-  # ADR 0100 operator-skill eval surface (PR1): README is the ONLY committable agent-evals/
-  # file. PR2 adds code + aggregate-report allowlist rules together with the content scanner.
+  # ADR 0100 operator-skill eval surface (PR2): scanner-backed committable surface.
   '^agent-evals/README\.md$'
+  '^agent-evals/core/__init__\.py$'
+  '^agent-evals/core/(schema|metrics|report)\.py$'
+  '^agent-evals/adapters/bidmate/__init__\.py$'
+  '^agent-evals/adapters/bidmate/task_mining\.py$'
+  '^agent-evals/playbooks/v(0_naive|1_spec_first)\.md$'
+  '^agent-evals/splits\.yaml$'
+  '^agent-evals/tasks/[^/]+/task\.yaml$'
+  '^agent-evals/reports/[^/]+\.aggregate\.json$'
 )
 
 # Guard: ADR file deletion/rename (CLAUDE.md Prohibited).
@@ -350,7 +357,7 @@ fi
 
 # NUL-delimited read (-z) so a staged path containing a newline or other control
 # character cannot split into multiple tokens and slip past the agent-evals/
-# README-only boundary (Codex pre-commit review, issue #1844). -z is robust
+# exact PR2 allowlist boundary (Codex pre-commit review, issue #1844). -z is robust
 # regardless of core.quotePath, unlike newline-delimited --name-only. read -r -d ''
 # stays bash-3.2 compatible (avoids mapfile -d, which needs bash 4+).
 staged_files=()
@@ -360,6 +367,22 @@ done < <(git diff --cached -z --name-only --diff-filter=ACMR 2>/dev/null || true
 
 if [[ ${#staged_files[@]} -eq 0 ]]; then
   exit 0
+fi
+
+agent_evals_staged=0
+for file in "${staged_files[@]}"; do
+  if [[ "$file" == agent-evals/* ]]; then
+    agent_evals_staged=1
+    break
+  fi
+done
+
+if [[ "$agent_evals_staged" -eq 1 ]]; then
+  agent_evals_scan_out=$(python3 agent-evals/core/report.py --check-staged 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$agent_evals_scan_out" >&2
+    exit 1
+  fi
 fi
 
 violations=()

--- a/.gitignore
+++ b/.gitignore
@@ -377,25 +377,24 @@ harness/real.yaml
 /node_modules/
 
 # ── agent-evals/ operator-skill eval — aggregate-only data boundary (ADR 0005, ADR 0100) ──
-# DENY-BY-DEFAULT: everything under agent-evals/ is ignored, then only README is unignored
+# DENY-BY-DEFAULT: everything under agent-evals/ is ignored, then PR2 explicitly
+# unignores only the scanner-backed code/task/playbook/split/aggregate-report surface
 # below. Per-run artifacts (run-logs, captured diffs/patches, reviewer inputs, traces,
-# per-run worktrees, reports) AND code/task.yaml/playbooks/splits all carry or could carry
-# raw issue/PR/diff text → never commit in PR1; ANY unanticipated name is denied by default.
-# PR1 committable surface = README ONLY (the curated surface definition). Enforced by
-# tests/test_agent_evals_gitignore.py (deny-by-default pattern + index-aware git ls-files
-# allowlist) and mirrored in .githooks/pre-commit; code + the content-level aggregate-only
-# scanner + report/data allowlist arrive in PR2 (agent-evals/core/report.py).
+# per-run worktrees) and any unanticipated name remain denied by default. The matching
+# commit-time content scanner is agent-evals/core/report.py and is invoked by
+# .githooks/pre-commit before the local ADR 0005 path boundary.
 agent-evals/**
 # Re-include directories so git descends (files stay denied unless explicitly unignored):
 !agent-evals/**/
-# PR1 commits exactly ONE file under agent-evals/: the curated, in-PR-reviewed README
-# (the surface definition). It is the ONLY exact-path exception. Everything else — code
-# (core/, adapters/), mined task.yaml, playbooks, splits.yaml, reports — is free-form text
-# that could carry raw issue/PR/RFP content (even a shallow code path like core/schema.py
-# could hold a string literal), so allowlisting ANY of it before the PR2 content scanner
-# exists would be a false aggregate-only claim. PR2 adds each unignore rule (exact module
-# filenames and/or `**` globs for code + tasks/*/task.yaml · playbooks/*.md · splits.yaml ·
-# reports/*.aggregate.json) together with the content-level privacy validator
-# (core/report.py) and a matching index-guard case. PR1 therefore asserts ONLY the path
-# boundary: README in, everything else out.
 !agent-evals/README.md
+!agent-evals/core/__init__.py
+!agent-evals/core/schema.py
+!agent-evals/core/metrics.py
+!agent-evals/core/report.py
+!agent-evals/adapters/bidmate/__init__.py
+!agent-evals/adapters/bidmate/task_mining.py
+!agent-evals/playbooks/v0_naive.md
+!agent-evals/playbooks/v1_spec_first.md
+!agent-evals/splits.yaml
+!agent-evals/tasks/*/task.yaml
+!agent-evals/reports/*.aggregate.json

--- a/agent-evals/README.md
+++ b/agent-evals/README.md
@@ -20,7 +20,7 @@
 | **비교 방식** | playbook 을 training split 에서 freeze → unseen **holdout** 에서 **paired**(v1 − v0). 주장은 paired **delta** 뿐, 절대 solve rate 아님. |
 | **왜 delta 만** | 운영자-기억 오염이 v0·v1 에 **동등 작용**(common-mode)할 때만 paired delta 에서 상쇄 → 그 균형을 강제: **freshness-exclusion**(unseen holdout) + **counterbalanced order**(v0/v1 적용 순서 balance) + **familiarity 메타** 기록, 측정·balance 안 되면 **paired-delta 주장 금지**(fail-closed, PR3 강제). 절대율은 inflated 가능 → 비주장. |
 | **Acceptance oracle** | 원래 PR 테스트 + repo pytest CI + regression = *necessary* gate. 최종 "accepted" primary arbiter = **candidate 와 다른 family** 의 fresh-context reviewer(issue+patch 만, 운영자 framing 차단) → same-family LLM-judges-LLM([ADR 0064](../docs/adr/0064-self-review-external-judge.md)) 회피. `candidate_family` 기록 + `reviewer_family != candidate_family` fail-closed (codex 도 candidate 가능 → reviewer codex 하드코딩 금지; PR3 runner/schema 강제). **payload privacy gate(외부 egress):** external-family reviewer 호출은 외부 서비스 egress 이므로 넘기는 reviewer payload(issue+patch)는 **public 증명(attestation)된 데이터일 때만** 외부로 나간다 — 아니면 **fail-closed**(외부 호출 차단, local/stub reviewer 강등). redaction/scanner 는 외부 egress 허가 조건이 아니라 commit/content 경계(PR2)용 — 불완전 redaction 의 private 누출 경로를 막기 위해 egress 는 public-data attestation 으로만 연다(commit 경계와 별개, [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)/[ADR 0061](../docs/adr/0061-external-and-paid-api-dependencies-allowed.md)). |
-| **데이터 경계 (2-layer)** | **path (PR1 enforce):** `.gitignore` deny-by-default + **index-aware 가드**(`git ls-files agent-evals/` ⊆ allowlist — `git add -f`/이미-tracked 차단) + **local pre-commit mirror**(`.githooks/pre-commit`) → **`README.md` 단 하나만** commit(exact-path; shallow `.py` 도 raw 가능 → code 예외 없음). **content (PR2 enforce):** code·`task.yaml`·playbook·`splits.yaml`·`reports/` 는 raw 본문 담을 수 있는 free-form 텍스트라 내용 스캐너(`core/report.py`) 들어오기 전까지 **commit 금지** → PR2 가 스캐너와 함께 그 unignore 규칙 추가. PR1 은 *경로* 경계만(README only) 주장 — content aggregate-only 강제는 PR2. |
+| **데이터 경계 (2-layer)** | **path (PR1 enforce):** `.gitignore` deny-by-default + **index-aware 가드**(`git ls-files agent-evals/` ⊆ allowlist — `git add -f`/이미-tracked 차단) + **local pre-commit mirror**(`.githooks/pre-commit`) 로 README-only 경계를 먼저 고정했다. **content (PR2 enforce):** `core/report.py --check-staged` 가 exact PR2 surface(code·`task.yaml`·playbook·`splits.yaml`·`*.aggregate.json`)를 commit 전 검사한다. Raw run-log/captured patch/reviewer input/worktree/non-aggregate report/unanticipated path 는 계속 denied. |
 | **추출 경계** | `core/` = repo-무관(import guard); BidMate 특화는 `adapters/bidmate/` 한정. |
 
 ## Falsifiability (anti-Goodhart)
@@ -30,32 +30,32 @@
 scaffolding 은 고정 budget 에서 accepted output 을 못 올린다"* 가 정직한 reportable
 finding 이다 — eval 실패가 아니다.
 
-## 레이아웃 (계획)
+## 레이아웃 (PR2 현재)
 
 ```
 agent-evals/
-├── README.md                 # 이 파일 (표면 정의 — PR1)
-├── core/                     # repo-무관: schema/metrics/oracle/report — ⛔ PR1 금지(code도 raw 가능) → PR2
-├── adapters/bidmate/         # task mining · runner · cross-family oracle 래퍼 — ⛔ PR1 금지 → PR2/PR3
-├── tasks/T-*/task.yaml       # mined task — ⛔ PR1 commit 금지(free-form, raw 가능) → PR2(scanner)
-├── playbooks/                # v0_naive.md · v1_spec_first.md (frozen, SHA) — ⛔ PR1 금지 → PR2
-├── splits.yaml               # train/holdout 배정 + freshness-exclusion — ⛔ PR1 금지 → PR2
+├── README.md                 # 표면 정의
+├── core/                     # repo-무관: schema/metrics/report content scanner
+├── adapters/bidmate/         # sanitized task mining (runner/oracle wrapper는 PR3)
+├── tasks/T-*/task.yaml       # scanner-backed sanitized task contracts
+├── playbooks/                # v0_naive.md · v1_spec_first.md (frozen)
+├── splits.yaml               # train/holdout 배정 + freshness-exclusion
 ├── runs/                     # ⛔ gitignored — per-run run-log/캡처 diff/reviewer 입력 (raw 본문)
-└── reports/                  # ⛔ PR1 commit 금지(content scanner 부재) → PR2 부터 *.aggregate.json commit
+└── reports/                  # scanner-backed *.aggregate.json only
 ```
 
 ## 상태 (thin slice, 3 PR)
 
-- **PR1 (현재):** ADR 0100 + 이 README + queue 항목 + CLAUDE.md 맵 — 계약 고정만(코드 없음).
-- **PR2:** `core/`(import 격리) + task mining(merge PR ~#1336–1820, hidden-test gate) +
-  playbook 2버전 + **3-task smoke report**(report-before-expansion).
+- **PR1 (완료):** ADR 0100 + 이 README + queue 항목 + CLAUDE.md 맵 — 계약 고정만(코드 없음).
+- **PR2 (현재):** `core/`(import 격리) + content scanner + task mining(merge PR ~#1336–1820, hidden-test gate) +
+  playbook 2버전 + split + **3-task smoke report**(report-before-expansion).
 - **PR3:** full runner(`git worktree add --detach`, ≥3 seed) + cross-family oracle(`reviewer_family != candidate_family` fail-closed) +
   paired bootstrap CI(min-N 가드) + holdout v0-vs-v1 report.
 
-## 실행 (PR2/PR3 에서 wire 예정)
+## 실행 (PR3 에서 Makefile wire 예정)
 
 ```bash
-# PR2+
+# PR3+
 make agent-eval-mine     # merge PR → task.yaml (hidden-test gate, mineable floor 경고)
 make agent-eval-run      # (playbook × holdout task × seed) → run-log
 make agent-eval-report   # holdout v0 vs v1 aggregate (paired bootstrap, min-N 가드)

--- a/agent-evals/adapters/bidmate/__init__.py
+++ b/agent-evals/adapters/bidmate/__init__.py
@@ -1,0 +1,1 @@
+"""BidMate adapter for sanitized operator-skill eval task mining."""

--- a/agent-evals/adapters/bidmate/task_mining.py
+++ b/agent-evals/adapters/bidmate/task_mining.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Sequence
 
+import yaml
+
 
 DEFAULT_MINEABLE_FLOOR = 132
 DEFAULT_HOLDOUT_TARGET = 46
@@ -106,23 +108,25 @@ def mine_tasks(
 
 
 def render_task_yaml(task: Mapping[str, object]) -> str:
-    """Render a scanner-friendly task.yaml fragment without external YAML deps."""
+    """Render a task.yaml fragment as well-formed YAML.
 
-    lines: list[str] = []
-    for key in (
-        "task_id",
-        "source",
-        "category",
-        "train_hint",
-        "acceptance",
-        "hidden_test_gate",
-        "aggregate_only_notes",
-    ):
-        value = task.get(key)
-        if isinstance(value, list):
-            lines.append(f"{key}:")
-            for item in value:
-                lines.append(f"  - {item}")
-        else:
-            lines.append(f"{key}: {value}")
-    return "\n".join(lines) + "\n"
+    Uses ``yaml.safe_dump`` so a scalar value containing YAML syntax (e.g. a
+    governance signal like ``"ADR 0005: privacy guard"``) is quoted rather than
+    silently reparsed into a mapping, which would corrupt the ``acceptance``
+    contract. Cross-family review flagged the previous manual f-string renderer.
+    """
+
+    ordered = {
+        key: task[key]
+        for key in (
+            "task_id",
+            "source",
+            "category",
+            "train_hint",
+            "acceptance",
+            "hidden_test_gate",
+            "aggregate_only_notes",
+        )
+        if key in task
+    }
+    return yaml.safe_dump(ordered, sort_keys=False, allow_unicode=True, default_flow_style=False)

--- a/agent-evals/adapters/bidmate/task_mining.py
+++ b/agent-evals/adapters/bidmate/task_mining.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Sanitized task mining for the ADR 0100 BidMate operator-skill eval surface.
+
+This adapter consumes already-summarized merge metadata.  It deliberately does
+not read PR bodies, issue bodies, patches, filenames, or RFP text; generated
+``task.yaml`` files contain only category-level contracts plus hidden-test gate
+metadata.  The content scanner in ``agent-evals/core/report.py`` is the commit
+boundary backstop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+
+DEFAULT_MINEABLE_FLOOR = 132
+DEFAULT_HOLDOUT_TARGET = 46
+
+_ALLOWED_CATEGORIES = {
+    "hook_privacy",
+    "eval_guard",
+    "doc_contract",
+    "workflow_guard",
+    "test_contract",
+}
+
+
+@dataclass(frozen=True)
+class MiningSummary:
+    mineable_count: int
+    holdout_target: int
+    warnings: tuple[str, ...]
+
+    def to_mapping(self) -> dict[str, int | list[str]]:
+        return {
+            "mineable_count": self.mineable_count,
+            "holdout_target": self.holdout_target,
+            "warnings": list(self.warnings),
+        }
+
+
+def _safe_task_id(number: int) -> str:
+    return f"T-{number:04d}"
+
+
+def is_mineable(record: Mapping[str, object]) -> bool:
+    """True iff summarized merge metadata can become an aggregate-only task."""
+
+    if not bool(record.get("merged")):
+        return False
+    if bool(record.get("contains_raw_payload")):
+        return False
+    category = str(record.get("category", ""))
+    if category not in _ALLOWED_CATEGORIES:
+        return False
+    signals = record.get("signals", ())
+    if not isinstance(signals, Sequence) or isinstance(signals, (str, bytes)):
+        return False
+    return bool(signals)
+
+
+def mine_tasks(
+    records: Iterable[Mapping[str, object]],
+    *,
+    mineable_floor: int = DEFAULT_MINEABLE_FLOOR,
+    holdout_target: int = DEFAULT_HOLDOUT_TARGET,
+) -> tuple[list[dict[str, object]], MiningSummary]:
+    """Convert sanitized merge metadata into task contracts.
+
+    The input may include stable PR numbers for deterministic task ids, but the
+    output omits issue ids, PR titles, file names, paths, queries, answers, and
+    evidence text.
+    """
+
+    tasks: list[dict[str, object]] = []
+    for record in records:
+        if not is_mineable(record):
+            continue
+        number = int(record["number"])
+        category = str(record["category"])
+        signals = tuple(str(item) for item in record.get("signals", ()))
+        tasks.append(
+            {
+                "task_id": _safe_task_id(number),
+                "source": "merged_pr_sanitized_metadata",
+                "category": category,
+                "train_hint": "derive behavior from governance contract, not copied task prose",
+                "acceptance": [f"preserve {signal}" for signal in signals],
+                "hidden_test_gate": "must pass an unseen regression derived from the same category",
+                "aggregate_only_notes": ["no raw issue, PR, patch, filename, path, query, answer, or evidence text"],
+            }
+        )
+
+    warnings: list[str] = []
+    if len(tasks) < mineable_floor:
+        warnings.append(f"mineable floor not met: {len(tasks)} < {mineable_floor}")
+    if holdout_target > len(tasks):
+        warnings.append(f"holdout target exceeds mineable count: {holdout_target} > {len(tasks)}")
+
+    return tasks, MiningSummary(
+        mineable_count=len(tasks),
+        holdout_target=holdout_target,
+        warnings=tuple(warnings),
+    )
+
+
+def render_task_yaml(task: Mapping[str, object]) -> str:
+    """Render a scanner-friendly task.yaml fragment without external YAML deps."""
+
+    lines: list[str] = []
+    for key in (
+        "task_id",
+        "source",
+        "category",
+        "train_hint",
+        "acceptance",
+        "hidden_test_gate",
+        "aggregate_only_notes",
+    ):
+        value = task.get(key)
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines) + "\n"

--- a/agent-evals/core/__init__.py
+++ b/agent-evals/core/__init__.py
@@ -1,0 +1,1 @@
+"""Operator-skill eval core helpers (ADR 0100)."""

--- a/agent-evals/core/metrics.py
+++ b/agent-evals/core/metrics.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Paired metric primitives for operator-skill eval reports.
+
+ADR 0100 forbids treating the surface as an absolute leaderboard.  The only
+primitive here is paired delta: compare two playbooks on the same task set and
+report the directional difference plus win/loss/tie counts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class PairedDelta:
+    metric: str
+    baseline: str
+    candidate: str
+    n: int
+    baseline_mean: float
+    candidate_mean: float
+    delta: float
+    wins: int
+    losses: int
+    ties: int
+
+    def to_mapping(self) -> dict[str, int | float | str]:
+        return {
+            "metric": self.metric,
+            "baseline": self.baseline,
+            "candidate": self.candidate,
+            "n": self.n,
+            "baseline_mean": self.baseline_mean,
+            "candidate_mean": self.candidate_mean,
+            "delta": self.delta,
+            "wins": self.wins,
+            "losses": self.losses,
+            "ties": self.ties,
+        }
+
+
+def paired_delta(
+    rows: Iterable[Mapping[str, float | int | bool]],
+    *,
+    baseline_key: str,
+    candidate_key: str,
+    metric: str,
+    baseline_name: str = "v0_naive",
+    candidate_name: str = "v1_spec_first",
+) -> PairedDelta:
+    """Return same-task candidate-minus-baseline delta.
+
+    Values are coerced to floats; booleans become 0.0/1.0.  Empty inputs are an
+    error because a paired delta with ``n=0`` is indistinguishable from an inert
+    report surface.
+    """
+
+    baseline_values: list[float] = []
+    candidate_values: list[float] = []
+    wins = losses = ties = 0
+
+    for row in rows:
+        if baseline_key not in row or candidate_key not in row:
+            missing = sorted({baseline_key, candidate_key} - set(row))
+            raise ValueError(f"row missing paired key(s): {missing}")
+        base = float(row[baseline_key])
+        cand = float(row[candidate_key])
+        baseline_values.append(base)
+        candidate_values.append(cand)
+        if cand > base:
+            wins += 1
+        elif cand < base:
+            losses += 1
+        else:
+            ties += 1
+
+    n = len(baseline_values)
+    if n == 0:
+        raise ValueError("paired_delta requires at least one paired row")
+
+    baseline_mean = sum(baseline_values) / n
+    candidate_mean = sum(candidate_values) / n
+    return PairedDelta(
+        metric=metric,
+        baseline=baseline_name,
+        candidate=candidate_name,
+        n=n,
+        baseline_mean=round(baseline_mean, 6),
+        candidate_mean=round(candidate_mean, 6),
+        delta=round(candidate_mean - baseline_mean, 6),
+        wins=wins,
+        losses=losses,
+        ties=ties,
+    )

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -106,6 +106,47 @@ _FORBIDDEN_IMPORT_PREFIXES = (
     "api.",
 )
 
+# Positive top-level key schemas for committable structured data artifacts.
+# The forbidden-key denylist above is a blocklist; these allowlists make the
+# committable artifacts fail closed on *unknown* top-level keys so a non-forbidden
+# raw sink (issue_title, pr_title, rfp_excerpt, ...) cannot ride in on a
+# force-added file. Kept inline rather than imported from schema.py so the
+# pre-commit boundary stays dependency-free; drift is guarded by a test that
+# asserts equality with schema.ALLOWED_TASK_KEYS / schema.ALLOWED_REPORT_KEYS.
+_ALLOWED_TASK_KEYS = frozenset(
+    {
+        "task_id",
+        "source",
+        "category",
+        "train_hint",
+        "acceptance",
+        "hidden_test_gate",
+        "aggregate_only_notes",
+    }
+)
+_ALLOWED_REPORT_KEYS = frozenset(
+    {
+        "schema_version",
+        "surface",
+        "report_id",
+        "generated_by",
+        "task_count",
+        "playbooks",
+        "metrics",
+        "scanner",
+        "notes",
+    }
+)
+_ALLOWED_SPLIT_KEYS = frozenset(
+    {
+        "schema_version",
+        "surface",
+        "freshness_exclusion_days",
+        "assignment",
+        "notes",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ScanViolation:
@@ -185,6 +226,19 @@ def _scan_json_keys(rel_path: str, value: Any, *, trail: str = "$") -> list[Scan
     return violations
 
 
+def _check_allowed_top_level_keys(
+    rel_path: str, parsed: Any, allowed: frozenset[str], kind: str
+) -> list[ScanViolation]:
+    """Fail closed on unknown top-level keys for a committable data artifact."""
+
+    if not isinstance(parsed, Mapping):
+        return []
+    unknown = sorted(str(key) for key in parsed if str(key) not in allowed)
+    if unknown:
+        return [ScanViolation(rel_path, f"unknown {kind} key(s) not in schema: {unknown}")]
+    return []
+
+
 def _yaml_error_summary(exc: yaml.YAMLError) -> str:
     text = str(exc).strip()
     return text.splitlines()[0] if text else exc.__class__.__name__
@@ -210,6 +264,10 @@ def _scan_yaml(rel_path: str, text: str) -> list[ScanViolation]:
         violations.append(ScanViolation(rel_path, f"unparseable YAML data artifact: {_yaml_error_summary(exc)}"))
         return violations
     if parsed is not None:
+        if rel_path == "agent-evals/splits.yaml":
+            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_SPLIT_KEYS, "split"))
+        elif rel_path.endswith("/task.yaml"):
+            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_TASK_KEYS, "task"))
         violations.extend(_scan_json_keys(rel_path, parsed))
     return violations
 
@@ -240,6 +298,7 @@ def validate_agent_eval_file(rel_path: str, text: str) -> list[ScanViolation]:
         else:
             if not isinstance(parsed, dict):
                 violations.append(ScanViolation(rel_path, "aggregate report must be a JSON object"))
+            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_REPORT_KEYS, "report"))
             violations.extend(_scan_json_keys(rel_path, parsed))
         return violations
 

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -51,6 +51,12 @@ _CODE_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^agent-evals/adapters/bidmate/.*\.py\Z"),
 )
 
+# Recursive blocklist: these key names are forbidden at *any* depth, so a raw
+# sink nested under an allowed top-level object (e.g. metrics.pr_title) or wrapped
+# in a sequence cannot leak past the positive top-level allowlists below. The
+# title/summary/description/excerpt/comment family has no legitimate use anywhere
+# in the aggregate-only artifacts and is the raw-prose path cross-family review
+# flagged (issue_title / pr_title / rfp_excerpt).
 _FORBIDDEN_DATA_KEYS = frozenset(
     {
         "answer",
@@ -58,16 +64,22 @@ _FORBIDDEN_DATA_KEYS = frozenset(
         "captured_diff",
         "chunk_id",
         "chunk_text",
+        "comment",
+        "comments",
+        "description",
         "doc_id",
         "document_id",
         "document_text",
         "evidence",
+        "excerpt",
         "file_name",
         "filename",
+        "issue_title",
         "local_path",
         "path",
         "patch",
         "pr_body",
+        "pr_title",
         "query",
         "raw_body",
         "raw_diff",
@@ -75,8 +87,11 @@ _FORBIDDEN_DATA_KEYS = frozenset(
         "raw_pr_body",
         "reviewer_input",
         "rfp_body",
+        "rfp_excerpt",
         "run_log",
+        "summary",
         "text",
+        "title",
     }
 )
 
@@ -263,12 +278,19 @@ def _scan_yaml(rel_path: str, text: str) -> list[ScanViolation]:
     except yaml.YAMLError as exc:
         violations.append(ScanViolation(rel_path, f"unparseable YAML data artifact: {_yaml_error_summary(exc)}"))
         return violations
-    if parsed is not None:
-        if rel_path == "agent-evals/splits.yaml":
-            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_SPLIT_KEYS, "split"))
-        elif rel_path.endswith("/task.yaml"):
-            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_TASK_KEYS, "task"))
+    if parsed is None:
+        return violations
+    if not isinstance(parsed, Mapping):
+        # A list/scalar document would otherwise skip the positive key allowlist,
+        # so wrapping unknown keys in a sequence could bypass the schema gate.
+        violations.append(ScanViolation(rel_path, "committable YAML artifact must be a mapping"))
         violations.extend(_scan_json_keys(rel_path, parsed))
+        return violations
+    if rel_path == "agent-evals/splits.yaml":
+        violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_SPLIT_KEYS, "split"))
+    elif rel_path.endswith("/task.yaml"):
+        violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_TASK_KEYS, "task"))
+    violations.extend(_scan_json_keys(rel_path, parsed))
     return violations
 
 

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -19,14 +19,20 @@ import hashlib
 import json
 import re
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
+import yaml
+
 
 SCHEMA_VERSION = 1
 SURFACE = "agent-evals-pr2"
+
+# Data-artifact string scalars (JSON values, YAML scalars) are capped well above
+# every legitimate aggregate note but far below a raw issue/PR/RFP excerpt, so an
+# oversized value cannot smuggle private prose under an otherwise-innocuous key.
+_MAX_DATA_STRING_LEN = 512
 
 _ALLOWED_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^agent-evals/README\.md\Z"),
@@ -168,7 +174,43 @@ def _scan_json_keys(rel_path: str, value: Any, *, trail: str = "$") -> list[Scan
         for idx, child in enumerate(value):
             violations.extend(_scan_json_keys(rel_path, child, trail=f"{trail}[{idx}]"))
     elif isinstance(value, str):
+        if len(value) > _MAX_DATA_STRING_LEN:
+            violations.append(
+                ScanViolation(
+                    rel_path,
+                    f"oversized data string at {trail} ({len(value)} chars) could hide raw text",
+                )
+            )
         violations.extend(_scan_values(rel_path, value))
+    return violations
+
+
+def _yaml_error_summary(exc: yaml.YAMLError) -> str:
+    text = str(exc).strip()
+    return text.splitlines()[0] if text else exc.__class__.__name__
+
+
+def _scan_yaml(rel_path: str, text: str) -> list[ScanViolation]:
+    """Validate a committed YAML data artifact structurally.
+
+    The whole-text value-pattern scan and the line-oriented forbidden-key check
+    remain as dependency-free backstops, but the structural parse is what stops
+    raw prose hidden under an innocuous, non-forbidden key (for example a long
+    ``train_hint`` smuggling issue/PR text, or a diff marker whose start-of-line
+    anchor only matches once the scalar value is extracted).
+    """
+
+    violations: list[ScanViolation] = []
+    violations.extend(_scan_values(rel_path, text))
+    if _FORBIDDEN_KEY_RE.search(text):
+        violations.append(ScanViolation(rel_path, "forbidden raw/private data key in text artifact"))
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        violations.append(ScanViolation(rel_path, f"unparseable YAML data artifact: {_yaml_error_summary(exc)}"))
+        return violations
+    if parsed is not None:
+        violations.extend(_scan_json_keys(rel_path, parsed))
     return violations
 
 
@@ -189,8 +231,8 @@ def validate_agent_eval_file(rel_path: str, text: str) -> list[ScanViolation]:
     if _is_code_path(rel_path):
         return _scan_python(rel_path, text)
 
-    violations.extend(_scan_values(rel_path, text))
     if rel_path.endswith(".aggregate.json"):
+        violations.extend(_scan_values(rel_path, text))
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError as exc:
@@ -199,11 +241,17 @@ def validate_agent_eval_file(rel_path: str, text: str) -> list[ScanViolation]:
             if not isinstance(parsed, dict):
                 violations.append(ScanViolation(rel_path, "aggregate report must be a JSON object"))
             violations.extend(_scan_json_keys(rel_path, parsed))
+        return violations
 
-    if rel_path.endswith((".yaml", ".yml", ".md")):
-        if _FORBIDDEN_KEY_RE.search(text):
-            violations.append(ScanViolation(rel_path, "forbidden raw/private data key in text artifact"))
+    if rel_path.endswith((".yaml", ".yml")):
+        return _scan_yaml(rel_path, text)
 
+    # Remaining committable surface: curated Markdown (playbooks). These are
+    # operator prose, so only value-pattern and forbidden-key text checks apply;
+    # a structural parse or size cap would false-positive on legitimate long prose.
+    violations.extend(_scan_values(rel_path, text))
+    if _FORBIDDEN_KEY_RE.search(text):
+        violations.append(ScanViolation(rel_path, "forbidden raw/private data key in text artifact"))
     return violations
 
 

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -301,6 +301,11 @@ def _scan_artifact_keys(
                     violations.append(ScanViolation(rel_path, f"{parent_key} entry must be a mapping: {child_trail}"))
             elif key_s not in top_allowed and key_s not in _ALLOWED_NESTED_KEYS:
                 violations.append(ScanViolation(rel_path, f"unknown {kind} key not in schema: {child_trail}"))
+            if key_s in _DYNAMIC_NAME_PARENTS and not isinstance(child, Mapping):
+                # A dynamic section (e.g. metrics) must be a mapping of name -> row;
+                # a list/scalar section would let raw items fall through unchecked.
+                violations.append(ScanViolation(rel_path, f"dynamic section must be a mapping: {child_trail}"))
+                continue
             violations.extend(
                 _scan_artifact_keys(rel_path, child, top_allowed, kind, trail=child_trail, parent_key=key_s)
             )

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -295,11 +295,19 @@ def _scan_artifact_keys(
             key_s = str(key)
             child_trail = f"{trail}.{key_s}"
             if parent_key in _DYNAMIC_NAME_PARENTS:
+                # immediate children of a dynamic section are free metric *names*
                 if not _DYNAMIC_NAME_RE.match(key_s):
                     violations.append(ScanViolation(rel_path, f"non-identifier key under {parent_key}: {child_trail}"))
                 if not isinstance(child, Mapping):
                     violations.append(ScanViolation(rel_path, f"{parent_key} entry must be a mapping: {child_trail}"))
-            elif key_s not in top_allowed and key_s not in _ALLOWED_NESTED_KEYS:
+            elif parent_key is None:
+                # artifact root: only the per-artifact top-level schema applies
+                if key_s not in top_allowed:
+                    violations.append(ScanViolation(rel_path, f"unknown {kind} key not in schema: {child_trail}"))
+            elif key_s not in _ALLOWED_NESTED_KEYS:
+                # below the root only the shared nested-row schema applies; a
+                # top-level-only key (notes/surface/...) must not reappear nested
+                # as a raw sink (e.g. metrics.<name>.notes).
                 violations.append(ScanViolation(rel_path, f"unknown {kind} key not in schema: {child_trail}"))
             if key_s in _DYNAMIC_NAME_PARENTS and not isinstance(child, Mapping):
                 # A dynamic section (e.g. metrics) must be a mapping of name -> row;

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -162,6 +162,37 @@ _ALLOWED_SPLIT_KEYS = frozenset(
     }
 )
 
+# Keys permitted inside the *nested* objects of a committable artifact. Enforcing
+# the allowlist recursively (not just at the top level) is what closes the
+# whack-a-mole: a raw sink nested under an allowed object (metrics.issue_body,
+# scanner.pr_title, ...) fails closed regardless of whether the sink name was
+# ever added to the denylist. Covers PairedDelta metric rows, playbooks, scanner
+# self-attest, and the split assignment.
+_ALLOWED_NESTED_KEYS = frozenset(
+    {
+        "metric",
+        "baseline",
+        "candidate",
+        "n",
+        "baseline_mean",
+        "candidate_mean",
+        "delta",
+        "wins",
+        "losses",
+        "ties",
+        "content_scan",
+        "path_allowlist",
+        "train",
+        "holdout",
+    }
+)
+
+# Under these parents the immediate child keys are free identifier *names* (e.g.
+# the metric name in ``metrics.<name>``); each such value must itself be a mapping
+# so a scalar raw sink (``metrics.pr_title: "..."``) cannot masquerade as a name.
+_DYNAMIC_NAME_PARENTS = frozenset({"metrics"})
+_DYNAMIC_NAME_RE = re.compile(r"[a-z][a-z0-9_]*\Z")
+
 
 @dataclass(frozen=True)
 class ScanViolation:
@@ -241,17 +272,44 @@ def _scan_json_keys(rel_path: str, value: Any, *, trail: str = "$") -> list[Scan
     return violations
 
 
-def _check_allowed_top_level_keys(
-    rel_path: str, parsed: Any, allowed: frozenset[str], kind: str
+def _scan_artifact_keys(
+    rel_path: str,
+    value: Any,
+    top_allowed: frozenset[str],
+    kind: str,
+    *,
+    trail: str = "$",
+    parent_key: str | None = None,
 ) -> list[ScanViolation]:
-    """Fail closed on unknown top-level keys for a committable data artifact."""
+    """Fail closed on unknown keys at every depth of a committable data artifact.
 
-    if not isinstance(parsed, Mapping):
-        return []
-    unknown = sorted(str(key) for key in parsed if str(key) not in allowed)
-    if unknown:
-        return [ScanViolation(rel_path, f"unknown {kind} key(s) not in schema: {unknown}")]
-    return []
+    Top-level keys must be in ``top_allowed``; nested keys must be in
+    ``top_allowed`` or ``_ALLOWED_NESTED_KEYS``. Children of a dynamic-name parent
+    (``metrics``) are free identifier names but must each be a mapping, so a scalar
+    raw sink cannot ride in as a fake metric name.
+    """
+
+    violations: list[ScanViolation] = []
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_s = str(key)
+            child_trail = f"{trail}.{key_s}"
+            if parent_key in _DYNAMIC_NAME_PARENTS:
+                if not _DYNAMIC_NAME_RE.match(key_s):
+                    violations.append(ScanViolation(rel_path, f"non-identifier key under {parent_key}: {child_trail}"))
+                if not isinstance(child, Mapping):
+                    violations.append(ScanViolation(rel_path, f"{parent_key} entry must be a mapping: {child_trail}"))
+            elif key_s not in top_allowed and key_s not in _ALLOWED_NESTED_KEYS:
+                violations.append(ScanViolation(rel_path, f"unknown {kind} key not in schema: {child_trail}"))
+            violations.extend(
+                _scan_artifact_keys(rel_path, child, top_allowed, kind, trail=child_trail, parent_key=key_s)
+            )
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            violations.extend(
+                _scan_artifact_keys(rel_path, child, top_allowed, kind, trail=f"{trail}[{idx}]", parent_key=parent_key)
+            )
+    return violations
 
 
 def _yaml_error_summary(exc: yaml.YAMLError) -> str:
@@ -287,9 +345,9 @@ def _scan_yaml(rel_path: str, text: str) -> list[ScanViolation]:
         violations.extend(_scan_json_keys(rel_path, parsed))
         return violations
     if rel_path == "agent-evals/splits.yaml":
-        violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_SPLIT_KEYS, "split"))
+        violations.extend(_scan_artifact_keys(rel_path, parsed, _ALLOWED_SPLIT_KEYS, "split"))
     elif rel_path.endswith("/task.yaml"):
-        violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_TASK_KEYS, "task"))
+        violations.extend(_scan_artifact_keys(rel_path, parsed, _ALLOWED_TASK_KEYS, "task"))
     violations.extend(_scan_json_keys(rel_path, parsed))
     return violations
 
@@ -320,7 +378,7 @@ def validate_agent_eval_file(rel_path: str, text: str) -> list[ScanViolation]:
         else:
             if not isinstance(parsed, dict):
                 violations.append(ScanViolation(rel_path, "aggregate report must be a JSON object"))
-            violations.extend(_check_allowed_top_level_keys(rel_path, parsed, _ALLOWED_REPORT_KEYS, "report"))
+            violations.extend(_scan_artifact_keys(rel_path, parsed, _ALLOWED_REPORT_KEYS, "report"))
             violations.extend(_scan_json_keys(rel_path, parsed))
         return violations
 

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Content scanner and aggregate-report serializer for ADR 0100 agent-evals.
+
+The scanner is intentionally conservative for committed data artifacts and
+lighter for implementation files.  It enforces three layers:
+
+* exact path allowlist for the PR2 surface;
+* data-artifact key/value checks that block raw issue, PR, RFP, filename, path,
+  query, answer, and evidence sinks;
+* implementation import guard so the repo-neutral core does not grow a BidMate
+  RAG back-edge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+SURFACE = "agent-evals-pr2"
+
+_ALLOWED_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^agent-evals/README\.md\Z"),
+    re.compile(r"^agent-evals/core/__init__\.py\Z"),
+    re.compile(r"^agent-evals/core/(schema|metrics|report)\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/__init__\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/task_mining\.py\Z"),
+    re.compile(r"^agent-evals/playbooks/v(0_naive|1_spec_first)\.md\Z"),
+    re.compile(r"^agent-evals/splits\.yaml\Z"),
+    re.compile(r"^agent-evals/tasks/[A-Za-z0-9_.-]+/task\.yaml\Z"),
+    re.compile(r"^agent-evals/reports/[A-Za-z0-9_.-]+\.aggregate\.json\Z"),
+)
+
+_CODE_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^agent-evals/core/.*\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/.*\.py\Z"),
+)
+
+_FORBIDDEN_DATA_KEYS = frozenset(
+    {
+        "answer",
+        "body",
+        "captured_diff",
+        "chunk_id",
+        "chunk_text",
+        "doc_id",
+        "document_id",
+        "document_text",
+        "evidence",
+        "file_name",
+        "filename",
+        "local_path",
+        "path",
+        "patch",
+        "pr_body",
+        "query",
+        "raw_body",
+        "raw_diff",
+        "raw_issue_body",
+        "raw_pr_body",
+        "reviewer_input",
+        "rfp_body",
+        "run_log",
+        "text",
+    }
+)
+
+_FORBIDDEN_KEY_RE = re.compile(
+    r"(?im)^\s*[\"']?(?:"
+    + "|".join(re.escape(key) for key in sorted(_FORBIDDEN_DATA_KEYS))
+    + r")[\"']?\s*[:=]"
+)
+
+_FORBIDDEN_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("absolute local path", re.compile(r"(?:/Users/|/Volumes/|/private/|/var/folders/|[A-Za-z]:\\)")),
+    ("raw diff marker", re.compile(r"(?m)^(?:diff --git|@@ |--- a/|\+\+\+ b/)")),
+    ("raw log marker", re.compile(r"(?i)\b(?:run-log|captured\.diff|reviewer-input|raw-dump)\b")),
+    ("rfp text marker", re.compile(r"(?i)\b(?:raw rfp|rfp body|document text|chunk text)\b")),
+)
+
+_FORBIDDEN_IMPORT_PREFIXES = (
+    "rag_core",
+    "rag_answer",
+    "rag_query",
+    "rag_retrieval",
+    "rag_verifier",
+    "rag_vector_store",
+    "ingestion",
+    "visual_ingestion",
+    "eval.",
+    "api.",
+)
+
+
+@dataclass(frozen=True)
+class ScanViolation:
+    path: str
+    reason: str
+
+    def render(self) -> str:
+        return f"{self.path}: {self.reason}"
+
+
+def _rel(path: str | Path, repo_root: Path) -> str:
+    p = Path(path)
+    if p.is_absolute():
+        p = p.relative_to(repo_root)
+    return p.as_posix()
+
+
+def is_allowed_agent_eval_path(rel_path: str) -> bool:
+    return any(pattern.match(rel_path) for pattern in _ALLOWED_PATH_PATTERNS)
+
+
+def _is_code_path(rel_path: str) -> bool:
+    return any(pattern.match(rel_path) for pattern in _CODE_PATH_PATTERNS)
+
+
+def _scan_values(rel_path: str, text: str) -> list[ScanViolation]:
+    out: list[ScanViolation] = []
+    for label, pattern in _FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(text):
+            out.append(ScanViolation(rel_path, f"forbidden {label}"))
+    return out
+
+
+def _scan_python(rel_path: str, text: str) -> list[ScanViolation]:
+    violations: list[ScanViolation] = []
+    try:
+        tree = ast.parse(text, filename=rel_path)
+    except SyntaxError as exc:
+        return violations + [ScanViolation(rel_path, f"python syntax error: {exc.msg}")]
+
+    for node in ast.walk(tree):
+        names: list[str] = []
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module or ""]
+        for name in names:
+            if name and any(name == prefix.rstrip(".") or name.startswith(prefix) for prefix in _FORBIDDEN_IMPORT_PREFIXES):
+                violations.append(ScanViolation(rel_path, f"forbidden repo back-edge import: {name}"))
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            value = node.value
+            if len(value) > 2000:
+                violations.append(ScanViolation(rel_path, "oversized string literal could hide raw text"))
+    return violations
+
+
+def _scan_json_keys(rel_path: str, value: Any, *, trail: str = "$") -> list[ScanViolation]:
+    violations: list[ScanViolation] = []
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_s = str(key)
+            if key_s in _FORBIDDEN_DATA_KEYS:
+                violations.append(ScanViolation(rel_path, f"forbidden data key {trail}.{key_s}"))
+            violations.extend(_scan_json_keys(rel_path, child, trail=f"{trail}.{key_s}"))
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            violations.extend(_scan_json_keys(rel_path, child, trail=f"{trail}[{idx}]"))
+    elif isinstance(value, str):
+        violations.extend(_scan_values(rel_path, value))
+    return violations
+
+
+def validate_agent_eval_file(rel_path: str, text: str) -> list[ScanViolation]:
+    """Validate one staged agent-evals file by repo-relative path and content."""
+
+    violations: list[ScanViolation] = []
+    if not is_allowed_agent_eval_path(rel_path):
+        violations.append(ScanViolation(rel_path, "path is outside the PR2 committable allowlist"))
+        return violations
+
+    # README is the curated surface-definition document. It necessarily names
+    # raw-sink classes (run logs, patches, reviewer inputs) while explaining the
+    # boundary, so data-artifact token checks would be false positives here.
+    if rel_path == "agent-evals/README.md":
+        return violations
+
+    if _is_code_path(rel_path):
+        return _scan_python(rel_path, text)
+
+    violations.extend(_scan_values(rel_path, text))
+    if rel_path.endswith(".aggregate.json"):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            violations.append(ScanViolation(rel_path, f"invalid aggregate JSON: {exc.msg}"))
+        else:
+            if not isinstance(parsed, dict):
+                violations.append(ScanViolation(rel_path, "aggregate report must be a JSON object"))
+            violations.extend(_scan_json_keys(rel_path, parsed))
+
+    if rel_path.endswith((".yaml", ".yml", ".md")):
+        if _FORBIDDEN_KEY_RE.search(text):
+            violations.append(ScanViolation(rel_path, "forbidden raw/private data key in text artifact"))
+
+    return violations
+
+
+def _git_staged_agent_eval_files(repo_root: Path) -> list[str]:
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR", "--", "agent-evals/"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.decode("utf-8", errors="replace"))
+    return [item.decode("utf-8", errors="surrogateescape") for item in proc.stdout.split(b"\0") if item]
+
+
+def _read_staged_text(repo_root: Path, rel_path: str) -> str:
+    proc = subprocess.run(
+        ["git", "show", f":{rel_path}"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"could not read staged content for {rel_path}: {proc.stderr.decode('utf-8', errors='replace')}")
+    return proc.stdout.decode("utf-8", errors="replace")
+
+
+def scan_staged(repo_root: Path) -> list[ScanViolation]:
+    violations: list[ScanViolation] = []
+    for rel_path in _git_staged_agent_eval_files(repo_root):
+        violations.extend(validate_agent_eval_file(rel_path, _read_staged_text(repo_root, rel_path)))
+    return violations
+
+
+def scan_worktree_paths(repo_root: Path, paths: Iterable[str | Path]) -> list[ScanViolation]:
+    violations: list[ScanViolation] = []
+    for path in paths:
+        rel_path = _rel(path, repo_root)
+        text = (repo_root / rel_path).read_text(encoding="utf-8")
+        violations.extend(validate_agent_eval_file(rel_path, text))
+    return violations
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_aggregate_report(path: Path, report: Mapping[str, Any]) -> None:
+    """Write a sorted aggregate report after validating serialized content."""
+
+    text = json.dumps(dict(report), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    rel_path = path.as_posix()
+    violations = validate_agent_eval_file(rel_path, text)
+    if violations:
+        rendered = "\n".join(v.render() for v in violations)
+        raise ValueError(f"aggregate report failed scanner:\n{rendered}")
+    path.write_text(text, encoding="utf-8")
+
+
+def _render_cli_violations(violations: Sequence[ScanViolation]) -> str:
+    if not violations:
+        return "agent-evals content scanner: OK"
+    lines = ["agent-evals content scanner: blocked non-aggregate/private content"]
+    lines.extend(f"  - {violation.render()}" for violation in violations)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check-staged", action="store_true", help="validate staged agent-evals/ files")
+    parser.add_argument("--check-paths", nargs="*", help="validate worktree paths")
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    violations: list[ScanViolation] = []
+    if args.check_staged:
+        violations.extend(scan_staged(repo_root))
+    if args.check_paths is not None:
+        violations.extend(scan_worktree_paths(repo_root, args.check_paths))
+    if not args.check_staged and args.check_paths is None:
+        parser.error("choose --check-staged or --check-paths")
+
+    print(_render_cli_violations(violations))
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-evals/core/schema.py
+++ b/agent-evals/core/schema.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Small schema helpers for the ADR 0100 operator-skill eval surface.
+
+The top-level directory is named ``agent-evals`` for readability, so this file
+is intentionally dependency-light and importable by path in tests/tools.  The
+schema is aggregate-only: task definitions carry sanitized category/contract
+metadata and never raw issue, PR, RFP, filename, path, query, answer, or evidence
+text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+ALLOWED_TASK_KEYS = frozenset(
+    {
+        "task_id",
+        "source",
+        "category",
+        "train_hint",
+        "acceptance",
+        "hidden_test_gate",
+        "aggregate_only_notes",
+    }
+)
+
+ALLOWED_REPORT_KEYS = frozenset(
+    {
+        "schema_version",
+        "surface",
+        "report_id",
+        "generated_by",
+        "task_count",
+        "playbooks",
+        "metrics",
+        "scanner",
+        "notes",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EvalTask:
+    """Sanitized operator task contract.
+
+    ``acceptance`` and ``hidden_test_gate`` are operator-authored aggregate
+    criteria, not copied issue/PR/RFP text.  The content scanner in
+    ``report.py`` enforces the same boundary before these files can be
+    committed.
+    """
+
+    task_id: str
+    source: str
+    category: str
+    train_hint: str
+    acceptance: tuple[str, ...]
+    hidden_test_gate: str
+    aggregate_only_notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "EvalTask":
+        unknown = set(data) - ALLOWED_TASK_KEYS
+        if unknown:
+            raise ValueError(f"unknown task key(s): {sorted(unknown)}")
+        required = {"task_id", "source", "category", "acceptance", "hidden_test_gate"}
+        missing = required - set(data)
+        if missing:
+            raise ValueError(f"missing task key(s): {sorted(missing)}")
+        return cls(
+            task_id=str(data["task_id"]),
+            source=str(data["source"]),
+            category=str(data["category"]),
+            train_hint=str(data.get("train_hint", "")),
+            acceptance=tuple(str(item) for item in data["acceptance"]),
+            hidden_test_gate=str(data["hidden_test_gate"]),
+            aggregate_only_notes=tuple(str(item) for item in data.get("aggregate_only_notes", ())),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "source": self.source,
+            "category": self.category,
+            "train_hint": self.train_hint,
+            "acceptance": list(self.acceptance),
+            "hidden_test_gate": self.hidden_test_gate,
+            "aggregate_only_notes": list(self.aggregate_only_notes),
+        }
+
+
+@dataclass(frozen=True)
+class Playbook:
+    name: str
+    version: str
+    sha256: str
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"name": self.name, "version": self.version, "sha256": self.sha256}

--- a/agent-evals/playbooks/v0_naive.md
+++ b/agent-evals/playbooks/v0_naive.md
@@ -1,0 +1,17 @@
+# v0_naive playbook
+
+Version: v0_naive
+Frozen-surface: ADR 0100 PR2 smoke
+
+## Contract
+
+1. Read the task contract once.
+2. Make the smallest safe code or documentation change that appears to satisfy it.
+3. Run the named local validation gates when they are available.
+4. Report only changed files, validation evidence, and remaining risk.
+
+## Guardrails
+
+- Do not use private RFP content.
+- Do not copy issue or PR bodies into outputs.
+- Do not claim aggregate improvement without paired same-task evidence.

--- a/agent-evals/playbooks/v1_spec_first.md
+++ b/agent-evals/playbooks/v1_spec_first.md
@@ -1,0 +1,18 @@
+# v1_spec_first playbook
+
+Version: v1_spec_first
+Frozen-surface: ADR 0100 PR2 smoke
+
+## Contract
+
+1. Restate the task as acceptance criteria before editing.
+2. Identify the smallest existing guard or test that should fail if the behavior regresses.
+3. Edit only the files required by that acceptance contract.
+4. Run targeted validation first, then the repository guard required for the touched surface.
+5. Report paired evidence against the same task, not an absolute leaderboard score.
+
+## Guardrails
+
+- Treat task text as sanitized metadata, never as raw issue or PR payload.
+- Keep holdout tasks unseen during implementation.
+- Fail closed when a privacy boundary is uncertain.

--- a/agent-evals/reports/smoke.aggregate.json
+++ b/agent-evals/reports/smoke.aggregate.json
@@ -1,0 +1,34 @@
+{
+  "generated_by": "agent-evals-pr2-smoke",
+  "metrics": {
+    "hidden_gate_pass_rate": {
+      "baseline": "v0_naive",
+      "baseline_mean": 0.333333,
+      "candidate": "v1_spec_first",
+      "candidate_mean": 0.666667,
+      "delta": 0.333334,
+      "losses": 0,
+      "metric": "hidden_gate_pass_rate",
+      "n": 3,
+      "ties": 1,
+      "wins": 2
+    }
+  },
+  "notes": [
+    "report-before-expansion smoke only",
+    "directional paired signal, not absolute leaderboard",
+    "aggregate counts only"
+  ],
+  "playbooks": {
+    "baseline": "v0_naive",
+    "candidate": "v1_spec_first"
+  },
+  "report_id": "smoke",
+  "scanner": {
+    "content_scan": "pass",
+    "path_allowlist": "PR2"
+  },
+  "schema_version": 1,
+  "surface": "agent-evals-pr2",
+  "task_count": 3
+}

--- a/agent-evals/splits.yaml
+++ b/agent-evals/splits.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+surface: agent-evals-pr2
+freshness_exclusion_days: 30
+assignment:
+  train:
+    - T-smoke-001
+    - T-smoke-002
+  holdout:
+    - T-smoke-003
+notes:
+  - smoke split only; full holdout expansion is PR3
+  - no raw issue, PR, patch, filename, path, query, answer, or evidence text

--- a/agent-evals/tasks/T-smoke-001/task.yaml
+++ b/agent-evals/tasks/T-smoke-001/task.yaml
@@ -1,0 +1,10 @@
+task_id: T-smoke-001
+source: smoke_synthetic_contract
+category: hook_privacy
+train_hint: prefer local guard before broad workflow changes
+acceptance:
+  - preserve deny-by-default boundary
+  - add scanner-backed commit exception only for curated surface files
+hidden_test_gate: unseen forced-add artifact remains blocked
+aggregate_only_notes:
+  - no raw issue, PR, patch, filename, path, query, answer, or evidence text

--- a/agent-evals/tasks/T-smoke-002/task.yaml
+++ b/agent-evals/tasks/T-smoke-002/task.yaml
@@ -1,0 +1,10 @@
+task_id: T-smoke-002
+source: smoke_synthetic_contract
+category: eval_guard
+train_hint: prefer paired directional measurement over absolute scoring
+acceptance:
+  - compute same-task candidate minus baseline delta
+  - reject empty paired input
+hidden_test_gate: unseen tie and regression cases preserve win loss tie counts
+aggregate_only_notes:
+  - no raw issue, PR, patch, filename, path, query, answer, or evidence text

--- a/agent-evals/tasks/T-smoke-003/task.yaml
+++ b/agent-evals/tasks/T-smoke-003/task.yaml
@@ -1,0 +1,10 @@
+task_id: T-smoke-003
+source: smoke_synthetic_contract
+category: doc_contract
+train_hint: state privacy and freshness exclusions before expansion
+acceptance:
+  - mark smoke report as report-before-expansion
+  - keep holdout expansion outside PR2
+hidden_test_gate: unseen split freshness exclusion remains documented
+aggregate_only_notes:
+  - no raw issue, PR, patch, filename, path, query, answer, or evidence text

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -283,3 +283,15 @@ def test_scanner_rejects_non_mapping_dynamic_section() -> None:
     violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
 
     assert any("dynamic section must be a mapping" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_top_level_key_reused_below_root() -> None:
+    # P1 (cross-family review): top-level-only keys (notes/surface/...) must not be
+    # accepted nested. A metric row reusing `notes` would otherwise smuggle short
+    # raw prose; only the root uses the top-level schema, nested uses the row set.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_nested_toplevel_test")
+
+    text = '{"schema_version": 1, "metrics": {"review_body": {"notes": "raw upstream body"}}}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("unknown report key not in schema" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -111,3 +111,64 @@ def test_schema_rejects_unknown_task_keys() -> None:
         assert "unknown task key" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("EvalTask accepted a raw-sink key")
+
+
+def test_scanner_rejects_oversized_yaml_value_under_innocuous_key() -> None:
+    # GAP 1: raw prose smuggled as a long scalar under a non-forbidden task key
+    # (``train_hint``) is only caught once the YAML is parsed structurally.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_yaml_size_test")
+
+    smuggled = "x" * 600
+    text = (
+        "task_id: T-1\n"
+        "source: smoke_synthetic_contract\n"
+        "category: hook_privacy\n"
+        f"train_hint: {smuggled}\n"
+        "acceptance:\n  - preserve guard\n"
+        "hidden_test_gate: unseen guard passes\n"
+    )
+    violations = report.validate_agent_eval_file("agent-evals/tasks/T-1/task.yaml", text)
+
+    assert any("oversized data string" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_yaml_value_pattern_only_visible_after_parse() -> None:
+    # GAP 1: the diff marker is anchored to start-of-line, so as a raw YAML scalar
+    # value it escapes the whole-text scan and is only exposed after a real parse.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_yaml_parse_test")
+
+    text = (
+        "task_id: T-1\n"
+        "source: smoke_synthetic_contract\n"
+        "category: hook_privacy\n"
+        "train_hint: 'diff --git a/secret b/secret'\n"
+        "acceptance:\n  - preserve guard\n"
+        "hidden_test_gate: unseen guard passes\n"
+    )
+    violations = report.validate_agent_eval_file("agent-evals/tasks/T-1/task.yaml", text)
+
+    assert any("raw diff marker" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_unparseable_yaml_artifact() -> None:
+    # GAP 1: a committable YAML artifact that does not parse cannot be cleared by
+    # the structural layer, so it is rejected rather than silently text-scanned.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_yaml_bad_test")
+
+    violations = report.validate_agent_eval_file(
+        "agent-evals/splits.yaml", "assignment: [unterminated\n"
+    )
+
+    assert any("unparseable YAML data artifact" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_oversized_aggregate_json_value() -> None:
+    # GAP 2: an aggregate JSON string value can hide a raw excerpt even when it
+    # matches none of the value patterns, so a size cap mirrors the Python check.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_json_size_test")
+
+    blob = "y" * 600
+    text = '{"schema_version": 1, "notes": "' + blob + '"}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("oversized data string" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -218,3 +218,30 @@ def test_scanner_rejects_unknown_splits_key() -> None:
     violations = report.validate_agent_eval_file("agent-evals/splits.yaml", text)
 
     assert any("unknown split key" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_raw_sink_under_allowed_report_object() -> None:
+    # P1 (cross-family review): a raw-title sink nested under an allowed top-level
+    # object (metrics) bypasses the top-level allowlist, so the recursive denylist
+    # must name it. pr_title/issue_title/rfp_excerpt are now forbidden at any depth.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_nested_sink_test")
+
+    text = '{"schema_version": 1, "metrics": {"pr_title": "raw upstream title"}}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any(
+        "forbidden data key" in violation.reason and "pr_title" in violation.reason
+        for violation in violations
+    )
+
+
+def test_scanner_rejects_non_mapping_yaml_artifact() -> None:
+    # P1 (cross-family review): wrapping unknown keys in a sequence must not bypass
+    # the positive key allowlist; a non-mapping committable YAML is rejected.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_yaml_seq_test")
+
+    violations = report.validate_agent_eval_file(
+        "agent-evals/tasks/T-1/task.yaml", "- issue_title: raw upstream issue title\n"
+    )
+
+    assert any("must be a mapping" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -172,3 +172,49 @@ def test_scanner_rejects_oversized_aggregate_json_value() -> None:
     violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
 
     assert any("oversized data string" in violation.reason for violation in violations)
+
+
+def test_scanner_key_allowlists_match_schema() -> None:
+    # The scanner mirrors schema.py's positive key sets inline so the pre-commit
+    # boundary stays import-free; this guards the duplication against drift.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_drift_test")
+    schema = load_module("agent-evals/core/schema.py", "agent_evals_schema_drift_test")
+
+    assert report._ALLOWED_TASK_KEYS == schema.ALLOWED_TASK_KEYS
+    assert report._ALLOWED_REPORT_KEYS == schema.ALLOWED_REPORT_KEYS
+
+
+def test_scanner_rejects_unknown_task_yaml_key() -> None:
+    # P1 (cross-family review): a non-forbidden raw sink under an unknown key
+    # (issue_title) must fail closed, not only the fixed forbidden-key list.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_task_key_test")
+
+    text = (
+        "task_id: T-1\n"
+        "source: smoke_synthetic_contract\n"
+        "category: hook_privacy\n"
+        "acceptance:\n  - preserve guard\n"
+        "hidden_test_gate: unseen guard passes\n"
+        "issue_title: raw upstream issue title\n"
+    )
+    violations = report.validate_agent_eval_file("agent-evals/tasks/T-1/task.yaml", text)
+
+    assert any("unknown task key" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_unknown_aggregate_report_key() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_report_key_test")
+
+    text = '{"schema_version": 1, "pr_title": "raw upstream pr title"}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("unknown report key" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_unknown_splits_key() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_split_key_test")
+
+    text = "schema_version: 1\nrfp_excerpt: a short raw excerpt\n"
+    violations = report.validate_agent_eval_file("agent-evals/splits.yaml", text)
+
+    assert any("unknown split key" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -245,3 +245,29 @@ def test_scanner_rejects_non_mapping_yaml_artifact() -> None:
     )
 
     assert any("must be a mapping" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_raw_body_variant_under_nested_object() -> None:
+    # P1 (cross-family review): nested raw sinks must fail closed structurally via
+    # the recursive allowlist, not depend on the denylist naming every variant
+    # (issue_body / review_body / comment_body / ...). scanner is a non-dynamic
+    # allowed object, so an unknown nested key is rejected outright.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_nested_body_test")
+
+    text = '{"schema_version": 1, "scanner": {"issue_body": "raw upstream body"}}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("unknown report key not in schema" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_scalar_metric_entry() -> None:
+    # P1 (cross-family review): under the dynamic-name parent `metrics`, a scalar
+    # raw sink masquerading as a metric name is rejected because each metric entry
+    # must itself be a mapping (a PairedDelta row). issue_body is not denylisted,
+    # so this proves the structural gate is independent of the denylist.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_scalar_metric_test")
+
+    text = '{"schema_version": 1, "metrics": {"issue_body": "raw upstream body"}}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("must be a mapping" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_paired_delta_reports_directional_same_task_difference() -> None:
+    metrics = load_module("agent-evals/core/metrics.py", "agent_evals_metrics_test")
+
+    delta = metrics.paired_delta(
+        [
+            {"v0": 0, "v1": 1},
+            {"v0": 1, "v1": 1},
+            {"v0": 0, "v1": 1},
+        ],
+        baseline_key="v0",
+        candidate_key="v1",
+        metric="hidden_gate_pass_rate",
+    )
+
+    assert delta.n == 3
+    assert delta.baseline_mean == 0.333333
+    assert delta.candidate_mean == 1.0
+    assert delta.delta == 0.666667
+    assert (delta.wins, delta.losses, delta.ties) == (2, 0, 1)
+
+
+def test_paired_delta_rejects_empty_input() -> None:
+    metrics = load_module("agent-evals/core/metrics.py", "agent_evals_metrics_empty_test")
+
+    try:
+        metrics.paired_delta([], baseline_key="v0", candidate_key="v1", metric="accepted")
+    except ValueError as exc:
+        assert "at least one" in str(exc)
+    else:  # pragma: no cover - explicit failure keeps this stdlib-only
+        raise AssertionError("paired_delta accepted an empty same-task set")
+
+
+def test_scanner_accepts_current_pr2_surface_files() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_accept_test")
+    rel_paths = sorted(
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "agent-evals").rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    violations = []
+    for rel_path in rel_paths:
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        violations.extend(report.validate_agent_eval_file(rel_path, text))
+
+    assert [violation.render() for violation in violations] == []
+
+
+def test_scanner_rejects_unexpected_agent_evals_path() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_path_test")
+
+    violations = report.validate_agent_eval_file("agent-evals/runs/T-1/run-log.json", "{}")
+
+    assert any("outside the PR2 committable allowlist" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_raw_data_keys_and_local_paths() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_raw_test")
+
+    violations = report.validate_agent_eval_file(
+        "agent-evals/reports/smoke.aggregate.json",
+        '{"schema_version": 1, "query": "redacted", "notes": ["/Users/example/private"]}',
+    )
+
+    rendered = "\n".join(violation.render() for violation in violations)
+    assert "forbidden data key" in rendered
+    assert "absolute local path" in rendered
+
+
+def test_scanner_rejects_bidmate_back_edge_in_core_code() -> None:
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_import_test")
+
+    violations = report.validate_agent_eval_file("agent-evals/core/schema.py", "import rag_core\n")
+
+    assert any("forbidden repo back-edge import" in violation.reason for violation in violations)
+
+
+def test_schema_rejects_unknown_task_keys() -> None:
+    schema = load_module("agent-evals/core/schema.py", "agent_evals_schema_test")
+
+    try:
+        schema.EvalTask.from_mapping(
+            {
+                "task_id": "T-1",
+                "source": "smoke_synthetic_contract",
+                "category": "hook_privacy",
+                "acceptance": ["preserve guard"],
+                "hidden_test_gate": "unseen guard passes",
+                "filename": "not allowed",
+            }
+        )
+    except ValueError as exc:
+        assert "unknown task key" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("EvalTask accepted a raw-sink key")

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -271,3 +271,15 @@ def test_scanner_rejects_scalar_metric_entry() -> None:
     violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
 
     assert any("must be a mapping" in violation.reason for violation in violations)
+
+
+def test_scanner_rejects_non_mapping_dynamic_section() -> None:
+    # P1 (cross-family review): a dynamic section (metrics) that is a list/scalar
+    # would let raw items fall through unchecked, so the section itself must be a
+    # mapping of name -> row before any entry is accepted.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_dyn_section_test")
+
+    text = '{"schema_version": 1, "metrics": ["short raw reviewer body"]}'
+    violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
+
+    assert any("dynamic section must be a mapping" in violation.reason for violation in violations)

--- a/tests/test_agent_evals_gitignore.py
+++ b/tests/test_agent_evals_gitignore.py
@@ -2,23 +2,22 @@
 
 The operator-skill eval surface (`agent-evals/`) runs paired playbook trials whose
 per-run artifacts — run-logs, captured PR diffs, reviewer inputs — carry raw issue/PR
-text that ADR 0005 forbids committing. PR1 enforces the **path layer** of the boundary
+text that ADR 0005 forbids committing. PR1 established the path layer and PR2 extends it with content scanning
 with three complementary checks:
 
 1. ``.gitignore`` is **deny-by-default**: everything under ``agent-evals/`` is ignored, then
-   ONLY ``README.md`` is unignored (``test_*`` below). Code (core/, adapters/), task.yaml
-   (mined from merge PRs), playbooks, splits.yaml, and reports are all free-form text that
-   can carry raw issue/PR/RFP content, so they stay denied until PR2 lands the content-level
-   aggregate-only scanner + per-file privacy validation — an exact-match README-only allowlist
-   means no generalizable pattern a raw artifact could match.
+   PR2 unignores only the exact scanner-backed code/task/playbook/split/aggregate-report
+   surface. Raw run logs, captured patches, reviewer inputs, worktrees, unexpected names, and
+   non-aggregate reports remain denied.
 2. An **index-aware guard** (``test_no_tracked_file_outside_committable_allowlist``):
    ``.gitignore`` is only advisory (``git add -f`` and already-tracked files bypass it),
    so the authoritative enforcement is that NO *tracked* file under ``agent-evals/`` falls
    outside the exact committable allowlist.
 3. A **local pre-commit mirror** (``test_precommit_hook_enforces_agent_evals_boundary``):
-   ``.githooks/pre-commit`` must carry the same deny-all-but-README rule so a force-added raw
-   artifact is rejected at commit time locally, not only in CI (mirrors the hook's existing
-   ADR 0005 path-block convention).
+   ``.githooks/pre-commit`` must carry the same deny-by-default rule and invoke
+   ``agent-evals/core/report.py --check-staged`` so a force-added raw artifact is rejected at
+   commit time locally, not only in CI (mirrors the hook's existing ADR 0005 path-block
+   convention).
 
 ``git check-ignore --no-index --quiet <path>`` exits 0 when a path is ignored by pattern,
 1 when not — ``--no-index`` evaluates the patterns regardless of tracking state, so the
@@ -35,8 +34,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Raw / per-run artifacts that MUST be denied (ignored) — including unanticipated names
-# and report files (reports become committable only in PR2, with the content scanner).
+# Raw / per-run artifacts that MUST be denied (ignored) — including unanticipated names.
 DENIED = [
     "agent-evals/runs/T-1/seed-0/run-log.json",
     "agent-evals/runs/T-1/seed-0/captured.diff",
@@ -54,21 +52,7 @@ DENIED = [
     "agent-evals/reports/2026-smoke-run-log.json",        # "smoke" in name but not allowed
     "agent-evals/reports/2026-smoke-captured-diff.json",
     "agent-evals/reports/raw-v0-vs-v1.json",
-    "agent-evals/reports/2026-01-01-v0-vs-v1.aggregate.json",  # reports deferred to PR2 → denied now
-    "agent-evals/reports/holdout.aggregate.json",             # (PR2 adds report allowlist + scanner)
-    # Free-form data, frozen instruments, AND code: in PR1 the ONLY committable agent-evals/
-    # file is README. task.yaml (mined from merge PRs), playbooks/splits (operator-authored),
-    # and even code (a .py can hold a raw string literal) all wait for PR2's content scanner +
-    # per-file privacy validation. PR2 moves the relevant ones to ALLOWED *and* adds content
-    # validation (changing both .gitignore and this test together is the intended tripwire).
-    "agent-evals/tasks/T-1/task.yaml",
-    "agent-evals/playbooks/v0_naive.md",
-    "agent-evals/splits.yaml",
-    "agent-evals/core/schema.py",                 # code waits for PR2 (NO .py allowlist in PR1)
-    "agent-evals/core/__init__.py",
-    "agent-evals/adapters/bidmate/task_mining.py",
-    "agent-evals/adapters/bidmate/__init__.py",
-    # A direct shallow .py is denied too — an exact-match README-only allowlist closes the
+    # Unanticipated shallow .py files are denied too — exact PR2 module allowlists close the
     # "shallow code path could be a raw sink" bypass (no generalizable .py pattern to match):
     "agent-evals/core/raw_dump.py",
     "agent-evals/adapters/bidmate/raw_dump.py",
@@ -76,17 +60,24 @@ DENIED = [
     "agent-evals/adapters/bidmate/worktrees/wt1/dump.py",
 ]
 
-# The ONLY agent-evals/ file committable in PR1: the curated, in-PR-reviewed README
-# (surface definition). Code / task.yaml / playbooks / splits / reports are all deliberately
-# absent — committable only from PR2 onward, behind the content scanner.
+# PR2 committable surface: exact scanner-backed files only.
 ALLOWED = [
     "agent-evals/README.md",
+    "agent-evals/core/__init__.py",
+    "agent-evals/core/schema.py",
+    "agent-evals/core/metrics.py",
+    "agent-evals/core/report.py",
+    "agent-evals/adapters/bidmate/__init__.py",
+    "agent-evals/adapters/bidmate/task_mining.py",
+    "agent-evals/playbooks/v0_naive.md",
+    "agent-evals/playbooks/v1_spec_first.md",
+    "agent-evals/splits.yaml",
+    "agent-evals/tasks/T-smoke-001/task.yaml",
+    "agent-evals/reports/smoke.aggregate.json",
 ]
 
 # Exact committable allowlist (regex over POSIX rel-paths) for the index-aware guard.
-# Mirrors the PR1 `.gitignore`: README ONLY. An exact-match allowlist (no code/data globs)
-# means there is no generalizable pattern a raw artifact could match — PR2 adds the code +
-# data unignore rules together with the content guard.
+# Mirrors the PR2 `.gitignore`: exact files plus task.yaml / aggregate-report path shapes.
 #
 # `\Z` (NOT `$`): Python's `$` also matches just before a trailing newline, so
 # `^agent-evals/README\.md$` would wrongly accept a tracked path literally named
@@ -95,6 +86,14 @@ ALLOWED = [
 # with `git ls-files -z` framing below so such a path arrives as one record, not a clean split.
 COMMITTABLE_RE = [
     re.compile(r"^agent-evals/README\.md\Z"),
+    re.compile(r"^agent-evals/core/__init__\.py\Z"),
+    re.compile(r"^agent-evals/core/(schema|metrics|report)\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/__init__\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/task_mining\.py\Z"),
+    re.compile(r"^agent-evals/playbooks/v(0_naive|1_spec_first)\.md\Z"),
+    re.compile(r"^agent-evals/splits\.yaml\Z"),
+    re.compile(r"^agent-evals/tasks/[^/]+/task\.yaml\Z"),
+    re.compile(r"^agent-evals/reports/[^/]+\.aggregate\.json\Z"),
 ]
 
 
@@ -130,8 +129,8 @@ def test_raw_agent_eval_artifacts_are_gitignored(rel_path: str) -> None:
 @pytest.mark.parametrize("rel_path", ALLOWED)
 def test_public_agent_eval_artifacts_are_committable(rel_path: str) -> None:
     assert not _is_ignored(rel_path), (
-        f"{rel_path} IS gitignored but should be committable in PR1 "
-        "(the curated surface-definition README)."
+        f"{rel_path} IS gitignored but should be committable in PR2 "
+        "(scanner-backed agent-evals surface)."
     )
 
 
@@ -152,9 +151,10 @@ def _extract_bash_array(hook_text: str, name: str) -> str:
 
 
 def test_precommit_hook_enforces_agent_evals_boundary() -> None:
-    """Local pre-commit mirror: `.githooks/pre-commit` must deny every agent-evals/ path and
-    allow only README, so a force-added (`git add -f`) raw artifact is rejected at commit time
-    locally — not only by the CI index guard. Mirrors the hook's documented
+    """Local pre-commit mirror: `.githooks/pre-commit` must deny every agent-evals/ path,
+    allow only the PR2 scanner-backed surface, and invoke the content scanner so a
+    force-added (`git add -f`) raw artifact is rejected at commit time locally — not only by
+    the CI index guard. Mirrors the hook's documented
     "BLOCKED_PATTERNS must mirror .gitignore's ADR 0005 boundary" convention.
     """
     hook = (REPO_ROOT / ".githooks" / "pre-commit").read_text()
@@ -165,24 +165,34 @@ def test_precommit_hook_enforces_agent_evals_boundary() -> None:
         "mirroring the .gitignore deny-by-default rule)."
     )
     assert r"'^agent-evals/README\.md$'" in allowed, (
-        "pre-commit ALLOWED_PATTERNS must permit agent-evals/README.md (the sole PR1 exception)."
+        "pre-commit ALLOWED_PATTERNS must permit agent-evals/README.md."
+    )
+    assert r"'^agent-evals/core/(schema|metrics|report)\.py$'" in allowed, (
+        "pre-commit ALLOWED_PATTERNS must permit exact PR2 core modules."
+    )
+    assert r"'^agent-evals/reports/[^/]+\.aggregate\.json$'" in allowed, (
+        "pre-commit ALLOWED_PATTERNS must permit aggregate reports only."
+    )
+    assert "agent-evals/core/report.py --check-staged" in hook, (
+        "pre-commit must run the PR2 content scanner before path allowlisting."
     )
     # Raw-sink trees must NOT leak into the local allowlist.
     assert "agent-evals/runs" not in allowed
-    assert "agent-evals/reports" not in allowed
+    assert "agent-evals/worktrees" not in allowed
+    assert "agent-evals/captures" not in allowed
 
 
 def test_precommit_hook_enumerates_staged_files_nul_safely() -> None:
     """The hook must enumerate staged files NUL-delimited (`git diff --cached -z` +
     `read -r -d ''`), not newline-delimited. A staged path with an embedded newline or
     control character would otherwise split into multiple tokens and slip past the
-    agent-evals/ README-only block (Codex pre-commit review, issue #1844). NUL framing is
+    agent-evals/ exact allowlist block (Codex pre-commit review, issue #1844). NUL framing is
     robust regardless of `core.quotePath`; `read -r -d ''` stays bash-3.2 compatible.
     """
     hook = (REPO_ROOT / ".githooks" / "pre-commit").read_text()
     assert "git diff --cached -z --name-only --diff-filter=ACMR" in hook, (
         "pre-commit must list staged files with `-z` (NUL-delimited) so newline-bearing "
-        "paths cannot evade the agent-evals/ README-only boundary."
+        "paths cannot evade the agent-evals/ exact allowlist boundary."
     )
     assert "while IFS= read -r -d '' file" in hook, (
         "pre-commit must parse the staged-file list with `read -r -d ''` (NUL records)."
@@ -238,7 +248,7 @@ def test_no_tracked_file_outside_committable_allowlist() -> None:
 def test_committable_regex_rejects_control_char_readme_variants(evasive: str) -> None:
     """The committable allowlist regex must reject any control-char/whitespace variant of the
     README path, so a tracked file named (e.g.) `agent-evals/README.md\\n` cannot masquerade
-    as the sole PR1 exception. This is why `COMMITTABLE_RE` uses `\\Z` (not `$`) and why the
+    as the exact README exception. This is why `COMMITTABLE_RE` uses `\\Z` (not `$`) and why the
     index guard reads `git ls-files -z` — together they ensure such a path is surfaced as one
     record and fails the allowlist (Codex pre-commit review, issue #1844).
     """

--- a/tests/test_agent_evals_task_mining.py
+++ b/tests/test_agent_evals_task_mining.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -75,6 +77,29 @@ def test_rendered_task_yaml_passes_content_scanner() -> None:
     violations = scanner.validate_agent_eval_file("agent-evals/tasks/T-1820/task.yaml", text)
 
     assert [violation.render() for violation in violations] == []
+
+
+def test_render_task_yaml_quotes_colon_signals() -> None:
+    # P2 (cross-family review): a governance-style signal containing a colon must
+    # render as a string, not silently reparse into a mapping that corrupts the
+    # acceptance contract.
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_colon_test")
+
+    tasks, _summary = mining.mine_tasks(
+        [
+            {
+                "number": 1500,
+                "merged": True,
+                "category": "doc_contract",
+                "signals": ["ADR 0005: privacy guard"],
+            }
+        ],
+        mineable_floor=1,
+        holdout_target=1,
+    )
+    parsed = yaml.safe_load(mining.render_task_yaml(tasks[0]))
+
+    assert parsed["acceptance"] == ["preserve ADR 0005: privacy guard"]
 
 
 def test_non_allowlisted_category_is_not_mineable() -> None:

--- a/tests/test_agent_evals_task_mining.py
+++ b/tests/test_agent_evals_task_mining.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_task_mining_uses_sanitized_metadata_only() -> None:
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_test")
+
+    tasks, summary = mining.mine_tasks(
+        [
+            {
+                "number": 1336,
+                "merged": True,
+                "category": "hook_privacy",
+                "signals": ["deny-by-default guard", "local precommit mirror"],
+            },
+            {
+                "number": 1337,
+                "merged": False,
+                "category": "hook_privacy",
+                "signals": ["ignored because not merged"],
+            },
+            {
+                "number": 1338,
+                "merged": True,
+                "category": "hook_privacy",
+                "signals": ["ignored because raw payload was detected"],
+                "contains_raw_payload": True,
+            },
+        ],
+        mineable_floor=2,
+        holdout_target=1,
+    )
+
+    assert len(tasks) == 1
+    assert summary.mineable_count == 1
+    assert summary.warnings == ("mineable floor not met: 1 < 2",)
+    task = tasks[0]
+    assert task["task_id"] == "T-1336"
+    forbidden = {"title", "issue_id", "pr_body", "patch", "filename", "path", "query", "answer", "evidence"}
+    assert forbidden.isdisjoint(task)
+
+
+def test_rendered_task_yaml_passes_content_scanner() -> None:
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_render_test")
+    scanner = load_module("agent-evals/core/report.py", "agent_evals_report_for_task_mining_test")
+
+    tasks, _summary = mining.mine_tasks(
+        [
+            {
+                "number": 1820,
+                "merged": True,
+                "category": "eval_guard",
+                "signals": ["paired delta primitive"],
+            }
+        ],
+        mineable_floor=1,
+        holdout_target=1,
+    )
+    text = mining.render_task_yaml(tasks[0])
+
+    violations = scanner.validate_agent_eval_file("agent-evals/tasks/T-1820/task.yaml", text)
+
+    assert [violation.render() for violation in violations] == []
+
+
+def test_non_allowlisted_category_is_not_mineable() -> None:
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_category_test")
+
+    assert not mining.is_mineable(
+        {
+            "number": 1500,
+            "merged": True,
+            "category": "freeform",
+            "signals": ["would be too unconstrained"],
+        }
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0100 operator-skill eval(운영자 기량 평가) 표면의 **PR2** — 실제 코어를 착지시킨다. `agent-evals/core` (schema, paired-delta metrics, content scanner `report.py`), bidmate `task_mining` 어댑터(이미 요약된 merge 메타데이터만 소비 — raw issue/PR/patch/filename/RFP 미접근), playbook v0_naive/v1_spec_first, `splits.yaml`, 합성(synthetic) 3-task smoke + counts-only smoke aggregate report, 그리고 content scanner를 `.githooks/pre-commit`에 wiring. PR1의 경로 경계(path layer) 위에 **내용 경계(content layer)** 를 올린다.

추가로, 이 PR은 **cross-session handoff** 산출물이다: 다른 (Codex) 세션이 코어를 구현(`b4affe52`)했고, 그 세션이 idle 상태가 된 뒤 내가 인수해 read-only 리뷰에서 찾은 **content scanner 2개 gap을 보강**했다 (아래 §3/§4).

Closes #1969

## 2. 영향 파일

load-bearing 경로(단일 출처 `scripts/_governance.py`) **없음**. `agent-evals/`는 ADR 0100이 정의한 신규 **비 load-bearing** 측정 표면이며, RAG 파이프라인(`rag_*`/`ingestion`/`eval/`/`api/`)을 건드리지 않는다.

- `agent-evals/core/{schema,metrics,report}.py`, `core/__init__.py` — schema 헬퍼 + paired-delta + content scanner (신규)
- `agent-evals/adapters/bidmate/{__init__,task_mining}.py` — sanitized task mining (신규)
- `agent-evals/playbooks/v0_naive.md`, `v1_spec_first.md` — frozen playbook 2버전 (신규)
- `agent-evals/splits.yaml`, `tasks/T-smoke-00{1,2,3}/task.yaml`, `reports/smoke.aggregate.json` — 합성 smoke 데이터 (신규)
- `agent-evals/README.md` — surface 문서 갱신
- `.githooks/pre-commit`, `.gitignore` — **자동화/거버넌스 표면**: scanner를 staged 게이트에 wiring + allowlisted 경로 unignore (deny-by-default 유지)
- `tests/test_agent_evals_{core,task_mining,gitignore}.py` — 단위/회귀 테스트

## 3. 리스크

- **Scanner false-positive (정당한 커밋 차단)** — 512자 data-string cap은 실제 최장 값(72자)의 7배. 강화된 scanner를 커밋된 전체 surface(13개 아티팩트)에 대해 `--check-paths` 실행 → exit 0 확인. 55개 테스트 green.
- **Scanner false-negative (raw data 누출)** — 인수 리뷰에서 찾은 정확히 2개 gap을 이 PR이 닫는다: (a) task.yaml/`*.yml`이 whole-text 값패턴+line-regex로만 스캔돼 **innocuous 키 아래 raw prose**(긴 `train_hint`) 또는 line-anchored 마커가 scalar 값으로 통과 가능 → **PyYAML 구조 파싱** 후 동일 key/value scanner 경유, 파싱 불가 YAML 아티팩트 자체를 violation 처리. (b) aggregate JSON 문자열 값에 크기 상한 부재(>2000 가드는 Python literal만) → ~1900자 raw 발췌가 패턴 미매치 시 통과 가능 → **512자 cap** 추가. whole-text + line backstop은 유지(중첩 방어).
- **pre-commit 훅 파손** — `bash -n` OK, scanner wiring(line 381) rebase 후 생존 확인, smoke 데이터가 실제 훅을 통과해 커밋됨.
- **PyYAML 의존** — 신규 의존 아님 (`requirements.txt:2 PyYAML>=6.0.3` 기존 하드 의존).

## 4. 테스트

- `tests/test_agent_evals_core.py` + `task_mining` + `gitignore` = **55 passed** (rebase 후 재확인).
- **Behavior change(보강 2개)에 대한 회귀 테스트 4개 신규** (보강 전 fail / 후 pass): oversized YAML value(innocuous 키), post-parse 전용 value 패턴(diff 마커), unparseable YAML, oversized JSON value.
- smoke 데이터는 전부 합성(`source: smoke_synthetic_contract`) — raw private 데이터 없음.
- **Multi-session/cross-session handoff:** `b4affe52`(다른 세션) 인수. 안전 확인 — 활성 git lock 없음, 커밋 후 ~10.5h idle, 이 브랜치로 열린 PR 없음(이중 커밋 회피), `origin/main` rebase 충돌 0.

## 5. Eval 영향

load-bearing 경로 미변경 → **real-data eval delta 없음** ("All `·`"). `agent-evals/`는 RAG 파이프라인과 분리된 별도 측정 표면(운영자 기량). smoke aggregate report는 **counts-only 합성** report-before-expansion(ADR 0064 self-reference pathology 회피)이며 절대 leaderboard로 쓰지 않는다(ADR 0100 paired-delta only). 커밋된 private 데이터 없음 — content scanner(ADR 0005 경계)가 staged 게이트에서 강제.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 깨짐 **없음**. `agent-evals/`는 additive(신규 최상위 디렉터리), `SCHEMA_VERSION=1` 신규. `.gitignore`는 allowlisted 경로만 unignore(deny-by-default 보존). Answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외 (PR3에서)

- full runner (`git worktree add --detach`, ≥3 seed) + **cross-family acceptance oracle** (`reviewer_family != candidate_family` fail-closed — codex도 candidate family라 reviewer 하드코딩 금지)
- paired bootstrap CI(min-N) + holdout v0-vs-v1 report
- 실제 task mining(범위 #1336-1820, 현재는 합성 smoke만) + external-reviewer payload egress(public-attestation-only 게이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
