### PR TITLE
test(parser-eval): cover singular hardcase category

### DIFF
--- a/tests/test_parser_eval.py
+++ b/tests/test_parser_eval.py
@@ -104,6 +104,24 @@ class ParserEvalTest(unittest.TestCase):
         self.assertEqual(1, by_category["noisy_ocr"]["num_documents_with_errors"])
         self.assertEqual({"artifact_missing": 1}, by_category["table_heavy"]["failure_counts"])
 
+    def test_build_report_groups_legacy_singular_hardcase_category(self) -> None:
+        gold = {
+            "documents": [
+                {
+                    "doc_id": "legacy-category-doc",
+                    "hardcase_category": "legacy_table",
+                }
+            ]
+        }
+
+        report = build_report(Path("missing-artifacts"), Path("gold.yaml"), gold, "unit", "2")
+        document = report["documents"][0]
+        by_category = report["summary"]["by_hardcase_category"]
+
+        self.assertEqual(["legacy_table"], document["hardcase_categories"])
+        self.assertEqual(1, by_category["legacy_table"]["num_documents"])
+        self.assertEqual({"artifact_missing": 1}, by_category["legacy_table"]["failure_counts"])
+
     def test_cli_writes_parser_eval_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             completed = subprocess.run(


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Parser eval gold가 legacy singular `hardcase_category` string을 사용할 때도 report document와 `summary.by_hardcase_category`에 동일 category로 반영된다는 test-only contract를 추가했습니다. 이미 지원되는 호환 경로를 작은 fixture로 고정합니다.

Closes #2394

## 2. 영향 파일

- `tests/test_parser_eval.py` — parser eval singular `hardcase_category` grouping test 추가

## 3. 리스크

- 리스크: legacy gold field 지원이 실수로 제거되면 parser hardcase slice 집계가 누락될 수 있음.
- 배제 근거: missing-artifact fixture를 통해 document-level `hardcase_categories`와 category summary `failure_counts`를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_parser_eval.py` → 6 passed
- `git diff --check`
- `make check-branch`
- multi-session overlap preflight: `OPEN_PRS=10`, `WORKTREES_SCANNED=100`, selected file `tests/test_parser_eval.py` clear from open PR file lists and dirty/ahead Codex/Claude worktrees.

## 5. Eval 영향

All `N/A` — test-only change. Parser eval production code and RAG behavior unchanged; real-eval not run.

## 6. 하위 호환

N/A — no schema, CLI flag, answer-contract, or public API changes. This PR only pins an existing legacy gold-field compatibility path.

## 7. 범위 외

- Production parser eval behavior changes are intentionally out of scope.
- Full test suite is intentionally not run for this narrow test-only PR.
