### PR TITLE
test(rag_query): make_plan strategy 문자열 빌드 커버리지

### DIFF
--- a/tests/test_rag_query_make_plan_strategy.py
+++ b/tests/test_rag_query_make_plan_strategy.py
@@ -1,0 +1,56 @@
+"""Unit coverage for rag_query.make_plan strategy 문자열 빌드 (issue #2371).
+
+``make_plan``(rag_query.py:479)의 ``strategy`` 문자열은 rerank·metadata_first·
+retrieval_backend 조합으로 결정되는데 직접 단위 테스트가 0건이었다. import-safe
+leaf(rag_core/torch/chromadb 미로드, ADR 0045). #2368(validation+budget) 후속으로
+strategy 문자열 한 concern 한정. test-only, 소스 무수정.
+
+핵심 변별:
+- rerank+metadata_first → "dense + lexical + metadata rerank"
+- metadata_first=False → "metadata-first " prefix 제거 + metadata rerank 절 제거
+- backend hybrid/m3 → 각각 RRF 래핑/대체 문자열.
+"""
+from __future__ import annotations
+
+from rag_query import make_plan
+
+_A = {"query_type": "single_doc"}
+
+
+def test_default_strategy_metadata_first_full_rerank() -> None:
+    # 기본: rerank=T, metadata_first=T, dense → 전체 rerank 절 + metadata-first prefix.
+    assert make_plan(_A)["strategy"] == "metadata-first dense + lexical + metadata rerank"
+
+
+def test_strategy_without_rerank_is_plain_dense() -> None:
+    # rerank=False → lexical/metadata rerank 절이 사라진다("dense" 만 남음).
+    assert make_plan(_A, rerank=False)["strategy"] == "metadata-first dense"
+
+
+def test_strategy_without_metadata_first_drops_prefix_and_metadata_rerank() -> None:
+    # metadata_first=False → "metadata-first " prefix 제거 + metadata rerank 절 제거.
+    assert make_plan(_A, metadata_first=False)["strategy"] == "dense + lexical rerank"
+
+
+def test_strategy_hybrid_backend_wraps_in_rrf() -> None:
+    # retrieval_backend="hybrid" → 기존 scoring 을 "hybrid (bm25 + {scoring}) rrf" 로 래핑.
+    assert (
+        make_plan(_A, retrieval_backend="hybrid")["strategy"]
+        == "metadata-first hybrid (bm25 + dense + lexical + metadata rerank) rrf"
+    )
+
+
+def test_strategy_m3_backend_replaces_scoring() -> None:
+    # retrieval_backend="m3" → m3 멀티채널 RRF 문자열로 대체(기존 scoring 무시).
+    assert (
+        make_plan(_A, retrieval_backend="m3")["strategy"]
+        == "metadata-first m3 (dense + sparse + colbert) rrf"
+    )
+
+
+def test_strategy_no_rerank_no_metadata_first_is_bare_dense() -> None:
+    # rerank=False + metadata_first=False → scoring 초기값 "dense" 그대로
+    # (rerank 절 없음 + "metadata-first " prefix 없음). rerank×metadata_first 2×2
+    # 진리표의 (F,F) 모서리를 닫아 초기값을 prefix 와 함께 gating 하는 compound
+    # mutant 를 차단한다.
+    assert make_plan(_A, rerank=False, metadata_first=False)["strategy"] == "dense"


### PR DESCRIPTION
## 1. 변경 요약
`make_plan`(rag_query.py:479)의 `strategy` 문자열 빌드 단위 테스트 6건 추가. **test-only, 소스 무수정.** (#2368 validation·#2377 stage/filter 와 함께 make_plan 분할 커버)

## 2. 변경 이유
strategy 문자열은 rerank·metadata_first·retrieval_backend 조합으로 결정되는 import-safe leaf(ADR 0045) 로직인데 직접 단위 테스트가 0건이었다. 조합 회귀를 음성단언으로 차단한다.

## 3. 변경 내용
- 기본(rerank+metadata_first) → `metadata-first dense + lexical + metadata rerank`
- `rerank=False` → `metadata-first dense`
- `metadata_first=False` → prefix/metadata-rerank 절 제거(`dense + lexical rerank`)
- `hybrid` → `hybrid (bm25 + {scoring}) rrf` 래핑 / `m3` → `m3 (dense + sparse + colbert) rrf` 대체
- **rerank×metadata_first 2×2 진리표의 (F,F) 모서리** → `dense`(compound mutant 차단)

## 4. 테스트
- `tests/test_rag_query_make_plan_strategy.py` 6건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 19개 single-point mutant 전부 KILL(scoring 리터럴 4종·분기 조건·prefix 결정·prefix 템플릿 텍스트 모두 pin). LOW recall gap((F,F) 조합에서 compound 2-edit mutant `MZ` 생존)을 받아 **`(F,F)==dense` 단언을 선제 추가** → 진리표 완성

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2371

🤖 Generated with [Claude Code](https://claude.com/claude-code)