### PR TITLE
fix(normalize): 단일 한글숫자글자+원이 화폐로 오정규화되어 grounding 오염 (사원→4)

### DIFF
--- a/tests/test_text_normalize_regression.py
+++ b/tests/test_text_normalize_regression.py
@@ -59,6 +59,12 @@ class NormalizeMoneyTest(unittest.TestCase):
         ("壹億伍仟萬元", 150_000_000, False),
         ("5천만정도", 50_000_000, True),
         ("5천만원 내외", 50_000_000, True),
+        # issue #2346: subunit-bearing bare-body Hangul amounts (오천원 = 오+천)
+        # and standalone Arabic amounts must still parse after the lone-Hangul-
+        # digit + 원 noun guard. The sectioned branch (만/억/조) is untouched.
+        ("오천원", 5_000, False),
+        ("오천오백원", 5_500, False),
+        ("5원", 5, False),
     ]
 
     def test_amounts_match_canonical_table(self) -> None:
@@ -147,6 +153,19 @@ class FalsePositiveGuardTest(unittest.TestCase):
         "삼정",
         "구정",  # 설날(舊正)
         "이정표",  # 이(2) + 정
+        # issue #2346: a single Hangul digit + 원 (사원/구원/일원화…) is an
+        # ordinary noun, not money. The bare-body branch accepted a lone 원
+        # after a single Hangul digit, so parse_amounts('사원') returned
+        # [ParsedAmount(value=4)] and normalize_text('사원')=='4' — the same
+        # false-grounding class as #2228 but on the 원 (not 정) suffix path.
+        "사원",  # 社員 — 사(4) + 원
+        "구원",  # 救援 — 구(9) + 원
+        "일원",
+        "이원",
+        "일원화",  # 일(1) + 원 + 화
+        "이원화",
+        "구원파",
+        "사원수",
     ]
 
     DATE_NEGATIVES = [
@@ -311,6 +330,21 @@ class EndToEndVerifyEvidenceTest(unittest.TestCase):
         item = _evidence_item("담당자는 1명이며 12월에 시작합니다.")  # no '일정', has '1'
         self.assertFalse(evidence_has_topic(item, ["일정"]))
         verified, reasons = verify_evidence(self._analysis(["일정"]), [item])
+        self.assertFalse(
+            verified, f"expected not grounded, got reasons={reasons}"
+        )
+
+    def test_won_noun_topic_does_not_false_match_bare_digit(self) -> None:
+        # issue #2346: a '사원'(employee) topic must NOT be grounded by
+        # evidence that merely contains a bare digit '4'. Before the fix
+        # normalize_text('사원')=='4' injected '4' into expand_forms('사원'),
+        # so any document with a '4' (4명/4월/제4조/4단계) false-matched and
+        # the #1008 single-doc grounding floor was bypassed — the same class
+        # as the #2228 '일정' bug but reached via the 원 suffix path.
+        self.assertEqual(["사원"], expand_forms("사원"))
+        item = _evidence_item("본 사업은 4단계로 4월에 추진한다.")  # has '4', no '사원'
+        self.assertFalse(evidence_has_topic(item, ["사원"]))
+        verified, reasons = verify_evidence(self._analysis(["사원"]), [item])
         self.assertFalse(
             verified, f"expected not grounded, got reasons={reasons}"
         )

--- a/text_normalize.py
+++ b/text_normalize.py
@@ -87,13 +87,27 @@ _HANGUL_MONEY_SUFFIX = r"(?:\s*원\s*정|\s*원|\s*정(?!도))"
 # containing a `1`). Require an explicit 원 unit here; the sectioned branch keeps
 # 정 so real amounts like `일금일억정`=100000000 are preserved.
 _HANGUL_MONEY_SUFFIX_BARE = r"(?:\s*원\s*정|\s*원)"
+# Bare-body money body (issue #2346): a lone Hangul digit + 원 is almost always a
+# noun (사원/구원/일원화...), not money. Real Hangul amounts always carry a subunit
+# (십백천) — 오천원, 삼천오백원 — or a section (만/억/조), and the sectioned branch
+# above already handles section-bearing amounts. So the bare Hangul path here
+# requires at least one subunit; the Arabic path ([\d,]+) stays standalone
+# (5원/5000원). Without this, `사원`->4 / `구원`->9 poison verifier topic grounding
+# the same false-grounding way #2228 (`일정`->1) did.
+_HANGUL_MONEY_BODY_BARE = (
+    r"(?:"
+    rf"[\d,]+\s*(?:{_HANGUL_SUBUNIT_PART}\s*{_HANGUL_DIGIT_PART}\s*)*{_HANGUL_SUBUNIT_PART}?"
+    r"|"
+    rf"[영공일이삼사오육칠팔구]\s*(?:{_HANGUL_SUBUNIT_PART}\s*{_HANGUL_DIGIT_PART}\s*)*{_HANGUL_SUBUNIT_PART}"
+    r")"
+)
 
 _HANGUL_MONEY_RE = re.compile(
     r"(?:일금\s*)?"
     r"(?:"
     rf"{_HANGUL_NUMBER_SECTIONED}{_HANGUL_MONEY_SUFFIX}?"  # sectioned (anchor = section)
     r"|"
-    rf"{_HANGUL_MYRIAD_BODY}{_HANGUL_MONEY_SUFFIX_BARE}"   # bare body (anchor = 원, #2228)
+    rf"{_HANGUL_MONEY_BODY_BARE}{_HANGUL_MONEY_SUFFIX_BARE}"   # bare body (anchor = 원, #2228/#2346)
     r")"
 )
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

bare-body 머니 정규식이 **단일 한글숫자 1글자(일~구) + lone 원**을 화폐로 받아 `normalize_text('사원')=='4'`, `'구원'=='9'`, `'일원화'=='1화'` 등으로 오정규화했습니다. `expand_forms('사원')==['사원','4']`로 숫자 form `4`가 주입되어 verifier topic grounding(`form in doc_text`)이 숫자 `4`를 포함한 모든 문서(4명/4월/제4조/4단계)에 false-match → #1008 single-doc grounding floor 무력화. #2228(`일정`→`1`, `정` suffix)과 **동형 false-grounding 클래스**이며 `원` suffix 경로라 #2228 수정 범위 밖이었습니다(pre-existing).

Closes #2346

## 2. 영향 파일

- `text_normalize.py` — **transitive load-bearing** (rag_query/rag_core/rag_verifier가 import). bare-body 머니 정규식만 변경.
- `tests/test_text_normalize_regression.py` — 회귀 가드 추가.

## 3. 리스크

가장 가능성 높은 깨짐: **정상 한글 화폐를 명사로 오인해 정규화 누락**. 배제 확인:
- 한글 경로는 subunit(십백천) >=1만 요구 — 정상 화폐는 항상 subunit/section 동반(오천원=오+천, 삼천오백원). 측정: 오천원→5000, 오천오백원→5500, 오만원→50000, 일금일억정→100000000, 5원→5 등 **10/10 보존**.
- sectioned 브랜치(만/억/조) 완전 불변.
- mutation test로 정확히 의도한 9 케이스만 영향 확인.

## 4. 테스트

Behavior change → 변경 전 fail / 변경 후 pass 테스트 추가:
- `FalsePositiveGuardTest.AMOUNT_NEGATIVES` +8 (사원/구원/일원/이원/일원화/이원화/구원파/사원수)
- `NormalizeMoneyTest.CASES` +3 보존 핀 (오천원/오천오백원/5원)
- `EndToEndVerifyEvidenceTest.test_won_noun_topic_does_not_false_match_bare_digit` — e2e verifier 오염 해소

검증: **20 passed, 59 subtests**. Mutation: bare-body를 원래 `_HANGUL_MYRIAD_BODY`로 revert 시 정확히 **9 FAIL**(8 명사 subtest + won_noun e2e), `일정`(#2228 별개 줄)은 영향 없이 통과 → 비공허 증명.

overlap-preflight: `reports/agent_loop/overlap_preflight.md` [OK] — 열린 PR 중 text_normalize.py 점유 0, 코덱스 issue-2311(currency)은 테스트 pin만(MERGED), 로직 미변경.

## 5. Eval 영향

**ADR 0001 naive_baseline byte-identical 불변** (다층 확인):
- **인덱싱 경로 normalize 미사용**: `build_index.py`/`ingestion.py`가 normalize_text/expand_forms 미호출(grep 0) → 인덱스 불변
- **정상 화폐 byte-identical 보존**: 10/10 (오천원→5000 … 일금일억정→100000000)
- **fixture 명사 부재**: smoke_rfp/raw에 단일한글숫자+원 명사 0건(grep)
- **make smoke 성공**: naive_baseline 전 stage SLO 통과
- 변경은 query/verify 시점만 영향하며 false-grounding을 **제거**(grounding 정확도 개선) — abstention/grounding이 더 정직해짐

real-eval delta: 미실행 (private surface ban 정책 준수; 동작 변화는 false-grounding 제거 방향으로 단조, baseline byte-identical).

## 6. 하위 호환

답변 계약(ADR 0003)/`schema_version` 불변. `normalize_text`/`expand_forms` 시그니처 불변. 단일한글숫자+원이 더 이상 숫자로 정규화되지 않는 것이 유일한 동작 변화이며, 이는 명사를 화폐로 오인하던 버그의 수정.

## 7. 범위 외

- `data/index/index.json`의 `text_span_hash` 필드 누락(committed index가 현재 빌더보다 stale) — 별개 concern, 미포함(make smoke 재빌드 시 표면화하나 정규화 무관).
- `text_normalize.py:58-59`의 미사용 `_APPROX_PREFIX`/`_APPROX_SUFFIX` dead code(#2228 이전부터 존재) — one-PR-one-concern, 별도 정리.
