### PR TITLE
fix(text_normalize): bare 한글숫자+section 명사 금액 오정규화 가드 (#2369)

### DIFF
--- a/tests/test_text_normalize_regression.py
+++ b/tests/test_text_normalize_regression.py
@@ -71,6 +71,15 @@ class NormalizeMoneyTest(unittest.TestCase):
         ("일조원", 1_000_000_000_000, False),
         ("1조 5천억원", 1_500_000_000_000, False),
         ("1조", 1_000_000_000_000, False),
+        # issue #2369: section-bearing amounts with a 원/정 suffix (구조원/오만원/
+        # 일억원), Arabic digits (3조), or compound sections must still parse after
+        # the bare 2-char Hangul-digit+section noun guard. 구조원(9조원) differs from
+        # the noun 구조(構造) by exactly the 원 suffix — that suffix is the
+        # disambiguator, so the money path must stay intact.
+        ("구조원", 9_000_000_000_000, False),
+        ("오만원", 50_000, False),
+        ("일억원", 100_000_000, False),
+        ("3조", 3_000_000_000_000, False),
     ]
 
     def test_amounts_match_canonical_table(self) -> None:
@@ -182,6 +191,24 @@ class FalsePositiveGuardTest(unittest.TestCase):
         "제3조의2",
         "제5조",
         "본 계약 제1조에 따라",  # sentence-level: 제1조 must survive intact
