### PR TITLE
fix(rag_answer): compound-noun guard for aggregate substring fallback

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -94,6 +94,17 @@ _AGGREGATE_SIGNALS: frozenset[str] = frozenset({
     "전부",    # all / entirety
 })
 
+# Noun-deriving suffixes (issue #2179): when an aggregate signal is immediately
+# followed by one of these, the match is a compound noun (전체성/목록화/정리율/
+# 일체형), not aggregate intent. Real aggregate phrases put a space, a verb
+# ending (전부다/정리해줘), or a compound-noun part (전체일정) after the signal —
+# never a bare nominalizer — so they stay detected by the substring fallback.
+_NOMINALIZER_SUFFIXES: frozenset[str] = frozenset("성화율률형")
+# 하다-verbalizer heads (issue #2179, Codex review): a nominalizer suffix that is
+# re-verbed by 하다 (목록화해줘/전체화하라) restores aggregate ("make a list of …")
+# intent, so it must NOT be guarded out — only the bare nominal noun (목록화) is.
+_VERBALIZER: frozenset[str] = frozenset("하해한할함했")
+
 # Pool ceiling for aggregate queries. Covers the typical multi-field
 # case where budget + duration + deadline live in separate chunks.
 _AGGREGATE_POOL_MAX: int = 5
@@ -531,15 +542,37 @@ def _is_aggregate_query(analysis: dict[str, Any]) -> bool:
     Detects tokens such as "모든" / "전체" / "정리" that indicate the
     user wants an exhaustive listing of all matching fields — not just
     the first matching chunk.  Checked against ``analysis["tokens"]``
