### PR TITLE
Test ToC middle-dot threshold boundary

### DIFF
--- a/tests/test_ingestion_toc_noise_regression.py
+++ b/tests/test_ingestion_toc_noise_regression.py
@@ -39,6 +39,13 @@ class StripLeaderDotsTest(unittest.TestCase):
         md = "1·2·3·4·5"
         self.assertEqual(_strip_kordoc_toc_noise(md), md)
 
+    def test_middle_dot_threshold_boundary(self):
+        below = "사업개요" + ("·" * 7) + "범위"
+        at_threshold = "사업개요" + ("·" * 8) + "범위"
+
+        self.assertEqual(_strip_kordoc_toc_noise(below), below)
+        self.assertEqual(_strip_kordoc_toc_noise(at_threshold), "사업개요 범위")
+
     def test_collapses_ascii_period_run_above_threshold(self):
         # 15+ ASCII periods: ToC leader; collapsed.
         md = "사업개요" + ("." * 30) + "1"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`_strip_kordoc_toc_noise`의 middle-dot ToC leader threshold가 문서화된 대로 “7개는 보존, 8개부터 collapse”임을 정확한 경계값 테스트로 고정합니다. 동작 변경은 없고, conservative stripping 기준이 실수로 완화/강화되는 회귀를 막기 위한 테스트-only PR입니다.

Closes #2372

## 2. 영향 파일

- `tests/test_ingestion_toc_noise_regression.py` — middle-dot threshold boundary regression 추가

## 3. 리스크

- 리스크: threshold boundary 테스트가 실제 production regex와 다르게 fixture만 고정할 수 있음.
- 배제: 테스트가 실제 `_strip_kordoc_toc_noise`를 직접 호출하고, 7개/8개 middle-dot 입력을 함께 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_ingestion_toc_noise_regression.py` → `14 passed, 7 subtests passed`
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR 10개 + Codex/Claude 포함 worktree 104개 스캔, `tests/test_ingestion_toc_noise_regression.py` 충돌 없음

## 5. Eval 영향

RAG/eval 동작 변화 없음. Test-only PR이며 load-bearing production 파일(`ingestion.py`)은 수정하지 않았습니다. real-eval 미실행: threshold behavior를 바꾸지 않고 기존 동작을 테스트로만 고정했습니다.

## 6. 하위 호환

하위 호환 영향 없음. API/CLI/answer schema 변경 없음.

## 7. 범위 외

- `_strip_kordoc_toc_noise` production regex 변경
- private real100_v2 eval 실행
- ASCII period threshold 추가 변경
