### PR TITLE
test(korquad): cover answers-list fallback

### DIFF
--- a/tests/test_korean_public_eval.py
+++ b/tests/test_korean_public_eval.py
@@ -78,6 +78,30 @@ def test_sample_korquad_strips_html_and_dedupes_articles() -> None:
     assert "운영자 교육 자료" in article_a["context"]
 
 
+def test_sample_korquad_uses_answers_list_fallback() -> None:
+    raw = {
+        "version": "tiny",
+        "data": [
+            {
+                "title": "기관_C",
+                "context": "기관 C는 데이터 품질 점검표를 제출한다.",
+                "qas": [
+                    {
+                        "id": "tiny_c_1",
+                        "question": "기관 C의 제출물은?",
+                        "answers": [
+                            {"text": ""},
+                            {"text": "데이터 품질 점검표", "answer_start": 0},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    payload = fetch_korquad.sample_korquad(raw, sample_size=1, seed=17)
+    assert payload["questions"][0]["answer_text"] == "데이터 품질 점검표"
+
+
 def test_sample_korquad_is_deterministic() -> None:
     a = fetch_korquad.sample_korquad(_tiny_korquad_raw(), sample_size=3, seed=17)
     b = fetch_korquad.sample_korquad(_tiny_korquad_raw(), sample_size=3, seed=17)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

KorQuAD public-eval sampler가 singular `answer` 객체가 없고 plural `answers` list만 있는 QA에서도 첫 non-empty answer text를 유지한다는 fixture-backed 회귀 테스트를 추가했습니다. public fixture smoke의 network-free 계약을 더 명확히 잠급니다.

Closes #2387

## 2. 영향 파일

- `tests/test_korean_public_eval.py` — KorQuAD sampler plural `answers` fallback test 추가

## 3. 리스크

- 리스크: 테스트 fixture shape가 실제 KorQuAD plural-answer fallback 계약과 어긋날 수 있음.
- 배제 근거: `eval/korean_public/fetch_korquad.py`의 `_extract_first_answer` fallback 경로를 tiny in-memory payload로 직접 호출하는 sampler 테스트로 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_korean_public_eval.py` → 7 passed
- `git diff --check`
- `make check-branch`
- multi-session overlap preflight: `OPEN_PRS=11`, `WORKTREES_SCANNED=102`, selected file `tests/test_korean_public_eval.py` clear from open PR file lists and dirty/ahead Codex/Claude worktrees.

## 5. Eval 영향

All `N/A` — test-only change. `eval/` production path and RAG behavior unchanged; real-eval not run.

## 6. 하위 호환

N/A — no schema, CLI, answer-contract, or public API changes.

## 7. 범위 외

- Production sampler behavior changes are intentionally out of scope.
- Full test suite is intentionally not run for this narrow test-only PR.
