### PR TITLE
test: pin dependency graph scanner string ignores

### DIFF
--- a/tests/test_dependency_graph_invariance.py
+++ b/tests/test_dependency_graph_invariance.py
@@ -78,6 +78,20 @@ def _find_rag_core_imports(source: str) -> list[tuple[int, str, str]]:
     return hits
 
 
+def test_find_rag_core_imports_ignores_non_import_mentions() -> None:
+    source = '''
+"""Mention rag_core in a module docstring."""
+
+RAG_CORE_TEXT = "from rag_core import run_rag_query"
+
+
+def explain() -> str:
+    """Mention import rag_core in a function docstring."""
+    return "rag_core should be ignored inside string literals too"
+'''
+    assert _find_rag_core_imports(source) == []
+
+
 @pytest.mark.parametrize("module_name", LEAF_MODULES)
 def test_leaf_module_has_zero_rag_core_back_edges(module_name: str) -> None:
     """Each ADR 0045 leaf module must have zero rag_core imports.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0045 dependency-graph invariance scanner가 `rag_core`라는 텍스트 mention이 아니라 실제 AST import node만 back-edge로 잡아야 한다는 regression guard를 추가했습니다.

Closes #2349

## 2. 영향 파일

- `tests/test_dependency_graph_invariance.py` — module/function docstring과 string literal 안의 `rag_core` mention이 `_find_rag_core_imports` 결과에 포함되지 않는지 검증 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: future scanner refactor가 text search처럼 동작해 docstring/string literal mention을 false positive로 잡는 경우.
- 배제 근거: 신규 테스트가 docstring/string literal만 있는 synthetic source에서 hit가 비어 있는지 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_dependency_graph_invariance.py` — 8 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=11, worktrees=111, and `tests/test_dependency_graph_invariance.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2349-depgraph-ignore-strings` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. Dependency scanner 구현 변경 없이 existing AST-only contract만 테스트로 고정했습니다.

## 7. 범위 외

ADR 0045 inventory, leaf module list, production import graph 변경은 하지 않았습니다.