-    (tokenised resolved query) and ``analysis["resolved_query"]`` as
-    a substring fallback for tokens the analyser may have merged or
-    split differently.
+    (tokenised resolved query) for an exact match, then ``resolved_query``
+    as a substring fallback for aggregates the tokeniser merged into a
+    compound token (전체일정/전부다).
     """
     resolved: str = analysis.get("resolved_query") or ""
     tokens: list[str] = analysis.get("tokens") or []
-    return any(sig in resolved for sig in _AGGREGATE_SIGNALS) or any(
-        sig in tokens for sig in _AGGREGATE_SIGNALS
-    )
+    # Exact token match is unambiguous — the precise primary path.
+    if any(sig in tokens for sig in _AGGREGATE_SIGNALS):
+        return True
+    # Substring fallback (#2170 recall) with a compound-noun guard (#2179): a
+    # signal occurrence counts only when it is NOT immediately followed by a
+    # nominalizer suffix (성/화/율/률/형). 전체성/목록화/정리율/일체형 are guarded
+    # out as compound nouns; 전체일정/전부다/정리해줘 (compound part, verb ending,
+    # or trailing space after the signal) stay detected, preserving #2170's
+    # recall for tokeniser-merged aggregate phrases.
+    for sig in _AGGREGATE_SIGNALS:
+        idx = resolved.find(sig)
+        while idx != -1:
+            after = idx + len(sig)
+            if after >= len(resolved) or resolved[after] not in _NOMINALIZER_SUFFIXES:
+                return True  # signal at end, or a non-nominalizer follows it
+            # A nominalizer suffix follows. Only ~화 naturally re-verbs with 하다
+            # (목록화해줘 = 목록으로 만들다 = aggregate); 형/율/률/성 + 하 is an
+            # accidental compound (일체형하우징/정리형하중), so restrict the verbalizer
+            # exception to the 화 suffix — every other bare nominal stays guarded.
+            if resolved[after] == "화":
+                nxt = resolved[after + 1] if after + 1 < len(resolved) else ""
+                if nxt in _VERBALIZER:
+                    return True
+            idx = resolved.find(sig, idx + 1)
+    return False
 
 
 def select_supporting_evidence(

--- a/tests/test_aggregate_evidence_selection_regression.py
+++ b/tests/test_aggregate_evidence_selection_regression.py
@@ -98,6 +98,84 @@ class TestIsAggregateQuery(unittest.TestCase):
                     f"signal '{sig}' did not trigger aggregate detection",
                 )
 
+    # --- issue #2179: substring-fallback compound-noun guard ----------------
+    # A signal fused with a nominalizer suffix (성/화/율/률/형) is a compound
+    # noun (전체성/목록화/정리율/일체형), not aggregate intent. A signal merged
+    # into a token but followed by a compound part / verb ending / space
+    # (전체일정/전부다/정리해줘) stays aggregate, preserving #2170 recall.
+    _COMPOUND_FALSE_POSITIVES = [
+        "전체성", "목록화", "정리율", "일체형",
+        "전체성 평가", "목록화 작업", "정리율 산정",
+    ]
+    _MERGED_TOKEN_AGGREGATES = [
+        "전체일정", "전부다", "모두다", "전체다", "정리해줘",
+        "나열해줘", "목록작성", "모든일정", "전부보여줘",
+    ]
+
+    def test_compound_noun_not_aggregate(self) -> None:
+        # tokens=[q] models the merged compound so only the substring fallback
+        # can fire; the nominalizer suffix must guard it out.
+        for q in self._COMPOUND_FALSE_POSITIVES:
+            with self.subTest(q=q):
+                a = _analysis(resolved_query=q, tokens=[q])
+                self.assertFalse(
+                    _is_aggregate_query(a), f"{q!r} should not be aggregate (#2179)"
+                )
+
+    def test_merged_token_aggregate_still_detected(self) -> None:
+        # #2170 recall: a real aggregate merged into one token (no exact match)
+        # must still fire via the substring fallback — the char after the signal
+        # is a compound part / verb ending, not a nominalizer.
+        for q in self._MERGED_TOKEN_AGGREGATES:
+            with self.subTest(q=q):
+                a = _analysis(resolved_query=q, tokens=[q])
+                self.assertTrue(
+                    _is_aggregate_query(a), f"{q!r} should stay aggregate (#2170)"
+                )
+
+    _VERBALIZED_AGGREGATES = [
+        "목록화해줘", "목록화해", "목록화하라", "목록화함",
+        "전체화해줘", "정리화하여", "목록화했다",
+    ]
+
+    def test_verbalized_nominalizer_still_aggregate(self) -> None:
+        # Codex review (#2179): a nominalizer suffix re-verbed by 하다 (목록화해줘)
+        # is a listing request, not a bare noun — it must stay aggregate while the
+        # bare nominal (목록화) is still guarded out by test_compound_noun_not_aggregate.
+        for q in self._VERBALIZED_AGGREGATES:
+            with self.subTest(q=q):
+                a = _analysis(resolved_query=q, tokens=[q])
+                self.assertTrue(
+                    _is_aggregate_query(a),
+                    f"{q!r} should stay aggregate (#2179 verbalized nominalizer)",
+                )
+
+    _SUFFIX_COMPOUND_NEGATIVES = [
+        "일체형하우징", "정리형하중", "전체형하부", "정리율하한", "전체성하부구조",
+    ]
+
+    def test_non_hwa_suffix_plus_ha_not_aggregate(self) -> None:
+        # Codex review (#2179): only ~화 takes 하다; 형/율/률/성 + 하 is an accidental
+        # compound (일체형하우징/정리형하중), not a verbalized aggregate. The verbalizer
+        # exception must stay scoped to the 화 suffix.
+        for q in self._SUFFIX_COMPOUND_NEGATIVES:
+            with self.subTest(q=q):
+                a = _analysis(resolved_query=q, tokens=[q])
+                self.assertFalse(
+                    _is_aggregate_query(a),
+                    f"{q!r} should not be aggregate (#2179 non-화 suffix)",
+                )
+
+    def test_exact_token_overrides_compound_suffix(self) -> None:
+        # An exact token signal wins even when resolved also carries a compound.
+        a = _analysis(resolved_query="전체성 분석", tokens=["전체", "분석"])
+        self.assertTrue(_is_aggregate_query(a))
+
+    def test_signal_at_string_end_is_aggregate(self) -> None:
+        # signal with nothing after it (string end, not a suffix) → aggregate.
+        a = _analysis(resolved_query="예산 전체", tokens=["예산전체"])
+        self.assertTrue(_is_aggregate_query(a))
+
 
 # ---------------------------------------------------------------------------
 # select_supporting_evidence pool-size tests
@@ -233,6 +311,15 @@ class TestAnalyzeQueryAggregateIntegration(unittest.TestCase):
 
     def test_plain_query_not_flagged_end_to_end(self) -> None:
         analysis = analyze_query("사업 예산은 얼마인가", [])
+        self.assertFalse(_is_aggregate_query(analysis))
+
+    def test_compound_noun_not_flagged_end_to_end(self) -> None:
+        # issue #2179: tokenize("전체성을 평가한다") merges "전체성" into one token,
+        # so the token path is blind; the substring fallback must NOT fire on the
+        # compound noun (전체 + 성 nominalizer). The precision-direction mirror of
+        # the #2170 recall drift guard above.
+        analysis = analyze_query("전체성을 평가한다", [])
+        self.assertNotIn("전체", analysis["tokens"])  # precondition: token path blind
         self.assertFalse(_is_aggregate_query(analysis))
 
 


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`_is_aggregate_query` 의 substring fallback (#2170/#2179) 이 nominalizer 접미사 합성어를 aggregate 로 오탐(false-positive)하던 것을 가드.

`_AGGREGATE_SIGNALS = {모든,전체,모두,목록,나열,정리,리스트,일체,전부}` 의 substring 분기는 recall 을 위해 `sig in resolved` 로 매칭한다. 그러나 한국어 명사화 접미사(성/화/율/률/형)가 붙은 추상명사는 aggregate 의도가 아니다:

- `전체성` (wholeness) ≠ 전체 나열
- `목록화` (cataloguing, 명사) ≠ "목록 보여줘"
- `정리율` (arrangement-rate), `일체형` (one-piece-type) — 모두 compound noun

이들이 substring 매칭으로 `select_supporting_evidence` 의 pool_size 를 2→5 로 부풀려 무관 근거를 답변에 끌어들이는 저빈도·무해(harmless) 정밀도(precision) 버그.

## 2. 어떻게 (How)

3단계 경계 휴리스틱 (외부 의존성·형태소 분석기 없이):

1. **exact-token-first**: `sig in tokens` (정확 토큰) 이면 즉시 aggregate — 분해된 토큰은 항상 신뢰.
2. **nominalizer-suffix boundary**: substring 매칭 시 signal 바로 뒤 문자가 명사화 접미사(`성화율률형`)면 compound noun 으로 보고 건너뜀. 단 signal 이 문자열 끝이거나 비-접미사가 뒤따르면 aggregate.
3. **화-verbalizer exception**: `~화` 만 `하다`로 재동사화(`목록화해줘` = "목록으로 만들어줘")되므로 `화` + `하해한할함했`이면 aggregate 복원. `형/율/률/성` + `하`는 우연한 합성(`일체형하우징`)이라 제외 — Codex adversarial review 2라운드 피드백 반영.

## 3. 테스트 (Tests)

`tests/test_aggregate_evidence_selection_regression.py`:
- `_COMPOUND_FALSE_POSITIVES` (전체성/목록화/정리율/일체형…) → not aggregate
- `_MERGED_TOKEN_AGGREGATES` (전체일정/전부다/정리해줘…) → 여전히 aggregate
- `_VERBALIZED_AGGREGATES` (목록화해줘/목록화하라…) → 여전히 aggregate (화-verbalizer)
- `_SUFFIX_COMPOUND_NEGATIVES` (일체형하우징/정리형하중…) → not aggregate (비-화 접미사+하)
- exact-token override, signal-at-end, e2e `test_compound_noun_not_flagged_end_to_end`

Mutation testing 으로 비공허(non-vacuous) 증명: 3개 가드 각각 revert 시 해당 테스트만 FAIL (8/7/5건), 복원 시 동일.

## 4. 범위 밖 (Out of scope)

`make_citation` 의 기존 Pyright `reportOptionalMemberAccess` 경고는 본 변경의 line-shift 로 표면화됐을 뿐 무관 — one-PR-one-concern 으로 미수정.

## 5. Eval 영향 (Eval impact)

load-bearing `rag_answer.py` 변경이나 **ADR 0001 naive_baseline byte-identity 영향 없음**:
- naive_baseline 은 direct-path 라 `select_supporting_evidence`/`_is_aggregate_query` 미호출 (rag_core.py:1318-1319)
- fixture smoke 의 FP 단어(전체성/목록화 등) 출현 0 → 동작 무변경
- `make smoke` 통과, answer 의미 무변경 (latency 비결정값만 차이)
- 변경은 순수 **정밀도 가드** (오탐 제거), recall 회귀 0 (merged-token/verbalized 테스트로 보장)

## 6. 체크리스트

- [x] Issue 참조: Closes #2179
- [x] 브랜치 컨벤션 (ADR 0007): `fix/issue-2179-aggregate-compound-guard`
- [x] 동작 변경 ↔ 회귀 테스트 추가
- [x] Codex adversarial pre-commit review 통과 (round 3: 0 blocking / 0 informational)

Closes #2179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
