### PR TITLE
fix(normalize): 제N조 법조문(條)이 兆 금액으로 오정규화되어 grounding 오염

### DIFF
--- a/tests/test_text_normalize_regression.py
+++ b/tests/test_text_normalize_regression.py
@@ -65,6 +65,12 @@ class NormalizeMoneyTest(unittest.TestCase):
         ("오천원", 5_000, False),
         ("오천오백원", 5_500, False),
         ("5원", 5, False),
+        # issue #2360: real 兆(trillion) amounts must still parse — the 제N조
+        # legal-article guard only fires on a '제' prefix, not on these.
+        ("5조원", 5_000_000_000_000, False),
+        ("일조원", 1_000_000_000_000, False),
+        ("1조 5천억원", 1_500_000_000_000, False),
+        ("1조", 1_000_000_000_000, False),
     ]
 
     def test_amounts_match_canonical_table(self) -> None:
@@ -166,6 +172,16 @@ class FalsePositiveGuardTest(unittest.TestCase):
         "이원화",
         "구원파",
         "사원수",
+        # issue #2360: '제N조'(條, legal article) is an ordinal, not a 兆(trillion)
+        # amount. The sectioned branch matched 숫자+조 as money, so
+        # parse_amounts('제1조') returned [ParsedAmount(value=1_000_000_000_000)]
+        # and normalize_text('제1조')=='제1000000000000'. RFP/계약 법조문 빈출어.
+        "제1조",
+        "제2조",
+        "제10조",
+        "제3조의2",
+        "제5조",
+        "본 계약 제1조에 따라",  # sentence-level: 제1조 must survive intact
     ]
 
     DATE_NEGATIVES = [
@@ -348,6 +364,23 @@ class EndToEndVerifyEvidenceTest(unittest.TestCase):
         self.assertFalse(
             verified, f"expected not grounded, got reasons={reasons}"
         )
+
+    def test_jo_article_topic_does_not_false_match_trillion(self) -> None:
+        # issue #2360: '제1조'(條, legal article) must NOT normalize to 1兆, so a
+        # canonical 1000000000000 (1조원) money topic must NOT ground on a legal-
+        # article document. Before the fix normalize_text('제1조')=='제1000000000000'
+        # so the canonical money form substring-matched the article text — the
+        # same false-grounding class as #2228/#2346 via the 조(條/兆) homograph.
+        self.assertEqual("제1조", normalize_text("제1조"))
+        article = _evidence_item("본 계약 제1조에 따라 용역을 이행한다.")  # 제1조, no 兆
+        self.assertFalse(evidence_has_topic(article, ["1000000000000"]))
+        verified, reasons = verify_evidence(
+            self._analysis(["1000000000000"]), [article]
+        )
+        self.assertFalse(verified, f"expected not grounded, got reasons={reasons}")
+        # 대조: a real 1조원 amount document must still ground.
+        real = _evidence_item("총사업비는 1조원 규모이다.")
+        self.assertTrue(evidence_has_topic(real, ["1000000000000"]))
 
     def test_canonical_iso_date_matches_korean_date_evidence(self) -> None:
         # Query topic "2026-03-15" (canonical) must match evidence written

--- a/text_normalize.py
+++ b/text_normalize.py
@@ -293,6 +293,16 @@ def parse_amounts(s: str) -> list[ParsedAmount]:
         # Trim trailing whitespace from span to keep approximation-suffix
         # detection accurate.
         end = start + len(raw)
+        # Ordinal/legal-article guard (issue #2360): '제N조'(條, article) is not a
+        # 兆(trillion) amount. The sectioned branch matches '숫자+조' as money
+        # (_SECTION_MAP['조']=10^12), but when the span is immediately preceded by
+        # '제' and ends in a bare section marker (no 원/정 suffix), it is an ordinal
+        # like 제1조/제10조 — pin it out so '예산 1조원' topics stop false-grounding
+        # on legal-article documents (same false-grounding class as #2228/#2346).
+        # Real 兆 amounts (5조원, 일조원, 1조 5천억원) keep a 원/정 suffix or combine
+        # with 억, and carry no '제' prefix, so they are unaffected.
+        if start > 0 and s[start - 1] == "제" and raw and raw[-1] in _SECTION_MAP:
+            continue
         value = _parse_korean_number(raw)
         if value is None or value == 0:
             continue


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

sectioned 머니 정규식이 `숫자+조`를 兆 금액으로 매치(`_SECTION_MAP['조']=10^12`)하여 `조`(條 article)와 `조`(兆 trillion) 동음이의를 구분 못함. `normalize_text('제1조')=='제1000000000000'`, `"제1조에 따라"→"제1000000000000에 따라"`. canonical money form `1000000000000`(1조원 topic)이 `제1조` 든 모든 법조항 문서에 false-ground → `verify_evidence` 잘못된 supported 판정. #2228(일정→1)/#2346(사원→4)과 동형 false-grounding 클래스, sectioned `조`(條/兆) 동음이의 경로.

Closes #2360

## 2. 영향 파일

- `text_normalize.py` — **transitive load-bearing** (rag_query/rag_core/rag_verifier가 import). `parse_amounts` 후처리 가드만 추가.
- `tests/test_text_normalize_regression.py` — 회귀 가드.

## 3. 리스크

가장 가능성 높은 깨짐: **진짜 兆 금액을 법조문으로 오인해 정규화 누락**. 배제 확인:
- 가드는 `제` prefix + section 끝 + 화폐 suffix(원/정) 없음에만 발동. 진짜 兆(5조원/일조원/1조5천억원)은 `원`/`정` suffix 또는 억 조합 + `제` 없음 → 불변. 측정 **4/4 보존**.
- `제` 없는 `1조`/`5조` 단독도 불변(1조원 의도 유지).
- mutation으로 정확히 7 케이스만 영향 확인.

## 4. 테스트

Behavior change → 변경 전 fail / 변경 후 pass:
- `FalsePositiveGuardTest.AMOUNT_NEGATIVES` +6 (제1조/제2조/제10조/제3조의2/제5조/문장)
- `NormalizeMoneyTest.CASES` +4 兆 보존 (5조원/일조원/1조5천억원/1조)
- `EndToEndVerifyEvidenceTest.test_jo_article_topic_does_not_false_match_trillion`

검증: **21 passed, 69 subtests**. Mutation: 가드 `== "제"` 무력화 시 정확히 **7 FAIL**, 일정/사원(#2228/#2346)은 영향 없이 통과 → 비공허 증명.

overlap-preflight: `reports/agent_loop/overlap_preflight.md` [OK] — 열린 PR 중 text_normalize.py 점유 0.

## 5. Eval 영향

**ADR 0001 naive_baseline byte-identical 불변** (다층 확인):
- **인덱싱 normalize 미사용**: build_index/ingestion이 normalize_text/parse_amounts 미호출(grep 0) → 인덱스 불변
- **fixture 제N조 0건**: smoke_rfp/raw에 법조문 0 (grep) → smoke 답변 불변
- **兆 금액 byte-identical 보존**: 4/4 (5조원→5e12 … 1조5천억원→1.5e12)
- **make smoke 성공**: naive_baseline SLO 통과
- 변경은 query/verify 시점만 영향하며 false-grounding을 **제거**(grounding 정확도 개선)

real-eval delta: 미실행 (private surface ban 정책; 동작 변화는 false-grounding 제거 방향 단조, baseline byte-identical).

## 6. 하위 호환

답변 계약(ADR 0003)/`schema_version` 불변. `parse_amounts`/`normalize_text` 시그니처 불변. `제N조`가 더 이상 兆로 정규화되지 않는 것이 유일한 동작 변화이며 버그 수정.

## 7. 범위 외

- `1조` **raw substring**이 `제1조` 텍스트에 매치되는 짧은-토픽 false-positive (#2179 substring fallback 영역) — normalize와 무관, 별도 concern.
- `data/index/index.json` `text_span_hash` stale (#2346과 동일, 별개).
- `text_normalize.py:58-59` dead code (#2228 이전부터).
