### PR TITLE
test(rag_query): make_context_resolution 컨텍스트 해소 dict 빌더 커버리지

### DIFF
--- a/tests/test_rag_query_make_context_resolution.py
+++ b/tests/test_rag_query_make_context_resolution.py
@@ -1,0 +1,59 @@
+"""Unit coverage for rag_query.make_context_resolution (issue #2367).
+
+``make_context_resolution`` 은 멀티턴 대화 컨텍스트 해소 결과를 8-key 고정
+스키마 dict 로 빌드하는 import-safe leaf(rag_core/torch/chromadb 미로드,
+ADR 0045)인데 직접 단위 테스트가 0건이었다(test-only, 소스 무수정).
+
+핵심 변별:
+- ``confidence`` 는 ``round(float(_), 3)`` — 3자리 반올림.
+- ``context_entities``/``context_projects``/``active_doc_ids`` 는 None → [] (or []).
+- ``resolved_query`` 는 None 보존(빈 문자열로 강제하지 않음).
+- 8-key 고정 스키마 + 제공 값 passthrough.
+"""
+from __future__ import annotations
+
+from rag_query import make_context_resolution
+
+
+def test_rounds_confidence_to_three_decimals() -> None:
+    # confidence 는 round(float(_), 3). 0.123456 → 0.123:
+    # round 제거 시 0.123456 노출, 자릿수 변경(2→0.12 / 4→0.1235)도 모두 KILL.
+    assert make_context_resolution("resolved", "history", 0.123456)["confidence"] == 0.123
+
+
+def test_defaults_none_lists_to_empty_and_preserves_none_query() -> None:
+    out = make_context_resolution("ambiguous", "none", 0.0)
+    # None 리스트 인자 → [] ("or []" 폴백 제거 시 None 으로 KILL).
+    assert out["context_entities"] == []
+    assert out["context_projects"] == []
+    assert out["active_doc_ids"] == []
+    # resolved_query 는 None 보존 — 다른 키와 달리 "or" 폴백이 없으므로
+    # "" 등으로 강제하는 mutation 을 잡는다.
+    assert out["resolved_query"] is None
+    # reason 기본값은 "".
+    assert out["reason"] == ""
+
+
+def test_passes_through_all_provided_values() -> None:
+    # 8-key 고정 스키마 전체 — 키 누락/오타/값 뒤바뀜이면 dict 동등성에서 KILL.
+    out = make_context_resolution(
+        "resolved", "entity", 0.9, reason="matched",
+        resolved_query="서울시 예산",
+        context_entities=["기관 A"], context_projects=["P1"], active_doc_ids=["d1"],
+    )
+    assert out == {
+        "status": "resolved",
+        "source": "entity",
+        "confidence": 0.9,
+        "reason": "matched",
+        "resolved_query": "서울시 예산",
+        "context_entities": ["기관 A"],
+        "context_projects": ["P1"],
+        "active_doc_ids": ["d1"],
+    }
+
+
+def test_confidence_coerced_to_float_type() -> None:
+    # confidence 는 round(float(_), 3) — float() 제거 시 int 입력에 int 가 그대로
+    # 남는다. 값 동등성(1 == 1.0)으론 구분 불가하므로 타입을 고정해 float() 캐스트를 pin.
+    assert type(make_context_resolution("resolved", "history", 1)["confidence"]) is float


### PR DESCRIPTION
## 1. 변경 요약
`make_context_resolution`(rag_query.py:167)에 대한 오라클 기반 단위 테스트 4건 추가. **test-only, 소스 무수정.**

## 2. 변경 이유
멀티턴 대화 컨텍스트 해소 결과를 8-key 고정 스키마 dict 로 빌드하는 import-safe leaf(ADR 0045 — rag_core/torch/chromadb 미로드)인데 직접 단위 테스트가 0건이었다. `resolve_conversation_context`의 반환 계약을 형성하므로 회귀 시 조용히 깨질 수 있어 음성단언으로 고정한다.

## 3. 변경 내용
- `confidence` = `round(float(_), 3)` 3자리 반올림(자릿수 변경 시 KILL) + **float() 캐스트 type pin**(int 입력 → `1.0` float, 값 동등성 `1==1.0`으론 못 잡아 타입 고정)
- `context_*`/`active_doc_ids` `None` → `[]` (`or []` 폴백)
- `resolved_query` `None` 보존(다른 키와 달리 폴백 없음 — `""` 강제 시 KILL)
- 8-key 고정 스키마 + 전체 passthrough(키 swap/누락 KILL)

## 4. 테스트
- `tests/test_rag_query_make_context_resolution.py` 4건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 16/16 behavioral mutant KILL(키 swap/default/None 보존/반올림 정밀도 모두 잡힘). M3(`float()` 제거)는 semantic-equivalent로 판정됐으나 LOW note(coercion contract 미pin)를 받아 **type-pin 단언을 선제 추가** → APPROVE

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2367

🤖 Generated with [Claude Code](https://claude.com/claude-code)