+        # issue #2369: a bare 2-char span of one Hangul digit + a section marker
+        # (만/억/조) with no 원/정 suffix is a common noun, not money. The sectioned
+        # branch matched 한글숫자+section even without a suffix, so
+        # parse_amounts('구조') returned [ParsedAmount(value=9_000_000_000_000)] and
+        # normalize_text('구조')=='9000000000000' — the largest remnant of the
+        # #2228/#2346 false-grounding class (구조/공조/오만 are RFP 최빈출어).
+        "구조",  # 構造 — 구(9) + 조
+        "공조",  # 共助/空調 — 공(0) + 조 (section default 1 → 1兆)
+        "오만",  # 傲慢 — 오(5) + 만
+        "일억",  # bare 일(1)+억 (only 일억원 is money)
+        "일조",  # 一組/一條 — bare (only 일조원 is money)
+        "이조",  # 吏曹 — 이(2) + 조
+        "구만",  # 구(9) + 만
+        "삼조",
+        "육조",  # 六曹
+        "팔조",
+        "본 시스템의 전체 구조를 설명한다",  # sentence-level: 구조 must survive
+        "부서 간 공조 체계",
     ]
 
     DATE_NEGATIVES = [
@@ -381,6 +408,25 @@ class EndToEndVerifyEvidenceTest(unittest.TestCase):
         # 대조: a real 1조원 amount document must still ground.
         real = _evidence_item("총사업비는 1조원 규모이다.")
         self.assertTrue(evidence_has_topic(real, ["1000000000000"]))
+
+    def test_bare_section_noun_topic_does_not_false_match_amount(self) -> None:
+        # issue #2369: a bare Hangul-digit+section noun (구조/공조/오만) must NOT
+        # normalize to a 兆/억/만 amount and false-ground a numeric money topic.
+        # Before the fix normalize_text('구조')=='9000000000000', so a 9조원 topic
+        # grounded on any document mentioning '구조'(構造) — the largest remnant of
+        # the #2228/#2346/#2360 false-grounding class (구조/공조/오만 are RFP 최빈출어).
+        self.assertEqual("구조", normalize_text("구조"))
+        self.assertEqual("공조", normalize_text("공조"))
+        self.assertEqual(["구조"], expand_forms("구조"))
+        doc = _evidence_item("본 시스템의 전체 구조를 설명한다.")  # 구조, no 9조 amount
+        self.assertFalse(evidence_has_topic(doc, ["9000000000000"]))
+        verified, reasons = verify_evidence(
+            self._analysis(["9000000000000"]), [doc]
+        )
+        self.assertFalse(verified, f"expected not grounded, got reasons={reasons}")
+        # 대조: a real 9조원 amount document must still ground (원 suffix disambiguates).
+        real = _evidence_item("총사업비는 9조원 규모이다.")
+        self.assertTrue(evidence_has_topic(real, ["9000000000000"]))
 
     def test_canonical_iso_date_matches_korean_date_evidence(self) -> None:
         # Query topic "2026-03-15" (canonical) must match evidence written

--- a/text_normalize.py
+++ b/text_normalize.py
@@ -303,6 +303,18 @@ def parse_amounts(s: str) -> list[ParsedAmount]:
         # with 억, and carry no '제' prefix, so they are unaffected.
         if start > 0 and s[start - 1] == "제" and raw and raw[-1] in _SECTION_MAP:
             continue
+        # Bare common-noun guard (issue #2369): a single Hangul digit char + a
+        # bare section marker (구조/공조/오만/일억...) is almost always a noun, not
+        # money. The sectioned branch matches '한글숫자+만/억/조' even without a 원/정
+        # suffix (_SECTION_MAP), so 구조(構造)→9兆 / 공조→1兆 / 오만→5만 leak numeric
+        # forms into expand_forms and false-ground verifier topics — the same
+        # false-grounding class as #2228/#2346/#2360. Real amounts carry a 원/정
+        # suffix (일조원/오만원/일억원), use Arabic digits (3조/5조원), or combine
+        # multiple sections (일조 5천억원); none of those is a bare 2-char
+        # Hangul-digit+section span, so they are unaffected. Arabic bare spans
+        # (3조) stay money — an author who writes digits means the amount.
+        if len(raw) == 2 and raw[0] in _HANGUL_DIGIT_MAP and raw[1] in _SECTION_MAP:
+            continue
         value = _parse_korean_number(raw)
         if value is None or value == 0:
             continue


### PR DESCRIPTION
## 요약
한글 단음절숫자 + section anchor(만/억/조) 2글자 bare 명사(구조/공조/오만/일억 등)가 금액으로 오정규화되는 false-grounding 버그 수정. #2228/#2346/#2360 과 동일 클래스의 **가장 큰 잔여**.

## 배경 (측정)
`normalize_text('구조')=='9000000000000'` → `expand_forms('구조')==['구조','9000000000000']` → verifier topic grounding 이 `'9000000000000' in doc_text` 로 false-match. '9조원' 토픽이 `구조`(構造) 든 모든 문서에 false-ground → #1008 single-doc grounding floor 무력화.

`origin/main` 측정 잔여: `구조→9兆`, `공조→1兆`, `오만→5만`, `일억/일조/이조/구만` 등. RFP 최빈출어(구조/공조/오만) 영향.

## 변경 사항
`parse_amounts` 가드 (정규식·ADR 0001 baseline 무변경): #2360 `제N조` 가드 직후, `raw` 가 `[한글digit][만|억|조]` 정확히 2글자이고 원/정 suffix·아라비아·복합 section 이 없으면 명사로 보고 skip.

진짜 금액 보존 (suffix/아라비아/복합이 disambiguator):
- `일조원→1兆`, `오만원→5만`, `일억원→1억`, `5조원→5兆`, `일조 5천억원→1.5兆`, `3조→3兆`
- `구조원`(9조원) 보존 ↔ `구조`(構造) 유지 — 원 suffix 1글자가 구분자

## 관련 이슈
Closes #2369

## 테스트
- 단위: 22 passed / 85 subtests (CASES +4 진짜금액, AMOUNT_NEGATIVES +12 명사, e2e `test_bare_section`)
- mutation: 가드 제거 시 13 fail (비공허 증명)
- 회귀: 정규화·verifier grounding 153 passed / 121 subtests (#1008 floor 포함)
- `make smoke` 통과 (latency SLO green)

## §5 Eval 영향
load-bearing `text_normalize.py` 변경이나 **fixture smoke 답변 의미 무변경** (answer.json status/citation/topic 무변경, `answer_generation_ms` 비결정값만 차이). 근거: (1) baseline 경로(ingestion/build_index/embedding) normalize 호출 0, (2) fixture raw 영향 단어 0, (3) 진짜 money byte-identical 보존(측정), (4) `make smoke` 통과. **ADR 0001 naive_baseline 무영향.** 측정 표면 = public fixture smoke + 합성 단위테스트 (ADR 0005 경계 내, 사적 데이터 미포함).

## 기타
- ADR 불요 (load-bearing 결정 제거/교체 아님 — 기존 #2360 가드 패턴 확장)
- One PR, one concern: bare-section 명사 false-grounding 단일 concern