### PR TITLE
test(rag_query): make_plan stage 선택 + metadata_filters 결정 커버리지

### DIFF
--- a/tests/test_rag_query_make_plan_stage_filters.py
+++ b/tests/test_rag_query_make_plan_stage_filters.py
@@ -1,0 +1,76 @@
+"""Unit coverage for rag_query.make_plan stage 선택 + metadata_filters 결정 (issue #2377).
+
+``make_plan``(rag_query.py:479)의 ``filter_stage``/``relaxed``/``metadata_filters``
+결정 로직이 직접 단위 테스트가 0건이었다. import-safe leaf(rag_core/torch/chromadb
+미로드, ADR 0045). #2368(validation)·#2371(strategy) 후속, stage/filter 선택 한
+concern 한정. test-only, 소스 무수정.
+
+핵심 변별:
+- 기본 strict / relaxed=True · metadata_first=False → relaxed.
+- relaxed stage → metadata_filters 비움.
+- by_stage 제공 시 우선, 부재 시 entities → agencies fallback.
+"""
+from __future__ import annotations
+
+from rag_query import make_plan
+
+_A = {"query_type": "single_doc"}
+
+
+def test_default_stage_is_strict_not_relaxed() -> None:
+    plan = make_plan(_A)
+    assert plan["filter_stage"] == "strict"
+    assert plan["relaxed"] is False
+
+
+def test_relaxed_flag_forces_relaxed_stage_and_clears_filters() -> None:
+    plan = make_plan(_A, relaxed=True)
+    assert plan["filter_stage"] == "relaxed"
+    assert plan["relaxed"] is True
+    # relaxed stage 는 metadata_filters 를 비운다(strict 분기와 구분).
+    assert plan["metadata_filters"] == {}
+
+
+def test_metadata_first_false_also_forces_relaxed() -> None:
+    # metadata_first=False 도 relaxed stage 로 강제(relaxed flag 와 독립 경로).
+    plan = make_plan(_A, metadata_first=False)
+    assert plan["filter_stage"] == "relaxed"
+    assert plan["relaxed"] is True
+
+
+def test_filters_fall_back_to_entities_as_agencies() -> None:
+    # by_stage 없고 명시 필터 없으면 entities 를 agencies 필터로 폴백.
+    plan = make_plan({"query_type": "single_doc", "entities": ["기관 A", "기관 B"]})
+    assert plan["metadata_filters"] == {"agencies": ["기관 A", "기관 B"]}
+
+
+def test_stage_specific_filters_take_precedence_over_entities() -> None:
+    # metadata_filters_by_stage[stage] 가 있으면 그것을 쓴다 — entities fallback 으로
+    # 떨어지지 않는다(precedence 역전 mutation 을 KILL).
+    plan = make_plan({
+        "query_type": "single_doc",
+        "entities": ["기관 IGNORED"],
+        "metadata_filters_by_stage": {"strict": {"agencies": ["X"]}},
+    })
+    assert plan["metadata_filters"] == {"agencies": ["X"]}
+
+
+def test_reduced_stage_reads_its_own_by_stage_filters() -> None:
+    # stage="reduced"(strict/relaxed 아닌 non-relaxed 경로) → by_stage 의 그 stage 키를
+    # 정확히 조회. get(stage) 를 "strict" 로 하드코딩하거나 reduced 분기를 무력화하면 KILL.
+    plan = make_plan(
+        {
+            "query_type": "single_doc",
+            "metadata_filters_by_stage": {"reduced": {"agencies": ["R"]}, "strict": {"agencies": ["S"]}},
+        },
+        stage="reduced",
+    )
+    assert plan["filter_stage"] == "reduced"
+    assert plan["metadata_filters"] == {"agencies": ["R"]}
+
+
+def test_reduced_stage_entities_fallback_not_strict_only() -> None:
+    # by_stage 부재 시 entities fallback 은 strict 뿐 아니라 reduced stage 에서도 동작한다.
+    # fallback 을 stage=="strict" 로 한정하는 mutation 을 KILL.
+    plan = make_plan({"query_type": "single_doc", "entities": ["기관 A"]}, stage="reduced")
+    assert plan["metadata_filters"] == {"agencies": ["기관 A"]}


### PR DESCRIPTION
## 1. 변경 요약
`make_plan`(rag_query.py:479)의 stage 선택 + metadata_filters 결정 단위 테스트 7건 추가. **test-only, 소스 무수정.** (#2368 validation·#2371 strategy 와 함께 make_plan 분할 커버)

## 2. 변경 이유
`filter_stage`/`relaxed`/`metadata_filters` 결정은 import-safe leaf(ADR 0045) 로직인데 직접 단위 테스트가 0건이었다. stage/filter 회귀를 음성단언으로 차단한다.

## 3. 변경 내용
- 기본 → `strict`/`relaxed=False`; `relaxed=True`·`metadata_first=False` → `relaxed`
- relaxed stage → `metadata_filters={}`
- by_stage 우선 / 부재 시 entities → agencies fallback(precedence 역전 KILL)
- **reduced(non-strict/non-relaxed) stage**: by_stage 그 키 정확 조회 + entities fallback 동작 (reviewer 지적 gap 봉쇄)

## 4. 테스트
- `tests/test_rag_query_make_plan_stage_filters.py` 7건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 18개 single-point mutant 전부 KILL(relaxed 양방향·filters {} 명시·by_stage trap 입력). MEDIUM gap(`stage="reduced"` 경로의 G1/G3/G4 mutant 생존, retry_policy 가 reduced 명시)을 받아 **reduced 정확-조회 + entities fallback 2행 선제 추가** → 봉쇄

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)