### PR TITLE
Test API injection screen diagnostics preservation

### DIFF
--- a/tests/test_api_security_screen.py
+++ b/tests/test_api_security_screen.py
@@ -9,6 +9,7 @@ the screen is diagnostic-only.
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -76,6 +77,26 @@ class ApiSecurityScreenTest(unittest.TestCase):
             sv = body["answer"].get("schema_version")
             if sv is not None:
                 self.assertEqual(sv, 2)
+
+
+    def test_screen_preserves_existing_diagnostics(self) -> None:
+        """Injection-screen diagnostics are additive to existing pipeline diagnostics."""
+
+        async def fake_arun_rag_query(*args, **kwargs):
+            return {
+                "answer": {"schema_version": 2, "text": "stub"},
+                "evidence": [],
+                "diagnostics": {"retrieval": {"strategy": "stub"}},
+            }
+
+        client = self._client()
+        with patch.object(api_main, "arun_rag_query", fake_arun_rag_query):
+            resp = client.post("/query", json={"query": "기관 A의 보안 통제 요구사항은?"})
+
+        self.assertEqual(resp.status_code, 200, resp.text)
+        diagnostics = resp.json()["diagnostics"]
+        self.assertEqual(diagnostics["retrieval"], {"strategy": "stub"})
+        self.assertEqual(diagnostics["injection_screen"]["status"], "passed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

API `POST /query`가 기존 `diagnostics` dict를 가진 pipeline 결과에 `diagnostics.injection_screen`을 붙일 때 기존 diagnostics 항목을 덮어쓰지 않는다는 회귀 테스트를 추가합니다. 동작은 이미 additive였고, 이번 PR은 그 계약을 테스트로 고정합니다.

Closes #2362

## 2. 영향 파일

- `tests/test_api_security_screen.py` — API injection-screen diagnostics 보존 회귀 테스트 추가

## 3. 리스크

- 리스크: mock한 async `arun_rag_query`가 실제 API await 경로와 어긋나면 테스트 신뢰도가 낮아질 수 있음.
- 배제: FastAPI `TestClient`로 실제 `/query` endpoint를 호출했고, response의 기존 `diagnostics.retrieval`과 신규 `diagnostics.injection_screen`을 함께 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_api_security_screen.py` → `4 passed`
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR 11개 + Codex/Claude 포함 worktree 106개 스캔, `tests/test_api_security_screen.py` 충돌 없음

## 5. Eval 영향

RAG/eval 동작 변화 없음. Test-only PR이며 load-bearing production 파일(`api/`)은 수정하지 않았습니다. real-eval 미실행: 테스트 보강만 수행했고 private eval surface에 영향을 주지 않습니다.

## 6. 하위 호환

하위 호환 영향 없음. API response schema/answer `schema_version` 변경 없음; additive diagnostics 계약을 테스트로만 고정합니다.

## 7. 범위 외

- API production code 변경
- private real100_v2 eval 실행
- injection-screen policy/blocking behavior 변경
