### PR TITLE
test(memory-lines): cover blocked write telemetry

### DIFF
--- a/tests/test_pretooluse_memory_lines_hook_regression.py
+++ b/tests/test_pretooluse_memory_lines_hook_regression.py
@@ -119,6 +119,9 @@ class TestMemoryLinesHook(unittest.TestCase):
         })
         self.assertEqual(r.returncode, 2)
         self.assertIn("32", r.stderr)
+        line = self._fires_log.read_text().strip()
+        self.assertIn("|blocked|memory-lines|line-count|", line)
+        self.assertIn(str(target), line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Write payload가 새 `MEMORY.md`를 block threshold 이상으로 만들 때 exit/stderr뿐 아니라 `.hook-fires.log`의 blocked telemetry까지 남는지 회귀 테스트로 고정합니다.

Closes #2405

## 2. 영향 파일

- `tests/test_pretooluse_memory_lines_hook_regression.py` — test-only, load-bearing 아님

## 3. 리스크

- 리스크: hook telemetry format 변경 시 테스트가 깨질 수 있음.
- 배제 근거: 기존 5-field format 문서화와 같은 substring(`|blocked|memory-lines|line-count|`) 및 target path만 확인해 과도하게 timestamp에 결합하지 않음.

## 4. 테스트

- `python3 -m pytest -q tests/test_pretooluse_memory_lines_hook_regression.py` → 5 passed
- `git diff --check` → pass
- `make check-branch` → pass
- Overlap preflight: latest `origin/main`=`2b946488cd25e303a6a8561f20572acbc92b4209`; branch file `tests/test_pretooluse_memory_lines_hook_regression.py`; main-side files empty; overlap empty; selection scan found no open PR or active Codex/Claude worktree touching this file.

## 5. Eval 영향

RAG/eval load-bearing 경로 변경 없음. Test-only hook regression coverage라 public/private eval 동작 변화 없음.

## 6. 하위 호환

하위 호환 영향 없음. Runtime hook behavior, answer schema, CLI flag 변경 없음.

## 7. 범위 외

- `scripts/claude-hooks/pretooluse-memory-lines.sh` runtime behavior 변경 없음.
- 다른 memory-lines hook test 파일 통합/정리는 범위 외.
