### PR TITLE
test(rag_query): metadata_resolution_diagnostics decision/reason 분기 커버리지

### DIFF
--- a/tests/test_rag_query_metadata_resolution_diagnostics.py
+++ b/tests/test_rag_query_metadata_resolution_diagnostics.py
@@ -1,0 +1,63 @@
+"""Unit coverage for rag_query.metadata_resolution_diagnostics decision/reason (issue #2382).
+
+``metadata_resolution_diagnostics``(rag_query.py:431)는 메타데이터 해소 진단
+dict 를 빌드하며 핵심으로 clarify/use_selected_candidates decision 을 결정하는
+import-safe leaf(rag_core/torch/chromadb 미로드, ADR 0045)인데 직접 단위 테스트가
+0건이었다. test-only, 소스 무수정.
+
+핵심 변별:
+- decision: ambiguous=False → use_selected_candidates; True+non-comparison → clarify;
+  True+comparison → use_selected_candidates(예외 분기).
+- decision 인자 명시 시 그대로 우선.
+- decision_reason: reason 인자 → metadata_ambiguity.reason → "".
+- relaxed stage 의 selected_candidates_by_stage 는 항상 [].
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from rag_query import metadata_resolution_diagnostics
+
+
+def _decision(analysis: dict[str, Any]) -> str:
+    return metadata_resolution_diagnostics("쿼리", analysis)["ambiguity"]["decision"]
+
+
+def test_decision_use_selected_when_not_ambiguous() -> None:
+    # ambiguous=False → use_selected_candidates(clarify 아님).
+    assert _decision({}) == "use_selected_candidates"
+    assert _decision({"metadata_ambiguous": False, "query_type": "single_doc"}) == "use_selected_candidates"
+
+
+def test_decision_clarify_when_ambiguous_and_not_comparison() -> None:
+    # ambiguous=True + 비교 아님 → clarify.
+    assert _decision({"metadata_ambiguous": True, "query_type": "single_doc"}) == "clarify"
+
+
+def test_decision_use_selected_when_ambiguous_but_comparison() -> None:
+    # ambiguous=True 라도 query_type=="comparison" 이면 clarify 하지 않는다(예외 분기 pin).
+    assert _decision({"metadata_ambiguous": True, "query_type": "comparison"}) == "use_selected_candidates"
+
+
+def test_explicit_decision_arg_overrides_computed() -> None:
+    # decision 인자가 주어지면 ambiguous 계산을 무시하고 그대로 쓴다.
+    out = metadata_resolution_diagnostics(
+        "쿼리", {"metadata_ambiguous": True, "query_type": "single_doc"}, decision="forced"
+    )
+    assert out["ambiguity"]["decision"] == "forced"
+
+
+def test_decision_reason_prefers_arg_then_ambiguity_then_empty() -> None:
+    f = metadata_resolution_diagnostics
+    # reason 인자 우선.
+    assert f("q", {"metadata_ambiguity": {"reason": "amb_r"}}, reason="arg_r")["ambiguity"]["decision_reason"] == "arg_r"
+    # reason 인자 없으면 metadata_ambiguity.reason 로 폴백.
+    assert f("q", {"metadata_ambiguity": {"reason": "amb_r"}})["ambiguity"]["decision_reason"] == "amb_r"
+    # 둘 다 없으면 "".
+    assert f("q", {})["ambiguity"]["decision_reason"] == ""
+
+
+def test_relaxed_stage_candidates_always_empty() -> None:
+    # relaxed stage 의 후보는 빌드하지 않고 항상 빈 리스트로 고정.
+    out = metadata_resolution_diagnostics("쿼리", {})
+    assert out["selected_candidates_by_stage"]["relaxed"] == []


### PR DESCRIPTION
## 1. 변경 요약
`metadata_resolution_diagnostics`(rag_query.py:431)의 decision/decision_reason 분기 단위 테스트 6건 추가. **test-only, 소스 무수정.**

## 2. 변경 이유
메타데이터 해소 진단 dict 의 핵심 decision(`clarify`/`use_selected_candidates`)을 결정하는 import-safe leaf(ADR 0045 — rag_core/torch/chromadb 미로드)인데 직접 단위 테스트가 0건이었다. clarify 분기 회귀를 음성단언으로 차단한다.

## 3. 변경 내용
- decision: `ambiguous=False` → `use_selected_candidates` / `True`+non-comparison → `clarify` / `True`+comparison → `use_selected_candidates`(예외 분기) / `decision` 인자 → 그대로 우선
- `decision_reason`: `reason` 인자 → `metadata_ambiguity.reason` → `""` 우선순위(양방향 pin)
- relaxed stage 후보는 항상 `[]`

## 4. 테스트
- `tests/test_rag_query_metadata_resolution_diagnostics.py` 6건 — `pytest -q` 통과, ruff/pyright clean
- **별도 lane code-reviewer adversarial mutation 검증**: 10개 in-scope mutant 전부 KILL(comparison-예외 triple-guard·decision_reason 양방향·ambiguous 상수화). M8a(`relaxed=strict`) survivor는 empty-matches 에서 semantic-equivalent + matches-projection out-of-scope로 판정 → **APPROVE, 0 real gap**

## 5. Eval 영향
N/A — test-only 추가, 소스/파이프라인 무변경(load-bearing 경로 아님). 산출물·메트릭 영향 없음.

## 6. 리스크/롤백
무위험(테스트 1파일 추가). 롤백 시 커버리지만 환원.

## 7. 관련 이슈
Closes #2382

🤖 Generated with [Claude Code](https://claude.com/claude-code)