### PR TITLE
Test CI band mean-only fallback

### DIFF
--- a/tests/test_bootstrap_ci.py
+++ b/tests/test_bootstrap_ci.py
@@ -91,6 +91,10 @@ class BootstrapCITest(unittest.TestCase):
         self.assertEqual(format_ci_band(None), "N/A")
         self.assertEqual(format_ci_band({"mean": None}), "N/A")
 
+    def test_format_ci_band_renders_mean_only_when_bounds_missing(self) -> None:
+        self.assertEqual(format_ci_band({"mean": 0.906, "ci_lo": 0.781}), "0.906")
+        self.assertEqual(format_ci_band({"mean": 0.906, "ci_hi": 1.0}, digits=2), "0.91")
+
 
 class PairedBootstrapCITest(unittest.TestCase):
     def test_paired_bootstrap_ci_deterministic_seed(self) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`format_ci_band`가 `mean`은 있지만 `ci_lo` 또는 `ci_hi` 중 하나가 없는 CI dict를 받을 때 band를 지어내지 않고 point estimate만 렌더링한다는 기존 fallback 계약을 테스트로 고정합니다. 동작 변경 없는 test-only PR입니다.

Closes #2378

## 2. 영향 파일

- `tests/test_bootstrap_ci.py` — missing-bound mean-only formatting regression 추가

## 3. 리스크

- 리스크: formatter fallback이 downstream table rendering에서 실수로 CI band처럼 보이도록 바뀔 수 있음.
- 배제: `format_ci_band`를 직접 호출해 `ci_lo`만 있는 경우와 `ci_hi`만 있는 경우 모두 mean-only 문자열을 반환하는지 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_bootstrap_ci.py` → `15 passed`
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR 12개 + Codex/Claude 포함 worktree 102개 스캔, `tests/test_bootstrap_ci.py` 충돌 없음

## 5. Eval 영향

Eval 동작 변화 없음. Test-only PR이며 load-bearing production 파일(`eval/`)은 수정하지 않았습니다. real-eval 미실행: formatter 동작을 바꾸지 않고 기존 fallback을 테스트로만 고정했습니다.

## 6. 하위 호환

하위 호환 영향 없음. API/CLI/answer schema 변경 없음.

## 7. 범위 외

- `eval/bootstrap.py` production formatter 변경
- README metric rendering 변경
- private real100_v2 eval 실행
