### PR TITLE
test: pin BOM case proposer seed doc ids

### DIFF
--- a/tests/test_case_proposer_csv_bom_regression.py
+++ b/tests/test_case_proposer_csv_bom_regression.py
@@ -99,6 +99,10 @@ class TestCaseProposerCsvBomRegression(unittest.TestCase):
             )
             # 2 seed docs × 2 templates per doc (single_doc + abstention).
             self.assertEqual(len(cases), 4)
+            self.assertEqual(
+                [c["proposer_meta"]["seed_doc_id"] for c in cases],
+                ["K2026-001", "K2026-001", "K2026-002", "K2026-002"],
+            )
 
     def test_bom_byte_is_actually_present_in_fixture(self) -> None:
         """Sanity check on the fixture: without this, a regression in


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

BOM-prefixed `data_list.csv`가 required-column parsing만 통과하는 데 그치지 않고, proposer output의 `proposer_meta.seed_doc_id`까지 notice id를 정확히 전달한다는 regression guard를 추가했습니다.

Closes #2345

## 2. 영향 파일

- `tests/test_case_proposer_csv_bom_regression.py` — BOM CSV로 생성된 4개 stub case의 `seed_doc_id` 순서를 검증 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: future CSV reader/refactor가 BOM은 제거하지만 first-column value propagation이나 row ordering을 조용히 깨뜨리는 경우.
- 배제 근거: 신규 테스트가 `K2026-001`, `K2026-002`가 proposer metadata까지 전달되는지 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_case_proposer_csv_bom_regression.py` — 2 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=12, worktrees=111, and `tests/test_case_proposer_csv_bom_regression.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2345-case-proposer-bom-docids` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0` after rebase to latest origin/main.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `eval/case_proposer.py` 구현 변경 없이 existing BOM handling contract만 테스트로 고정했습니다.

## 7. 범위 외

Case proposer implementation, CSV schema, real eval config 변경은 하지 않았습니다.
