### PR TITLE
test: pin axis5 missing mtime details

### DIFF
--- a/tests/test_self_review_axis_5_regression.py
+++ b/tests/test_self_review_axis_5_regression.py
@@ -93,6 +93,8 @@ class TestComputeAxis5MemoryHygiene(unittest.TestCase):
         self.assertEqual(result["total"], 2)
         self.assertEqual(result["fresh_in_quarter"], 1)
         self.assertEqual(result["fresh_rate"], 0.5)
+        self.assertEqual(result["stale_count"], 1)
+        self.assertEqual(result["oldest_mtime"], "2026-05-01")
 
 
 class TestCollectMemoryEmitsMtime(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

self-review axis #5 memory freshness 계산에서 `mtime`이 없는 memory file은 stale로 세되, `oldest_mtime`은 datable file에서만 계산한다는 detail contract를 테스트로 고정했습니다.

Closes #2358

## 2. 영향 파일

- `tests/test_self_review_axis_5_regression.py` — missing `mtime` fixture에서 `stale_count == 1` 및 `oldest_mtime == "2026-05-01"` assertion 추가 (non-load-bearing test file)

## 3. 리스크

- 가장 가능성 높은 리스크: future collector refactor가 missing `mtime`을 freshness denominator에는 포함하면서 stale count나 oldest mtime 산출을 다르게 처리하는 경우.
- 배제 근거: 기존 missing-mtime test에 stale-count와 oldest-mtime detail assertion을 추가했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_self_review_axis_5_regression.py` — 6 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest scan reported open PRs=14, worktrees=111, and `tests/test_self_review_axis_5_regression.py` in CLEAR_TESTS_UNDER_220; worktree `.codex/worktrees/issue-2358-axis5-missing-mtime` created from latest `origin/main`; pre-push drift check `git rev-list --left-right --count HEAD...origin/main` = `1 0`.

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only 변경이라 real eval 미실행.

## 6. 하위 호환

기존 API/CLI/schema 변경 없음. `scripts/claude-hooks/_self_review.py` 구현 변경 없이 existing memory freshness accounting contract만 테스트로 고정했습니다.

## 7. 범위 외

Self-review collector 구현, quarterly report schema, memory scan 대상 변경은 하지 않았습니다.
