### PR TITLE
test(rag_answer): build_insufficiency 미지지 타겟/엔티티 폴백/reasons 3-tier 커버리지

### DIFF
--- a/tests/test_rag_answer_build_insufficiency.py
+++ b/tests/test_rag_answer_build_insufficiency.py
@@ -1,0 +1,70 @@
+"""Unit coverage for rag_answer.build_insufficiency 진단 dict (issue #2400).
+
+``build_insufficiency``(rag_answer.py:423)는 보류(abstention) 응답의 진단 dict 를
+빌드하는 순수 import-safe leaf(rag_core/torch/chromadb 미로드, ADR 0045)인데 직접
+단위 테스트가 0건이었다. 외부 dep ``specific_topics`` 는 빈 analysis 로 ``[]`` 고정해
+타깃 자체 로직만 격리 검증한다. test-only, 소스 무수정.
+
+핵심 변별:
+- missing_targets = checked_entities − claims target 집합(set 차집합).
+- re-fill 분기는 ``not verified`` 일 때만(verified 면 미실행).
+- checked_entities = entities → context_entities → [] 폴백(entities 우선).
+- reasons 3-tier: 주어진 verification_reasons → ["verification_failed"](not verified) → [].
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from rag_answer import build_insufficiency
+
+_SUPPORTED_A: list[dict[str, Any]] = [{"target": "기관A", "claim": "x"}]
+
+
+def test_missing_targets_set_difference_and_doc_ids() -> None:
+    out = build_insufficiency(
+        "예산은?",
+        {"entities": ["기관A", "기관B"], "matched_doc_ids": ["d1"]},
+        _SUPPORTED_A,  # 기관A 만 지지.
+        True,
+        [],
+    )
+    # 지지되지 않은 기관B 만 missing(set 차집합).
+    assert out["missing_targets"] == ["기관B"]
+    assert "기관A" not in out["missing_targets"]
+    # checked_doc_ids 는 matched_doc_ids 그대로.
+    assert out["checked_doc_ids"] == ["d1"]
+    # matched_doc_ids 키 부재 시 빈 리스트로 폴백(`or []` — None 누출 차단, 보류 dict 의 흔한 경로).
+    assert build_insufficiency("q", {}, [], True, [])["checked_doc_ids"] == []
+    # message 는 query 보간 고정 문구.
+    assert out["message"] == "'예산은?'에 대한 충분한 근거를 찾지 못했습니다."
+
+
+def test_refill_missing_targets_only_when_not_verified() -> None:
+    analysis = {"entities": ["기관A"]}
+    # not verified + missing 없음(전부 지지) + checked 있음 → 전체 checked 로 re-fill.
+    unverified = build_insufficiency("q", analysis, _SUPPORTED_A, False, [])
+    assert unverified["missing_targets"] == ["기관A"]
+    # verified 면 동일 조건이라도 re-fill 안 함(`not verified` 가드) → missing 빈 채로.
+    verified = build_insufficiency("q", analysis, _SUPPORTED_A, True, [])
+    assert verified["missing_targets"] == []
+
+
+def test_checked_entities_entities_then_context_then_empty() -> None:
+    # entities 우선(둘 다 있어도 entities).
+    both = build_insufficiency("q", {"entities": ["기관A"], "context_entities": ["기관Z"]}, [], True, [])
+    assert both["checked_entities"] == ["기관A"]
+    # entities 없으면 context_entities 폴백.
+    ctx = build_insufficiency("q", {"context_entities": ["기관C"]}, [], True, [])
+    assert ctx["checked_entities"] == ["기관C"]
+    # 둘 다 없으면 [].
+    empty = build_insufficiency("q", {}, [], True, [])
+    assert empty["checked_entities"] == []
+
+
+def test_reasons_three_tier() -> None:
+    # 주어진 verification_reasons 우선(not verified 라도 그대로).
+    assert build_insufficiency("q", {}, [], False, ["custom"])["reasons"] == ["custom"]
+    # 비어 있고 not verified → ["verification_failed"].
+    assert build_insufficiency("q", {}, [], False, [])["reasons"] == ["verification_failed"]
+    # 비어 있고 verified → [].
+    assert build_insufficiency("q", {}, [], True, [])["reasons"] == []


### PR DESCRIPTION
## 1. 概要 / What
`rag_answer.py` 의 `build_insufficiency`(:423) — 보류(abstention) 응답 진단 dict 를 빌드하는 순수 import-safe leaf — 에 직접 단위 테스트(0건 → 4 test)를 추가한다. **test-only, 소스 무수정.** (외부 dep `specific_topics` 는 빈 analysis 로 `[]` 고정해 격리.)

## 2. 動機 / Why
set 차집합 missing_targets, `not verified` 조건부 re-fill, entities→context_entities 폴백, reasons 3-tier 같은 보류 진단 분기가 커버리지 0이었다. 분기 mutant 를 음성 assertion 으로 차단한다.

## 3. 変更点 / Changes
- `tests/test_rag_answer_build_insufficiency.py` 신규 (4 test)
  - missing_targets set 차집합 + checked_doc_ids(matched_doc_ids·키 부재 시 `[]` 폴백)
  - re-fill 은 `not verified` 일 때만(verified 반례로 가드 양방향 pin)
  - checked_entities entities→context_entities→[] 폴백(entities 우선)
  - reasons 3-tier(given / verification_failed / verified-empty)

## 4. テスト / Tests
- `pytest tests/test_rag_answer_build_insufficiency.py -q` → **4 passed**
- `ruff` clean / `pyright` 0 errors / import-safety(ADR 0045) 확인
- 별도 레인 code-reviewer adversarial mutation: **18/19 KILL**(re-fill `not verified` 가드 양방향 + reasons 3-tier 각 tier 독립 pin 확인). 지적된 LOW gap(`checked_doc_ids` `or []` 빈 폴백)을 `{}→[]` assertion 1줄 선반영. vacuous 0 / real gap 0. APPROVE.

## 5. Eval 影響 / Eval impact
N/A — test-only. `rag_answer.py` byte-identical, 런타임 경로 무변경이라 real-data 델타 없음.

## 6. リスク / Risk
낮음. 테스트 파일 1개 추가, 프로덕션 코드 0줄.

## 7. ロールバック / Rollback
`tests/test_rag_answer_build_insufficiency.py` 삭제로 원복.

Closes #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)