### PR TITLE
test(rag_query): make_plan 입력 검증 + top_k budget 출처 커버리지

### DIFF
--- a/tests/test_rag_query_make_plan_validation.py
+++ b/tests/test_rag_query_make_plan_validation.py
@@ -1,0 +1,74 @@
+"""Unit coverage for rag_query.make_plan 입력 검증 + top_k budget 출처 (issue #2368).
+
+``make_plan`` 은 analysis dict 를 검색 계획 dict 로 투영하는 import-safe leaf
+(rag_core/torch/chromadb 미로드, ADR 0045)인데 직접 단위 테스트가 0건이었다.
+본 파일은 **입력 검증 가드 + top_k budget 출처** 한 concern 으로 한정한다
+(scoring/stage/filters 빌드 로직은 후속). test-only, 소스 무수정.
+
+핵심 변별:
+- retrieval_mode/backend, rrf_k 범위, bm25 3종 파라미터가 허용 집합 밖이면 ValueError.
+  ``match=`` 로 *올바른 필드*의 메시지인지까지 고정(다른 필드 메시지로
+  cross-wiring 되는 mutation 차단).
+- rrf_k 경계(1, 1000)는 통과(off-by-one mutation 차단).
+- retrieval_budget.reason 이 top_k/top_k_reason 출처를 반영.
+"""
+from __future__ import annotations
+
+import pytest
+
+from rag_query import make_plan
+
+_ANALYSIS = {"query_type": "single_doc"}
+
+
+def test_valid_minimal_plan_uses_query_type_defaults() -> None:
+    # 유효 기본 입력 → query_type 기본 top_k(=4), budget reason=default, strict stage.
+    plan = make_plan(_ANALYSIS)
+    assert plan["top_k"] == 4
+    assert plan["retrieval_budget"]["reason"] == "single_doc_default"
+    assert plan["filter_stage"] == "strict"
+
+
+def test_rejects_invalid_retrieval_mode() -> None:
+    # VALID_RETRIEVAL_MODES 밖 → ValueError(가드 제거/메시지 cross-wiring 시 KILL).
+    with pytest.raises(ValueError, match="retrieval_mode"):
+        make_plan(_ANALYSIS, retrieval_mode="BOGUS")
+
+
+def test_rejects_invalid_retrieval_backend() -> None:
+    with pytest.raises(ValueError, match="retrieval_backend"):
+        make_plan(_ANALYSIS, retrieval_backend="BOGUS")
+
+
+def test_rrf_k_range_boundaries() -> None:
+    # 경계 1, 1000 은 통과 — 비교 < / > 가 <= / >= 로 바뀌면(off-by-one) KILL.
+    assert make_plan(_ANALYSIS, rrf_k=1)["rrf_k"] == 1
+    assert make_plan(_ANALYSIS, rrf_k=1000)["rrf_k"] == 1000
+    # 범위 밖(0, 1001) → ValueError(범위 가드 제거 시 KILL).
+    with pytest.raises(ValueError, match="rrf_k"):
+        make_plan(_ANALYSIS, rrf_k=0)
+    with pytest.raises(ValueError, match="rrf_k"):
+        make_plan(_ANALYSIS, rrf_k=1001)
+
+
+def test_rejects_invalid_bm25_params() -> None:
+    # 3개 bm25 파라미터 각각이 독립적으로 검증된다 — 한 가드라도 빠지면 그 줄이 KILL.
+    # match= 로 각 가드가 자기 필드 메시지를 내는지까지 pin.
+    with pytest.raises(ValueError, match="bm25_stopword_profile"):
+        make_plan(_ANALYSIS, bm25_stopword_profile="BOGUS")
+    with pytest.raises(ValueError, match="bm25_tokenizer"):
+        make_plan(_ANALYSIS, bm25_tokenizer="BOGUS")
+    with pytest.raises(ValueError, match="bm25_backend"):
+        make_plan(_ANALYSIS, bm25_backend="BOGUS")
+
+
+def test_budget_reason_reflects_top_k_source() -> None:
+    # 명시 top_k → explicit_override.
+    assert make_plan(_ANALYSIS, top_k=9)["retrieval_budget"]["reason"] == "explicit_override"
+    # top_k_reason 명시 → 그대로 우선(top_k 없어도 default 로 떨어지지 않는다).
+    assert (
+        make_plan(_ANALYSIS, top_k_reason="custom_reason")["retrieval_budget"]["reason"]
+        == "custom_reason"
+    )
+    # 둘 다 없음 → "{query_type}_default".
+    assert make_plan(_ANALYSIS)["retrieval_budget"]["reason"] == "single_doc_default"


### PR DESCRIPTION
## 1. 변경 요약
`make_plan`(rag_query.py:479)의 **입력 검증 가드 + top_k budget 출처** 단위 테스트 6건 추가. **test-only, 소스 무수정.** (scoring/stage/filters 빌드는 후속 PR #2371 등으로 분할)

## 2. 변경 이유
analysis dict 를 검색 계획 dict 로 투영하는 import-safe leaf(ADR 0045 — rag_core/torch/chromadb 미로드)인데 직접 단위 테스트가 0건이었다. 잘못된 retrieval/bm25 파라미터를 조용히 통과시키는 회귀를 음성단언으로 차단한다.

## 3. 변경 내용
- `retrieval_mode`/`retrieval_backend`, `bm25_stopword_profile`/`bm25_tokenizer`/`bm25_backend` 허용 집합 밖 → `ValueError` (각 `match=` 필드명으로 cross-wiring 메시지 mutation 차단)
- `rrf_k` 범위 [1,1000] — 경계 1/1000 통과 + 0/1001 `ValueError`(off-by-one 가드 차단)
- `retrieval_budget.reason`: `top_k`→`explicit_override` / `top_k_reason` 우선 / `{query_type}_default`

## 4. 테스트
- `tests/test_rag_query_make_plan_validation.py` 6건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 6/6 테스트 모두 KILL(rrf_k off-by-one 4종, bm25 assertion-granularity 3 guard, budget 3분기). int(rrf_k) cast survivor는 unreachable semantic-equivalent로 판정. non-blocking observation(`match=` 부재)을 받아 **6 raises 전체에 `match=` 필드명 단언을 선제 추가** → APPROVE

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)