### PR TITLE
Test case proposer missing-doc skip counter

### DIFF
--- a/tests/test_case_proposer_stub.py
+++ b/tests/test_case_proposer_stub.py
@@ -50,6 +50,23 @@ class CaseProposerStubTest(unittest.TestCase):
             self.assertEqual(result, calls[0])
         self.assertEqual(len(calls[0]), 4)  # 2 rows * 2 templates
 
+    def test_stub_skips_missing_doc_id_without_consuming_ids(self) -> None:
+        rows = [
+            {"발주 기관": "누락기관", "사업명": "누락사업"},
+            {"doc_id": "doc-001", "발주 기관": "A기관", "사업명": "사업A"},
+        ]
+
+        out = propose_cases(rows, backend="stub", now_iso="2026-05-13T00:00:00Z")
+
+        self.assertEqual(
+            [case["id"] for case in out],
+            ["proposed_20260513_001", "proposed_20260513_002"],
+        )
+        self.assertEqual(
+            [case["proposer_meta"]["seed_doc_id"] for case in out],
+            ["doc-001", "doc-001"],
+        )
+
     def test_resolve_backend_default_is_stub(self) -> None:
         name, fn = resolve_backend()
         self.assertEqual(name, "stub")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

case proposer stub이 `doc_id` 없는 seed row를 skip할 때 proposed-case ID counter를 소비하지 않고, 뒤따르는 정상 row가 `proposed_..._001`, `..._002`부터 연속적으로 생성된다는 기존 deterministic 계약을 테스트로 고정합니다. 동작 변경 없는 test-only PR입니다.

Closes #2381

## 2. 영향 파일

- `tests/test_case_proposer_stub.py` — missing `doc_id` skip/counter regression 추가

## 3. 리스크

- 리스크: malformed seed row가 있을 때 proposed ID에 gap이 생기면 reviewer 로컬 산출물의 byte-stability가 흔들릴 수 있음.
- 배제: 실제 `propose_cases(..., backend="stub")` 호출로 missing-doc row 뒤 valid row의 ID/seed_doc_id를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_case_proposer_stub.py` → `11 passed`
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR 11개 + Codex/Claude 포함 worktree 102개 스캔, `tests/test_case_proposer_stub.py` 충돌 없음

## 5. Eval 영향

Eval 동작 변화 없음. Test-only PR이며 load-bearing production 파일(`eval/`)은 수정하지 않았습니다. real-eval 미실행: proposer 동작을 바꾸지 않고 기존 deterministic stub behavior를 테스트로만 고정했습니다.

## 6. 하위 호환

하위 호환 영향 없음. API/CLI/answer schema 변경 없음.

## 7. 범위 외

- `eval/case_proposer.py` production 변경
- csv_metadata/openai_compatible proposer backend 변경
- private real100_v2 eval 실행
