### PR TITLE
test(rag_query): 쿼리 의도 분류 술어(comparison/implicit-reference) 커버리지

### DIFF
--- a/tests/test_rag_query_query_intent_predicates.py
+++ b/tests/test_rag_query_query_intent_predicates.py
@@ -1,0 +1,56 @@
+"""Unit coverage for rag_query 쿼리 의도 분류 술어 (issue #2357).
+
+``has_comparison_request`` / ``has_implicit_reference`` 는 query_type 라우팅과
+멀티턴 컨텍스트 해소의 분기 조건인 import-safe leaf(rag_core/torch/chromadb
+미로드, ADR 0045)인데 직접 단위 테스트가 0건이었다(test-only, 소스 무수정).
+
+핵심 변별:
+- ``has_comparison_request`` — ``normalize_entity`` 후 비교어
+  ("차이"/"비교"/"각각"/"대비") 중 하나라도 부분일치하면 True(any).
+- ``has_implicit_reference`` — ``normalize_entity`` 후 IMPLICIT_REFERENCE_PATTERNS
+  ("그 사업" 등 12종) 중 하나라도 부분일치하면 True(any). 패턴에 내부 공백이
+  있어 ``normalize_entity`` 의 다중공백 축약 적용 여부가 매칭을 가른다.
+"""
+from __future__ import annotations
+
+from rag_query import has_comparison_request, has_implicit_reference
+
+
+# ---- has_comparison_request ----
+
+def test_has_comparison_request_true_for_each_comparison_term() -> None:
+    # 4개 비교어가 각각 단독으로 True 를 트리거 — any() 이므로 한 입력에 한 term 만
+    # 등장한다. 특정 term 을 튜플에서 빼면 그 줄이 KILL(개별 커버리지).
+    assert has_comparison_request("A와 B의 차이는?") is True   # 차이
+    assert has_comparison_request("각각 알려줘") is True        # 각각
+    assert has_comparison_request("둘을 비교해줘") is True      # 비교
+    assert has_comparison_request("작년 대비 올해") is True     # 대비
+
+
+def test_has_comparison_request_false_without_comparison_term() -> None:
+    # 비교어가 전혀 없으면 False — 상수 True 반환이면 KILL.
+    assert has_comparison_request("예산은 얼마인가요?") is False
+    assert has_comparison_request("") is False
+
+
+# ---- has_implicit_reference ----
+
+def test_has_implicit_reference_true_for_demonstrative_patterns() -> None:
+    # 접두 계열("그 "/"해당 ") + 단독 토큰("그중") 대표 패턴이 각각 True.
+    assert has_implicit_reference("그 사업 예산은?") is True
+    assert has_implicit_reference("해당 기관 정보 줘") is True
+    assert has_implicit_reference("그중 첫번째") is True
+
+
+def test_has_implicit_reference_false_without_pattern() -> None:
+    # 명시적 엔티티만 있고 지시 참조가 없으면 False — 상수 True 면 KILL.
+    assert has_implicit_reference("서울시 사업 예산은?") is False
+    assert has_implicit_reference("이거 알려줘") is False
+    assert has_implicit_reference("") is False
+
+
+def test_has_implicit_reference_applies_normalize_entity_whitespace_collapse() -> None:
+    # "그  사업"(공백 2칸)은 raw 부분문자열로는 "그 사업"(1칸) 패턴과 불일치하지만,
+    # normalize_entity 가 내부 다중공백을 1칸으로 축약하므로 매칭되어 True.
+    # → normalize_entity 호출을 제거하고 raw query 로 매칭하는 mutation 을 KILL.
+    assert has_implicit_reference("그  사업 예산은?") is True


### PR DESCRIPTION
## 1. 변경 요약
`has_comparison_request` / `has_implicit_reference`(rag_query.py:106-113)에 대한 오라클 기반 단위 테스트 5건 추가. **test-only, 소스 무수정.**

## 2. 변경 이유
두 술어는 query_type 라우팅과 멀티턴 컨텍스트 해소의 분기 조건인 import-safe leaf(ADR 0045 — rag_core/torch/chromadb 미로드)인데 직접 단위 테스트가 0건이었다. 회귀 시 비교/지시참조 분기가 조용히 깨질 수 있어 음성단언으로 동작을 고정한다.

## 3. 변경 내용
- `has_comparison_request` — 4개 비교어(차이/비교/각각/대비) **개별** 커버리지(any 시맨틱) + 비교어 부재 시 False
- `has_implicit_reference` — 접두/단독 대표 패턴 True + 명시 엔티티만일 때 False
- `normalize_entity` 다중공백 축약 적용 pin: `"그  사업"`(공백 2칸)은 raw 부분문자열로는 `"그 사업"` 패턴과 불일치하나 정규화 축약으로 매칭 → normalize 호출 제거 mutation을 KILL

## 4. 테스트
- `tests/test_rag_query_query_intent_predicates.py` 5건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 17 mutation 중 16/16 behavioral mutant KILL, 1 survivor(`has_comparison_request`의 normalize 제거)는 brute-force(829,524 + 200,000 검사, 0 mismatch)로 semantic-equivalent 확정 → **APPROVE, 0 real gap**

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)