### PR TITLE
test(prompt-injection): cover tool chat token

### DIFF
--- a/tests/test_prompt_injection_regression.py
+++ b/tests/test_prompt_injection_regression.py
@@ -28,6 +28,7 @@ CHAT_TOKEN_CANARIES = [
     "<|system|>",
     "<|user|>",
     "<|assistant|>",
+    "<|tool|>",
     "<|endoftext|>",
 ]
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Evidence-boundary neutralization이 이미 지원하는 `<|tool|>` chat-template token을 prompt-injection regression canary 목록에 추가했습니다. judge/verifier prompt에 tool-role token이 raw로 남지 않는 계약을 test-only로 고정합니다.

Closes #2402

## 2. 영향 파일

- `tests/test_prompt_injection_regression.py` — `<|tool|>` chat token redaction canary 추가

## 3. 리스크

- 리스크: 지원 regex와 테스트 canary 목록이 어긋나면 tool-role prompt token 회귀를 놓칠 수 있음.
- 배제 근거: `neutralize_instruction_patterns`와 judge prompt boundary 테스트가 동일 `CHAT_TOKEN_CANARIES` 목록을 순회해 raw token 미노출을 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_prompt_injection_regression.py` → 10 passed, 10 subtests passed
- `git diff --check`
- `make check-branch`
- multi-session overlap preflight: `OPEN_PRS=10`, `WORKTREES_SCANNED=98`, selected file `tests/test_prompt_injection_regression.py` clear from open PR file lists and dirty/ahead Codex/Claude worktrees.

## 5. Eval 영향

All `N/A` — test-only change. RAG behavior, prompt construction code, and eval outputs unchanged; real-eval not run.

## 6. 하위 호환

N/A — no schema, CLI flag, answer-contract, or public API changes.

## 7. 범위 외

- Production redaction regex changes are intentionally out of scope because `<|tool|>` is already supported.
- Full test suite is intentionally not run for this narrow test-only PR.
