### PR TITLE
feat(agent-evals): PR3 runner + cross-family acceptance oracle + paired-bootstrap holdout report

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -117,9 +117,9 @@ ALLOWED_PATTERNS=(
   # ADR 0100 operator-skill eval surface (PR2): scanner-backed committable surface.
   '^agent-evals/README\.md$'
   '^agent-evals/core/__init__\.py$'
-  '^agent-evals/core/(schema|metrics|report)\.py$'
+  '^agent-evals/core/(schema|metrics|report|oracle)\.py$'
   '^agent-evals/adapters/bidmate/__init__\.py$'
-  '^agent-evals/adapters/bidmate/task_mining\.py$'
+  '^agent-evals/adapters/bidmate/(task_mining|runner|oracle_bidmate)\.py$'
   '^agent-evals/playbooks/v(0_naive|1_spec_first)\.md$'
   '^agent-evals/splits\.yaml$'
   '^agent-evals/tasks/[^/]+/task\.yaml$'

--- a/.gitignore
+++ b/.gitignore
@@ -391,8 +391,11 @@ agent-evals/**
 !agent-evals/core/schema.py
 !agent-evals/core/metrics.py
 !agent-evals/core/report.py
+!agent-evals/core/oracle.py
 !agent-evals/adapters/bidmate/__init__.py
 !agent-evals/adapters/bidmate/task_mining.py
+!agent-evals/adapters/bidmate/runner.py
+!agent-evals/adapters/bidmate/oracle_bidmate.py
 !agent-evals/playbooks/v0_naive.md
 !agent-evals/playbooks/v1_spec_first.md
 !agent-evals/splits.yaml

--- a/agent-evals/adapters/bidmate/oracle_bidmate.py
+++ b/agent-evals/adapters/bidmate/oracle_bidmate.py
@@ -232,12 +232,29 @@ def evaluate(
             regression_pass=gates.regression_pass,
             hard_gates=hard,
         )
-    reviewer = cross_family_review(
-        payload_provider,
-        public_attestation=public_attestation,
-        candidate_family=candidate_family,
-        reviewer_family=reviewer_family,
-        reviewer_call=reviewer_call,
+    # Privacy-preserving egress order: only hand the issue+patch payload to the
+    # external cross-family reviewer when the objective gates ALREADY pass. If a
+    # hard gate fired (e.g. added_secrets / destructive) or a necessary gate
+    # failed, rejection is fully determined by the gates, so the payload — which
+    # may contain exactly the secret/destructive content the hard gate detected —
+    # must NOT leave the boundary (ADR 0005). Skipping the call here means no
+    # payload is built or sent; decide_verdict then rejects on the gates alone.
+    gates_pass = (
+        not gates.hard_gates
+        and gates.hidden_test_gate is True
+        and gates.pytest_pass is True
+        and gates.regression_pass is True
+    )
+    reviewer = (
+        cross_family_review(
+            payload_provider,
+            public_attestation=public_attestation,
+            candidate_family=candidate_family,
+            reviewer_family=reviewer_family,
+            reviewer_call=reviewer_call,
+        )
+        if gates_pass
+        else None
     )
     tier = oracle.decide_verdict(
         gates,
@@ -249,6 +266,9 @@ def evaluate(
         "tier": tier.name,
         "candidate_family": candidate_family,
         "reviewer_family": reviewer.reviewer_family if reviewer is not None else None,
-        "egress": "performed" if public_attestation else "skipped",
+        # Egress reflects whether the payload ACTUALLY left the boundary: a reviewer
+        # object exists only when cross_family_review ran (gates passed AND public
+        # attestation open). Gate failure or closed attestation => no egress.
+        "egress": "performed" if reviewer is not None else "skipped",
         "reason_code": reviewer.reason_code if reviewer is not None else None,
     }

--- a/agent-evals/adapters/bidmate/oracle_bidmate.py
+++ b/agent-evals/adapters/bidmate/oracle_bidmate.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""BidMate adapter that drives real gates + cross-family review into the oracle.
+
+This is the only layer that touches subprocesses / an external reviewer; it feeds
+*already-sanitized* booleans and short tokens into ``core/oracle.py`` (which stays
+repo-agnostic and stdlib-only).  The core module is loaded by file path with
+``importlib`` because the top-level directory name ``agent-evals`` contains a
+hyphen and is therefore not a valid Python package name, so ``from agent-evals...``
+is impossible; a path load also keeps this adapter off the forbidden RAG/eval/api
+import prefixes the content scanner blocks.
+
+Egress discipline (ADR 0005 + ADR 0064):
+
+* ``cross_family_review`` performs the ONLY payload egress, and ONLY when
+  ``public_attestation`` is True.  When it is False the ``payload_provider`` is
+  not even invoked — there is no payload built and nothing leaves the boundary.
+* The same-family validity check is enforced *downstream* in
+  ``oracle.decide_verdict``: even if a same-family reviewer returns a verdict, the
+  tier is neutralized to ``NECESSARY_GATE_ONLY``.  This adapter therefore does not
+  need to special-case family equality before returning a verdict.
+
+No raw stdout/diff/patch/review prose is ever stored in a returned structure here;
+only pass/fail booleans, hard-gate members, a short ``reason_code`` token, and the
+sanitized verdict dict cross the boundary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+_GATE_TIMEOUT_SECONDS = 1800
+_REVIEW_TIMEOUT_SECONDS = 600
+
+
+def _load_core(name: str):
+    """Load ``core/<name>.py`` by path (hyphenated dir is not importable)."""
+
+    core_path = Path(__file__).resolve().parents[2] / "core" / f"{name}.py"
+    module_name = f"agent_evals_core_{name}"
+    spec = importlib.util.spec_from_file_location(module_name, core_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"could not load agent-evals core module: {core_path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass forward-ref resolution (e.g.
+    # ``tuple[HardGate, ...]``) can find the module in ``sys.modules`` during class
+    # creation; without this, ``@dataclass`` post-processing raises AttributeError.
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+oracle = _load_core("oracle")
+
+
+# Map of sanitized diff-summary boolean keys -> HardGate members. The caller
+# passes booleans/counts only (never raw diff text), so this detector is a pure
+# lookup over an already-sanitized summary.
+_HARD_GATE_FLAGS: tuple[tuple[str, Any], ...] = (
+    ("build_failure", oracle.HardGate.BUILD_FAILURE),
+    ("added_secrets", oracle.HardGate.SECRET_LEAK),
+    ("destructive", oracle.HardGate.DESTRUCTIVE),
+    ("unrelated_churn", oracle.HardGate.UNRELATED_REWRITE),
+    ("instruction_violation", oracle.HardGate.INSTRUCTION_VIOLATION),
+    ("unauthorized_migration", oracle.HardGate.UNAUTHORIZED_MIGRATION),
+)
+
+
+def run_necessary_gates(
+    worktree: Path,
+    *,
+    hidden_test_cmd: list[str],
+    pytest_cmd: list[str],
+    regression_cmd: list[str],
+    runner_subprocess: Callable[..., Any] = subprocess.run,
+    timeout: int = _GATE_TIMEOUT_SECONDS,
+) -> Any:  # oracle.GateResults — oracle is importlib-loaded so it is not a static type
+    """Run the three necessary-gate commands in ``worktree`` and map rc==0 -> pass.
+
+    ``runner_subprocess`` is injectable so tests pass a fake mapping returncodes to
+    commands without spawning real processes.  Only the boolean pass/fail of each
+    command is retained — stdout/stderr is never captured into the returned
+    ``GateResults`` (or any committed structure).
+    """
+
+    def _passed(cmd: list[str]) -> bool:
+        proc = runner_subprocess(
+            cmd,
+            cwd=str(worktree),
+            timeout=timeout,
+            check=False,
+            capture_output=True,
+        )
+        return int(getattr(proc, "returncode", 1)) == 0
+
+    return oracle.GateResults(
+        hidden_test_gate=_passed(hidden_test_cmd),
+        pytest_pass=_passed(pytest_cmd),
+        regression_pass=_passed(regression_cmd),
+    )
+
+
+def detect_hard_gates(diff_summary: Mapping[str, Any]) -> tuple[Any, ...]:
+    """Map an already-sanitized diff-summary dict to HardGate members.
+
+    The summary carries booleans/counts only (e.g. ``{"build_failure": bool,
+    "added_secrets": bool, "destructive": bool, "unrelated_churn": bool,
+    "unauthorized_migration": bool, "instruction_violation": bool,
+    "deleted_paths": int}``) — never raw diff text.  ``deleted_paths`` is treated
+    as a destructive signal when positive.
+    """
+
+    gates: list[Any] = []
+    for key, gate in _HARD_GATE_FLAGS:
+        if bool(diff_summary.get(key)):
+            gates.append(gate)
+    deleted = diff_summary.get("deleted_paths")
+    if isinstance(deleted, (int, float)) and deleted > 0 and oracle.HardGate.DESTRUCTIVE not in gates:
+        gates.append(oracle.HardGate.DESTRUCTIVE)
+    return tuple(gates)
+
+
+def cross_family_review(
+    payload_provider: Callable[[], Any],
+    *,
+    public_attestation: bool,
+    candidate_family: str,
+    reviewer_family: str,
+    reviewer_call: "Callable[[Any], tuple[bool, str]] | None" = None,
+) -> Any:  # oracle.ReviewerVerdict | None — oracle is importlib-loaded, not a static type
+    """Run a cross-family reviewer over the candidate payload, egress-gated.
+
+    Egress happens ONLY when ``public_attestation`` is True.  When it is False this
+    returns ``None`` and ``payload_provider`` is NOT invoked, so no payload (issue +
+    patch) is ever built or sent.  The family validity check is intentionally NOT
+    done here; it is enforced downstream in ``oracle.decide_verdict`` so that even a
+    same-family reviewer's verdict is neutralized to ``NECESSARY_GATE_ONLY``.
+
+    ``reviewer_call`` is injectable; tests pass a fake so the real codex egress path
+    is never exercised by the suite.  ``candidate_family`` is accepted for interface
+    symmetry / future provenance and is not used to short-circuit egress.
+    """
+
+    if not public_attestation:
+        return None
+    call = reviewer_call if reviewer_call is not None else _default_codex_reviewer
+    payload = payload_provider()
+    accepted, reason_code = call(payload)
+    return oracle.ReviewerVerdict(
+        accepted=bool(accepted),
+        reviewer_family=reviewer_family,
+        reason_code=str(reason_code),
+    )
+
+
+def _default_codex_reviewer(payload: Any) -> tuple[bool, str]:
+    """Real cross-family egress path: hand the payload to a read-only codex review.
+
+    This is the ONLY function that actually sends the candidate payload to an
+    external model, so it runs only when ``cross_family_review`` was called with
+    ``public_attestation=True``.  It is deliberately minimal and is NOT exercised
+    by the test suite (tests inject ``reviewer_call``).  The payload is written to a
+    temp file and passed on stdin; only a short ``(accepted, reason_code)`` token
+    pair is parsed back, never the model's prose.
+    """
+
+    text = payload if isinstance(payload, str) else str(payload)
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=True) as handle:
+        handle.write(text)
+        handle.flush()
+        with open(handle.name, "r", encoding="utf-8") as stdin_handle:
+            proc = subprocess.run(
+                [
+                    "codex",
+                    "exec",
+                    "--sandbox",
+                    "read-only",
+                    "-c",
+                    "model_reasoning_effort=high",
+                ],
+                stdin=stdin_handle,
+                capture_output=True,
+                text=True,
+                timeout=_REVIEW_TIMEOUT_SECONDS,
+                check=False,
+            )
+    verdict_line = proc.stdout.strip().splitlines()[-1].strip().lower() if proc.stdout.strip() else ""
+    accepted = verdict_line.startswith("accept")
+    reason_code = "ok" if accepted else "rejected"
+    return accepted, reason_code
+
+
+def evaluate(
+    worktree: Path,
+    *,
+    task: Mapping[str, Any],
+    candidate_family: str,
+    public_attestation: bool,
+    reviewer_family: str,
+    payload_provider: Callable[[], Any],
+    hidden_test_cmd: list[str],
+    pytest_cmd: list[str],
+    regression_cmd: list[str],
+    diff_summary: "Mapping[str, Any] | None" = None,
+    runner_subprocess: Callable[..., Any] = subprocess.run,
+    reviewer_call: "Callable[[Any], tuple[bool, str]] | None" = None,
+) -> dict[str, Any]:
+    """Tie gates + hard-gate detection + cross-family review through the oracle.
+
+    Returns a sanitized verdict dict only — no payload, prose, or command output:
+    ``{"tier", "candidate_family", "reviewer_family"|None, "egress", "reason_code"|None}``.
+    ``task`` is accepted for provenance symmetry; the verdict does not embed task prose.
+    """
+
+    gates = run_necessary_gates(
+        worktree,
+        hidden_test_cmd=hidden_test_cmd,
+        pytest_cmd=pytest_cmd,
+        regression_cmd=regression_cmd,
+        runner_subprocess=runner_subprocess,
+    )
+    hard = detect_hard_gates(diff_summary or {})
+    if hard:
+        gates = oracle.GateResults(
+            hidden_test_gate=gates.hidden_test_gate,
+            pytest_pass=gates.pytest_pass,
+            regression_pass=gates.regression_pass,
+            hard_gates=hard,
+        )
+    reviewer = cross_family_review(
+        payload_provider,
+        public_attestation=public_attestation,
+        candidate_family=candidate_family,
+        reviewer_family=reviewer_family,
+        reviewer_call=reviewer_call,
+    )
+    tier = oracle.decide_verdict(
+        gates,
+        reviewer,
+        candidate_family=candidate_family,
+        public_attestation=public_attestation,
+    )
+    return {
+        "tier": tier.name,
+        "candidate_family": candidate_family,
+        "reviewer_family": reviewer.reviewer_family if reviewer is not None else None,
+        "egress": "performed" if public_attestation else "skipped",
+        "reason_code": reviewer.reason_code if reviewer is not None else None,
+    }

--- a/agent-evals/adapters/bidmate/runner.py
+++ b/agent-evals/adapters/bidmate/runner.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Sequential paired-trial runner for the BidMate operator-skill eval surface.
+
+Each trial runs one frozen playbook against one task in a DETACHED git worktree
+created at a fixed start commit, then ALWAYS tears the worktree down.  The run-log
+is a sanitized dict of timings / counts / gate booleans — never raw diff, patch,
+issue, PR, or reviewer prose — and the caller persists it to a GITIGNORED path
+(``agent-evals/runs/`` is deny-by-default).
+
+Design constraints:
+
+* The candidate is INJECTED (``candidate(...)``).  The default stub is
+  deterministic and applies nothing, so the runner itself stays side-effect-free
+  and testable; the real candidate (which invokes a coding agent) is wired by the
+  CLI, not here.
+* The clock is injectable and there is NO module-import-time ``datetime.now()`` —
+  tests pass a fixed clock so run-logs are byte-deterministic.
+* Worktree teardown runs in a ``finally`` (remove --force, best-effort rmtree,
+  then ``git worktree prune``) so a crashing candidate cannot leak worktrees and
+  fill the disk; the matrix runs one worktree at a time for the same reason.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+
+DEFAULT_PLAYBOOKS: tuple[str, ...] = ("v0_naive", "v1_spec_first")
+DEFAULT_SEEDS: tuple[int, ...] = (17, 18, 19)
+_WORKTREE_OP_TIMEOUT = 300
+
+
+def _zero_clock() -> float:
+    """Deterministic default clock (tests override; never wall-clock at import)."""
+
+    return 0.0
+
+
+def stub_candidate(*, worktree: Path, task_id: str, playbook: str, seed: int) -> dict[str, Any]:
+    """Deterministic no-op candidate used as the default / in tests.
+
+    Applies no repository change and returns a fixed sanitized result.  The
+    ``gate_results`` here are intentionally all-pass so the downstream stub
+    pipeline can surface some ACCEPTED rows under public attestation + a stub
+    cross-family reviewer; this is a directional smoke signal, not a real solve.
+    """
+
+    return {
+        "intervention_count": 0,
+        "cost": {"input_tokens": 0, "output_tokens": 0, "usd": 0.0},
+        "human_minutes": 0.0,
+        "gate_results": {
+            "hidden_test_gate": True,
+            "pytest_pass": True,
+            "regression_pass": True,
+            "hard_gates": [],
+        },
+    }
+
+
+def run_one(
+    *,
+    start_commit: str,
+    task_id: str,
+    playbook: str,
+    seed: int,
+    candidate: Callable[..., dict[str, Any]] = stub_candidate,
+    repo_root: Path,
+    clock: Callable[[], float] = _zero_clock,
+    subprocess_run: Callable[..., Any] = subprocess.run,
+    workdir_factory: Callable[..., str] = tempfile.mkdtemp,
+) -> dict[str, Any]:
+    """Run one (task, playbook, seed) trial in a fresh detached worktree.
+
+    Returns a sanitized run-log dict.  The worktree is always removed before
+    return (success or failure).  ``candidate`` is injected; the default applies
+    nothing.  ``clock`` is injected so ``started``/``finished`` are deterministic
+    in tests.
+    """
+
+    tmp = workdir_factory(prefix=f"agent-evals-{task_id}-{playbook}-seed{seed}-")
+    tmp_path = Path(tmp)
+    started = float(clock())
+    try:
+        subprocess_run(
+            ["git", "-C", str(repo_root), "worktree", "add", str(tmp_path), "--detach", start_commit],
+            check=True,
+            capture_output=True,
+            timeout=_WORKTREE_OP_TIMEOUT,
+        )
+        candidate_result = candidate(
+            worktree=tmp_path,
+            task_id=task_id,
+            playbook=playbook,
+            seed=seed,
+        )
+    finally:
+        _cleanup_worktree(repo_root, tmp_path, subprocess_run=subprocess_run)
+
+    finished = float(clock())
+    result = candidate_result or {}
+    cost = result.get("cost") or {}
+    gate_results = result.get("gate_results") or {}
+    return {
+        "task_id": task_id,
+        "playbook": playbook,
+        "seed": int(seed),
+        "start_commit": start_commit,
+        "timestamps": {"started": started, "finished": finished},
+        "human_minutes": float(result.get("human_minutes", 0.0)),
+        "intervention_count": int(result.get("intervention_count", 0)),
+        "cost": {
+            "input_tokens": int(cost.get("input_tokens", 0)),
+            "output_tokens": int(cost.get("output_tokens", 0)),
+            "usd": float(cost.get("usd", 0.0)),
+        },
+        "gate_results": {
+            "hidden_test_gate": bool(gate_results.get("hidden_test_gate", False)),
+            "pytest_pass": bool(gate_results.get("pytest_pass", False)),
+            "regression_pass": bool(gate_results.get("regression_pass", False)),
+            "hard_gates": list(gate_results.get("hard_gates", [])),
+            "tier": gate_results.get("tier"),
+        },
+        "candidate_meta": {
+            "candidate": getattr(candidate, "__name__", "candidate"),
+            "applied_change": bool(result.get("applied_change", False)),
+        },
+    }
+
+
+def _cleanup_worktree(
+    repo_root: Path,
+    tmp_path: Path,
+    *,
+    subprocess_run: Callable[..., Any] = subprocess.run,
+) -> None:
+    """Best-effort teardown: ``worktree remove --force`` -> rmtree -> ``prune``."""
+
+    try:
+        subprocess_run(
+            ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(tmp_path)],
+            check=False,
+            capture_output=True,
+            timeout=_WORKTREE_OP_TIMEOUT,
+        )
+    except Exception:  # pragma: no cover - teardown must never raise
+        pass
+    if tmp_path.exists():
+        shutil.rmtree(tmp_path, ignore_errors=True)
+    try:
+        subprocess_run(
+            ["git", "-C", str(repo_root), "worktree", "prune"],
+            check=False,
+            capture_output=True,
+            timeout=_WORKTREE_OP_TIMEOUT,
+        )
+    except Exception:  # pragma: no cover - teardown must never raise
+        pass
+
+
+def write_run_log(run_log: dict[str, Any], *, runs_dir: Path) -> Path:
+    """Persist one run-log to ``runs_dir/<task_id>__<playbook>__seed<seed>.json``.
+
+    ``runs_dir`` defaults under ``agent-evals/runs/`` (GITIGNORED, deny-by-default)
+    so a run-log is never committed.  The directory is created if missing.
+    """
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    name = f"{run_log['task_id']}__{run_log['playbook']}__seed{run_log['seed']}.json"
+    out_path = runs_dir / name
+    out_path.write_text(json.dumps(run_log, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return out_path
+
+
+def run_matrix(
+    *,
+    tasks: Iterable[str],
+    start_commit: str,
+    repo_root: Path,
+    playbooks: Sequence[str] = DEFAULT_PLAYBOOKS,
+    seeds: Sequence[int] = DEFAULT_SEEDS,
+    candidate: Callable[..., dict[str, Any]] = stub_candidate,
+    clock: Callable[[], float] = _zero_clock,
+    subprocess_run: Callable[..., Any] = subprocess.run,
+    workdir_factory: Callable[..., str] = tempfile.mkdtemp,
+) -> list[dict[str, Any]]:
+    """Run the full (task x playbook x seed) matrix sequentially.
+
+    Sequential by design: one worktree exists at a time so concurrent disk usage
+    stays bounded.  Returns the list of run-log dicts (caller persists them).
+    """
+
+    run_logs: list[dict[str, Any]] = []
+    for task_id in tasks:
+        for playbook in playbooks:
+            for seed in seeds:
+                run_logs.append(
+                    run_one(
+                        start_commit=start_commit,
+                        task_id=task_id,
+                        playbook=playbook,
+                        seed=int(seed),
+                        candidate=candidate,
+                        repo_root=repo_root,
+                        clock=clock,
+                        subprocess_run=subprocess_run,
+                        workdir_factory=workdir_factory,
+                    )
+                )
+    return run_logs

--- a/agent-evals/adapters/bidmate/runner.py
+++ b/agent-evals/adapters/bidmate/runner.py
@@ -34,6 +34,12 @@ DEFAULT_PLAYBOOKS: tuple[str, ...] = ("v0_naive", "v1_spec_first")
 DEFAULT_SEEDS: tuple[int, ...] = (17, 18, 19)
 _WORKTREE_OP_TIMEOUT = 300
 
+# Name of the per-run manifest written alongside the run-logs in the GITIGNORED
+# runs dir. The report reads ONLY the files this manifest lists, so a later run
+# with a smaller task list or different seeds (same start_commit) cannot fold
+# stale logs from an earlier, differently-shaped matrix into the aggregate.
+RUN_MANIFEST_NAME = "run_manifest.json"
+
 
 def _zero_clock() -> float:
     """Deterministic default clock (tests override; never wall-clock at import)."""
@@ -175,6 +181,56 @@ def write_run_log(run_log: dict[str, Any], *, runs_dir: Path) -> Path:
     out_path = runs_dir / name
     out_path.write_text(json.dumps(run_log, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return out_path
+
+
+def write_run_manifest(
+    run_log_paths: Sequence[Path],
+    *,
+    runs_dir: Path,
+    start_commit: str,
+    tasks: Sequence[str],
+    playbooks: Sequence[str] = DEFAULT_PLAYBOOKS,
+    seeds: Sequence[int] = DEFAULT_SEEDS,
+) -> Path:
+    """Record EXACTLY which run-log files belong to the matrix just executed.
+
+    The report consumes only the basenames listed in ``run_logs`` (see
+    ``read_run_manifest``).  Because every run overwrites this single manifest, a
+    later run with a smaller task list or different seeds — which leaves the earlier
+    run's now-orphaned ``*.json`` files on disk under the same ``start_commit`` —
+    cannot silently inflate ``task_count`` / means / deltas: those orphans are no
+    longer listed, so the report skips them.  Lives in the GITIGNORED runs dir and
+    is never committed.  The extra ``start_commit``/``tasks``/``playbooks``/``seeds``
+    fields are provenance only; ``run_logs`` is authoritative.
+    """
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "run_logs": sorted(p.name for p in run_log_paths),
+        "start_commit": start_commit,
+        "tasks": list(tasks),
+        "playbooks": list(playbooks),
+        "seeds": [int(s) for s in seeds],
+    }
+    out_path = runs_dir / RUN_MANIFEST_NAME
+    out_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def read_run_manifest(runs_dir: Path) -> "dict[str, Any] | None":
+    """Return the run manifest dict, or ``None`` when the dir has no manifest.
+
+    ``None`` signals a legacy / hand-populated runs dir; the caller then falls back
+    to globbing (with the cross-commit guard as the safety net).
+    """
+
+    path = runs_dir / RUN_MANIFEST_NAME
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def run_matrix(

--- a/agent-evals/core/metrics.py
+++ b/agent-evals/core/metrics.py
@@ -12,6 +12,20 @@ from dataclasses import dataclass
 from typing import Iterable, Mapping
 
 
+# Minimum paired sample size below which a paired delta is reported as a
+# directional point estimate only — no bootstrap CI band. ADR 0100 forbids
+# absolute leaderboard claims; a CI on n<10 paired tasks would imply a precision
+# the surface does not have, so the report attaches an ``underpowered`` flag and
+# omits the band instead.
+N_MIN_DEFAULT = 10
+
+
+def underpowered(n: int, *, n_min: int = N_MIN_DEFAULT) -> bool:
+    """True iff ``n`` paired samples are below the CI-reporting floor ``n_min``."""
+
+    return n < n_min
+
+
 @dataclass(frozen=True)
 class PairedDelta:
     metric: str

--- a/agent-evals/core/oracle.py
+++ b/agent-evals/core/oracle.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Fail-closed verdict logic for the ADR 0100 operator-skill eval surface.
+
+This module is repo-agnostic and stdlib-only on purpose: the verdict decision is
+the load-bearing correctness contract of the surface, so it is kept fully
+unit-testable with no subprocess, numpy, RAG, eval, or api imports.  The BidMate
+adapter (``adapters/bidmate/oracle_bidmate.py``) is the only place that runs real
+gates / external reviewers and it feeds *already-sanitized* booleans into the
+functions here.
+
+Two independent privacy gates guard the ACCEPTED tier, and BOTH default to
+fail-closed — a missing, private, or same-family reviewer can never yield
+``ACCEPTED``:
+
+1. **Public-attestation egress gate.** Acceptance requires a cross-family
+   reviewer to actually see the candidate payload (issue + patch).  That payload
+   is private by default (ADR 0005), so it may only leave the boundary when the
+   operator has explicitly opted into public attestation.  When
+   ``public_attestation`` is False, ``decide_verdict`` can climb no higher than
+   ``NECESSARY_GATE_ONLY`` regardless of what reviewer object is passed in — the
+   egress never happened, so there is nothing valid to accept on.
+
+2. **Cross-family validity gate (ADR 0064).** Even with egress open, a reviewer
+   from the *same* model family as the candidate is a self-judge and is
+   neutralized: its verdict is discarded and the tier caps at
+   ``NECESSARY_GATE_ONLY``.  Only a genuinely cross-family reviewer's
+   ``accepted`` flag can move the tier to ``ACCEPTED`` (or, if it rejects, to
+   ``REJECTED_BY_REVIEWER``).
+
+The hard-gate and necessary-gate checks run *before* either privacy gate, so a
+build failure / secret leak / destructive change is rejected outright and a
+candidate that fails the hidden test / pytest / regression gates is rejected
+before acceptance is ever considered.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class HardGate(enum.Enum):
+    """Categorical non-recoverable failures that reject a candidate outright."""
+
+    BUILD_FAILURE = "build_failure"
+    SECRET_LEAK = "secret_leak"
+    DESTRUCTIVE = "destructive"
+    UNRELATED_REWRITE = "unrelated_rewrite"
+    INSTRUCTION_VIOLATION = "instruction_violation"
+    UNAUTHORIZED_MIGRATION = "unauthorized_migration"
+
+
+class VerdictTier(enum.Enum):
+    """Ordered outcome tiers for a single candidate run.
+
+    ``ACCEPTED`` is the only tier that counts as a solved task (see
+    ``is_accepted``).  ``NECESSARY_GATE_ONLY`` means the candidate passed every
+    objective necessary gate but could not earn acceptance because the
+    cross-family reviewer was unavailable, egress was closed, or the reviewer was
+    same-family — it is a fail-closed cap, not a success.
+    """
+
+    ACCEPTED = "accepted"
+    REJECTED_BY_REVIEWER = "rejected_by_reviewer"
+    NECESSARY_GATE_ONLY = "necessary_gate_only"
+    REJECTED_NECESSARY_GATE = "rejected_necessary_gate"
+    REJECTED_HARD_GATE = "rejected_hard_gate"
+
+
+@dataclass(frozen=True)
+class GateResults:
+    """Objective, already-evaluated gate outcomes for one candidate run.
+
+    Only booleans / categorical hard-gate members are carried here; raw command
+    output (stdout/stderr, diffs) is deliberately *not* part of this structure so
+    it can never reach a committed report.
+    """
+
+    hidden_test_gate: bool
+    pytest_pass: bool
+    regression_pass: bool
+    hard_gates: tuple[HardGate, ...] = ()
+
+
+@dataclass(frozen=True)
+class ReviewerVerdict:
+    """A cross-family reviewer's sanitized verdict.
+
+    ``reason_code`` is a SHORT enum-like token (for example ``ok``,
+    ``contract_violation``, ``missing_test``), NEVER free-form reviewer prose.
+    Keeping it a token is what lets the verdict travel into an aggregate report
+    without smuggling raw review text past the ADR 0005 boundary.
+    """
+
+    accepted: bool
+    reviewer_family: str
+    reason_code: str
+
+
+def _normalize_family(family: object) -> str:
+    """Canonicalize a model-family label for the self-judge comparison.
+
+    Family labels are expected to be short canonical tokens (``codex``,
+    ``claude``).  This collapses cosmetic variants — surrounding whitespace and
+    letter case — so that ``'Codex'``, ``' codex '`` and ``'codex'`` all compare
+    equal.
+
+    The canonical token is derived with the UNBOUND base ``str`` methods
+    (``str.lower(str.strip(family))``), NOT ``str(family)`` or
+    ``family.strip().lower()``.  A ``str`` *subclass* can override ``__str__`` /
+    ``strip`` / ``lower`` to return a spoofed value — e.g. a ``SpoofStr('codex')``
+    whose ``__str__`` returns ``'claude'`` — which would make a same-family label
+    read as cross-family and slip past the self-judge gate.  The unbound base
+    methods operate on the real character buffer and ignore any subclass override,
+    so the real value (``'codex'``) is always used.  Non-``str`` input (already
+    rejected upstream by ``_is_valid_family``) normalizes to ``''`` defensively.
+    Alias / substring and unicode-homoglyph matching are intentionally OUT OF
+    SCOPE: only exact post-normalization equality counts (labels are trusted
+    canonical tokens, not attacker free-text).
+    """
+
+    if not isinstance(family, str):
+        return ""
+    return str.lower(str.strip(family))
+
+
+def _is_same_family(reviewer_family: object, candidate_family: object) -> bool:
+    """True iff the two family labels are the same after normalization."""
+
+    return _normalize_family(reviewer_family) == _normalize_family(candidate_family)
+
+
+def _is_valid_family(family: object) -> bool:
+    """True iff ``family`` is a usable canonical family label.
+
+    Family labels are TRUSTED internal tokens set by the harness / adapter (never
+    candidate-controlled free text), so this is a robustness guard against a
+    MISCONFIGURED caller, not an adversarial-input filter.  A valid label must be a
+    ``str`` that is non-empty after stripping.  A non-``str`` label is rejected
+    rather than ``str()``-coerced, because coercing e.g. ``b'codex'`` yields the
+    repr ``"b'codex'"`` which would spuriously read as cross-family and bypass the
+    same-family self-judge gate.  Unicode-homoglyph / alias matching is out of
+    scope (labels are canonical tokens, not attacker text).
+    """
+
+    # Unbound base ``str.strip`` so a subclass that overrides ``strip`` cannot
+    # spoof emptiness; see _normalize_family for the full rationale.
+    return isinstance(family, str) and str.strip(family) != ""
+
+
+def decide_verdict(
+    gates: GateResults,
+    reviewer: "ReviewerVerdict | None",
+    *,
+    candidate_family: str,
+    public_attestation: bool,
+) -> VerdictTier:
+    """Map gate + reviewer state to a verdict tier with a fixed, fail-closed order.
+
+    The decision table is evaluated top to bottom; the first matching rule wins:
+
+    1. any hard gate  -> ``REJECTED_HARD_GATE``
+    2. any necessary gate not strictly ``True`` -> ``REJECTED_NECESSARY_GATE``
+    3. necessary gates all pass; acceptance needs a VALID cross-family reviewer:
+       a. egress not strictly opened (``public_attestation is not True``)
+          -> ``NECESSARY_GATE_ONLY``
+       b. reviewer is ``None`` (unavailable/skipped)  -> ``NECESSARY_GATE_ONLY``
+       c. same-family reviewer (ADR 0064 self-judge)  -> ``NECESSARY_GATE_ONLY``
+       d. cross-family reviewer did not strictly accept -> ``REJECTED_BY_REVIEWER``
+       e. cross-family reviewer strictly accepted -> ``ACCEPTED``
+
+    Every gate that could OPEN the path to ``ACCEPTED`` is checked with a strict
+    ``is True`` (or an explicit family match), never Python truthiness.  This is
+    deliberate: the gate / attestation / accepted fields are *typed* as booleans,
+    but a malformed caller that passes a truthy non-bool (e.g. the string
+    ``"false"``) must not be able to slip past a necessary or privacy gate.
+    Truthiness here would be fail-OPEN; ``is True`` keeps every opener fail-closed.
+    """
+
+    # Any TRUTHY hard_gates value rejects outright — a real ``(HardGate.…,)`` tuple,
+    # or even a malformed truthy value (fail closed). Only a FALSY value (the
+    # default ``()``, or None / 0 / False) means "no hard gate detected", which is
+    # the clean common case and correctly falls through to the gates below.
+    if gates.hard_gates:
+        return VerdictTier.REJECTED_HARD_GATE
+    necessary_gates_pass = (
+        gates.hidden_test_gate is True
+        and gates.pytest_pass is True
+        and gates.regression_pass is True
+    )
+    if not necessary_gates_pass:
+        return VerdictTier.REJECTED_NECESSARY_GATE
+    # Necessary gates all pass — now the two fail-closed privacy gates. Each
+    # opener requires a STRICT True / explicit cross-family match so a non-bool
+    # or cosmetic-variant value can never fail open into ``ACCEPTED``.
+    if public_attestation is not True:
+        # Egress gate closed unless strictly opted into: the payload may not
+        # leave the boundary, so no cross-family reviewer could have seen it and
+        # acceptance is barred.
+        return VerdictTier.NECESSARY_GATE_ONLY
+    if reviewer is None:
+        # Reviewer unavailable/skipped — fail closed, never accept on absence.
+        return VerdictTier.NECESSARY_GATE_ONLY
+    if not (_is_valid_family(reviewer.reviewer_family) and _is_valid_family(candidate_family)):
+        # A valid cross-family reviewer needs BOTH labels to be usable canonical
+        # strings. A non-str label (e.g. bytes ``b'codex'``, whose ``str()`` is the
+        # repr ``"b'codex'"``) or an empty/whitespace label cannot establish
+        # cross-family validity, so fail closed rather than let it read as
+        # "different" and slip past the same-family self-judge gate.
+        return VerdictTier.NECESSARY_GATE_ONLY
+    if _is_same_family(reviewer.reviewer_family, candidate_family):
+        # Same-family self-judge is invalid (ADR 0064): neutralize the verdict.
+        # The comparison is case/whitespace-insensitive so a cosmetic variant
+        # such as 'Codex' cannot bypass a 'codex' candidate's self-judge gate.
+        return VerdictTier.NECESSARY_GATE_ONLY
+    if reviewer.accepted is True:
+        return VerdictTier.ACCEPTED
+    # Reviewer present and cross-family but did not strictly accept (an explicit
+    # rejection, or a malformed non-True ``accepted`` flag) — fail closed to a
+    # reviewer rejection rather than letting a truthy non-bool reach ACCEPTED.
+    return VerdictTier.REJECTED_BY_REVIEWER
+
+
+def is_accepted(tier: VerdictTier) -> bool:
+    """True iff ``tier`` is the single success tier (``ACCEPTED``)."""
+
+    return tier is VerdictTier.ACCEPTED

--- a/agent-evals/core/report.py
+++ b/agent-evals/core/report.py
@@ -37,9 +37,9 @@ _MAX_DATA_STRING_LEN = 512
 _ALLOWED_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^agent-evals/README\.md\Z"),
     re.compile(r"^agent-evals/core/__init__\.py\Z"),
-    re.compile(r"^agent-evals/core/(schema|metrics|report)\.py\Z"),
+    re.compile(r"^agent-evals/core/(schema|metrics|report|oracle)\.py\Z"),
     re.compile(r"^agent-evals/adapters/bidmate/__init__\.py\Z"),
-    re.compile(r"^agent-evals/adapters/bidmate/task_mining\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/(task_mining|runner|oracle_bidmate)\.py\Z"),
     re.compile(r"^agent-evals/playbooks/v(0_naive|1_spec_first)\.md\Z"),
     re.compile(r"^agent-evals/splits\.yaml\Z"),
     re.compile(r"^agent-evals/tasks/[A-Za-z0-9_.-]+/task\.yaml\Z"),
@@ -184,6 +184,15 @@ _ALLOWED_NESTED_KEYS = frozenset(
         "path_allowlist",
         "train",
         "holdout",
+        # PR3 paired-CI extension on metric rows: an underpowered (n<n_min) row
+        # carries only ``underpowered``; a powered row additionally carries the
+        # bootstrap band (``ci_lo``/``ci_hi``) plus its provenance
+        # (``num_resamples``/``alpha``). All numeric/bool — never raw prose.
+        "underpowered",
+        "ci_lo",
+        "ci_hi",
+        "num_resamples",
+        "alpha",
     }
 )
 

--- a/agent-evals/reports/holdout-v0-vs-v1.aggregate.json
+++ b/agent-evals/reports/holdout-v0-vs-v1.aggregate.json
@@ -22,8 +22,8 @@
       "delta": 0.0,
       "losses": 0,
       "metric": "cost_per_accepted",
-      "n": 3,
-      "ties": 3,
+      "n": 1,
+      "ties": 1,
       "underpowered": true,
       "wins": 0
     },
@@ -48,8 +48,8 @@
       "delta": 0.0,
       "losses": 0,
       "metric": "human_min_per_accepted",
-      "n": 3,
-      "ties": 3,
+      "n": 1,
+      "ties": 1,
       "underpowered": true,
       "wins": 0
     }

--- a/agent-evals/reports/holdout-v0-vs-v1.aggregate.json
+++ b/agent-evals/reports/holdout-v0-vs-v1.aggregate.json
@@ -1,0 +1,78 @@
+{
+  "generated_by": "scripts/agent_evals_report.py",
+  "metrics": {
+    "accepted_solve_rate": {
+      "baseline": "v0_naive",
+      "baseline_mean": 0.333333,
+      "candidate": "v1_spec_first",
+      "candidate_mean": 1.0,
+      "delta": 0.666667,
+      "losses": 0,
+      "metric": "accepted_solve_rate",
+      "n": 3,
+      "ties": 1,
+      "underpowered": true,
+      "wins": 2
+    },
+    "cost_per_accepted": {
+      "baseline": "v0_naive",
+      "baseline_mean": 0.0,
+      "candidate": "v1_spec_first",
+      "candidate_mean": 0.0,
+      "delta": 0.0,
+      "losses": 0,
+      "metric": "cost_per_accepted",
+      "n": 3,
+      "ties": 3,
+      "underpowered": true,
+      "wins": 0
+    },
+    "difficulty_weighted_rate": {
+      "baseline": "v0_naive",
+      "baseline_mean": 0.333333,
+      "candidate": "v1_spec_first",
+      "candidate_mean": 1.0,
+      "delta": 0.666667,
+      "losses": 0,
+      "metric": "difficulty_weighted_rate",
+      "n": 3,
+      "ties": 1,
+      "underpowered": true,
+      "wins": 2
+    },
+    "human_min_per_accepted": {
+      "baseline": "v0_naive",
+      "baseline_mean": 0.0,
+      "candidate": "v1_spec_first",
+      "candidate_mean": 0.0,
+      "delta": 0.0,
+      "losses": 0,
+      "metric": "human_min_per_accepted",
+      "n": 3,
+      "ties": 3,
+      "underpowered": true,
+      "wins": 0
+    }
+  },
+  "notes": [
+    "UNDERPOWERED N=3",
+    "stub candidate + stub reviewer; no external egress",
+    "directional paired signal, not absolute leaderboard",
+    "aggregate counts only",
+    "seeds: 17, 18, 19",
+    "n_min=10",
+    "ci source: eval.bootstrap"
+  ],
+  "playbooks": {
+    "baseline": "v0_naive",
+    "candidate": "v1_spec_first"
+  },
+  "report_id": "holdout-v0-vs-v1",
+  "scanner": {
+    "content_scan": "pass",
+    "path_allowlist": "PR3"
+  },
+  "schema_version": 1,
+  "surface": "agent-evals-pr3",
+  "task_count": 3
+}

--- a/scripts/agent_evals_report.py
+++ b/scripts/agent_evals_report.py
@@ -85,10 +85,39 @@ def _load_paired_bootstrap_ci() -> tuple[Callable[..., Any], str]:
 
 
 def _read_run_logs(runs_dir: Path) -> list[dict[str, Any]]:
-    logs: list[dict[str, Any]] = []
-    for path in sorted(runs_dir.glob("*.json")):
-        logs.append(json.loads(path.read_text(encoding="utf-8")))
-    return logs
+    """Read the CURRENT run's logs from ``runs_dir``.
+
+    When ``agent_evals_run.py`` wrote a ``run_manifest.json``, read ONLY the files
+    it lists: a later run with a smaller task list or different seeds overwrites the
+    manifest, so the now-orphaned logs from the earlier matrix (same ``start_commit``,
+    which ``build_report``'s guard cannot catch) are skipped instead of silently
+    inflating the aggregate. Without a manifest (legacy / hand-populated dir) fall
+    back to globbing every ``*.json`` — excluding the manifest file itself — and rely
+    on the cross-commit guard in ``build_report`` as the remaining safety net.
+    """
+
+    runner = load_module(
+        "agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_for_report"
+    )
+    manifest = runner.read_run_manifest(runs_dir)
+    if manifest is not None:
+        names = manifest.get("run_logs") or []
+        missing = [name for name in names if not (runs_dir / name).exists()]
+        if missing:
+            preview = missing[:3]
+            raise FileNotFoundError(
+                f"run_manifest.json lists {len(missing)} run-log(s) not on disk "
+                f"({preview}{'...' if len(missing) > 3 else ''}); the runs dir is "
+                "inconsistent — re-run scripts/agent_evals_run.py."
+            )
+        return [
+            json.loads((runs_dir / name).read_text(encoding="utf-8")) for name in names
+        ]
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(runs_dir.glob("*.json"))
+        if path.name != runner.RUN_MANIFEST_NAME
+    ]
 
 
 def _is_accepted(run_log: dict[str, Any]) -> bool:

--- a/scripts/agent_evals_report.py
+++ b/scripts/agent_evals_report.py
@@ -102,8 +102,16 @@ def _per_task_playbook(logs: list[dict[str, Any]]) -> dict[tuple[str, str], list
     return grouped
 
 
-def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float:
-    """Compute one (task, playbook) metric value from its seed runs (safe denom)."""
+def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float | None:
+    """Compute one (task, playbook) metric value from its seed runs.
+
+    Returns ``None`` when the metric is UNDEFINED for this group — specifically the
+    per-accepted cost / human-minute metrics when nothing was accepted. Returning
+    ``0.0`` there would make a zero-solve playbook look *cheapest* (best), inverting
+    the cost metric: a baseline that solves nothing would tie or beat a candidate
+    that solves at nonzero cost. An undefined value is dropped from the paired
+    sample (see ``_paired_rows``) rather than scored as free.
+    """
 
     n_runs = len(runs)
     accepted_runs = [r for r in runs if _is_accepted(r)]
@@ -115,11 +123,11 @@ def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float:
         return ((n_accepted / n_runs) * weight) if n_runs else 0.0
     if metric == "human_min_per_accepted":
         if n_accepted == 0:
-            return 0.0  # safe denom: never divide by zero accepted
+            return None  # undefined: no accepted run to amortize human-minutes over
         return sum(float(r.get("human_minutes", 0.0)) for r in accepted_runs) / n_accepted
     if metric == "cost_per_accepted":
         if n_accepted == 0:
-            return 0.0  # safe denom: never divide by zero accepted
+            return None  # undefined: no accepted run to amortize cost over
         return sum(float(r.get("cost", {}).get("usd", 0.0)) for r in accepted_runs) / n_accepted
     raise ValueError(f"unknown metric: {metric}")
 
@@ -131,12 +139,14 @@ def _paired_rows(metric: str, grouped, task_ids: list[str]) -> list[dict[str, fl
         cand_runs = grouped.get((task_id, CANDIDATE_PLAYBOOK))
         if not base_runs or not cand_runs:
             continue  # a task missing either playbook cannot form a paired row
-        rows.append(
-            {
-                "v0": _metric_value(metric, base_runs),
-                "v1": _metric_value(metric, cand_runs),
-            }
-        )
+        v0 = _metric_value(metric, base_runs)
+        v1 = _metric_value(metric, cand_runs)
+        if v0 is None or v1 is None:
+            # Metric undefined for one side (e.g. zero-accepted cost_per_accepted):
+            # a paired delta is only meaningful when both sides are defined, so drop
+            # this task from THIS metric's sample rather than scoring it as 0.0.
+            continue
+        rows.append({"v0": v0, "v1": v1})
     return rows
 
 
@@ -151,11 +161,27 @@ def build_report(
     metrics_mod = load_module("agent-evals/core/metrics.py", "agent_evals_metrics_report")
     paired_bootstrap_ci, ci_provenance = _load_paired_bootstrap_ci()
 
+    # Fail loud on a dirty runs directory: the gitignored runs dir is read whole
+    # (every *.json), and the run script overwrites only the current matrix's
+    # filenames — it never clears older files. If logs from a DIFFERENT start_commit
+    # are still present, folding them into one aggregate would silently corrupt
+    # task_count / means / deltas (comparing measurements taken at different code
+    # states). Refuse rather than corrupt; the operator should report from a fresh
+    # --runs-dir per matrix. (Same-commit stale tasks remain valid measurements at
+    # that commit and are not blocked here.)
+    start_commits = sorted({log["start_commit"] for log in logs if log.get("start_commit")})
+    if len(start_commits) > 1:
+        raise ValueError(
+            "run-logs span multiple start_commit values "
+            f"({start_commits}); stale logs would corrupt the aggregate. "
+            "Use a fresh --runs-dir for a clean matrix, or remove stale logs."
+        )
+
     grouped = _per_task_playbook(logs)
     task_ids = sorted({task_id for (task_id, _playbook) in grouped})
 
     metrics_block: dict[str, Any] = {}
-    n_for_notes = 0
+    n_by_metric: dict[str, int] = {}
     for metric in CORE_METRICS:
         rows = _paired_rows(metric, grouped, task_ids)
         if not rows:
@@ -169,7 +195,7 @@ def build_report(
             candidate_name=CANDIDATE_PLAYBOOK,
         )
         row_mapping = delta.to_mapping()
-        n_for_notes = delta.n
+        n_by_metric[metric] = delta.n
         if metrics_mod.underpowered(delta.n):
             row_mapping["underpowered"] = True
         else:
@@ -193,6 +219,11 @@ def build_report(
                 row_mapping["underpowered"] = True
         metrics_block[metric] = row_mapping
 
+    # Headline N reflects the PRIMARY metric (accepted_solve_rate). The per-accepted
+    # cost / human-minute metrics can have a SMALLER n after dropping zero-accepted
+    # tasks (P3), so they must not set the headline sample size; each metric row
+    # still carries its own ``n``.
+    n_for_notes = n_by_metric.get("accepted_solve_rate", 0)
     notes = [
         f"UNDERPOWERED N={n_for_notes}" if metrics_mod.underpowered(n_for_notes) else f"N={n_for_notes}",
         "stub candidate + stub reviewer; no external egress",

--- a/scripts/agent_evals_report.py
+++ b/scripts/agent_evals_report.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Aggregate agent-evals run-logs into a paired v0-vs-v1 report.
+
+Lives in ``scripts/`` (ordinary tooling, not under the agent-evals allowlist). It
+reads GITIGNORED run-logs, builds per-task paired rows (baseline ``v0_naive`` vs
+candidate ``v1_spec_first``) for four core metrics, and writes a committable
+aggregate report through ``core.report.write_aggregate_report`` — which re-runs the
+content scanner and raises if anything fails, so a successful write is the
+correctness check.
+
+Metrics (per task, aggregated across seeds):
+
+* ``accepted_solve_rate`` — fraction of seeds whose verdict tier is ``ACCEPTED``.
+* ``difficulty_weighted_rate`` — accepted rate scaled by the task difficulty
+  weight (smoke tasks default to weight 1.0).
+* ``human_min_per_accepted`` — total human-minutes / accepted count (0.0 when no
+  accepted run, never a divide-by-zero).
+* ``cost_per_accepted`` — total USD / accepted count (0.0 when no accepted run).
+
+For each metric the point estimate is ``core.metrics.paired_delta``. If the paired
+sample is NOT underpowered (n >= n_min) a paired bootstrap CI is attached
+(``ci_lo``/``ci_hi``/``num_resamples``/``alpha``); if it IS underpowered the row
+carries ``underpowered: true`` and OMITS the band — ADR 0100 forbids implying a
+precision the surface lacks.
+
+CI computation reuses ``eval.bootstrap.paired_bootstrap_ci`` (numpy). If the
+``eval`` package import fails, this script falls back to a path-load of
+``eval/bootstrap.py`` and reports the fallback rather than silently skipping the CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACCEPTED_TIER = "ACCEPTED"
+BASELINE_PLAYBOOK = "v0_naive"
+CANDIDATE_PLAYBOOK = "v1_spec_first"
+DEFAULT_SEEDS = (17, 18, 19)
+CORE_METRICS = (
+    "accepted_solve_rate",
+    "difficulty_weighted_rate",
+    "human_min_per_accepted",
+    "cost_per_accepted",
+)
+
+
+def load_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_paired_bootstrap_ci() -> tuple[Callable[..., Any], str]:
+    """Return ``(paired_bootstrap_ci, provenance)``; path-load fallback if needed.
+
+    The preferred path is the package import ``from eval.bootstrap import ...``;
+    REPO_ROOT is put on ``sys.path`` first so the package import resolves even when
+    the script is launched with ``sys.path[0]`` pointing at ``scripts/``. If the
+    package import still fails (e.g. ``eval`` shadowed or numpy missing inside it),
+    fall back to a direct path-load of ``eval/bootstrap.py`` and report the
+    fallback explicitly rather than silently skipping the CI computation.
+    """
+
+    repo_root_str = str(REPO_ROOT)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+    try:
+        from eval.bootstrap import paired_bootstrap_ci  # type: ignore
+
+        return paired_bootstrap_ci, "eval.bootstrap"
+    except Exception:
+        module = load_module("eval/bootstrap.py", "agent_evals_bootstrap_fallback")
+        return module.paired_bootstrap_ci, "eval/bootstrap.py (path-load fallback)"
+
+
+def _read_run_logs(runs_dir: Path) -> list[dict[str, Any]]:
+    logs: list[dict[str, Any]] = []
+    for path in sorted(runs_dir.glob("*.json")):
+        logs.append(json.loads(path.read_text(encoding="utf-8")))
+    return logs
+
+
+def _is_accepted(run_log: dict[str, Any]) -> bool:
+    return run_log.get("gate_results", {}).get("tier") == ACCEPTED_TIER
+
+
+def _per_task_playbook(logs: list[dict[str, Any]]) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for log in logs:
+        grouped.setdefault((log["task_id"], log["playbook"]), []).append(log)
+    return grouped
+
+
+def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float:
+    """Compute one (task, playbook) metric value from its seed runs (safe denom)."""
+
+    n_runs = len(runs)
+    accepted_runs = [r for r in runs if _is_accepted(r)]
+    n_accepted = len(accepted_runs)
+    if metric == "accepted_solve_rate":
+        return (n_accepted / n_runs) if n_runs else 0.0
+    if metric == "difficulty_weighted_rate":
+        weight = float(runs[0].get("difficulty_weight", 1.0)) if runs else 1.0
+        return ((n_accepted / n_runs) * weight) if n_runs else 0.0
+    if metric == "human_min_per_accepted":
+        if n_accepted == 0:
+            return 0.0  # safe denom: never divide by zero accepted
+        return sum(float(r.get("human_minutes", 0.0)) for r in accepted_runs) / n_accepted
+    if metric == "cost_per_accepted":
+        if n_accepted == 0:
+            return 0.0  # safe denom: never divide by zero accepted
+        return sum(float(r.get("cost", {}).get("usd", 0.0)) for r in accepted_runs) / n_accepted
+    raise ValueError(f"unknown metric: {metric}")
+
+
+def _paired_rows(metric: str, grouped, task_ids: list[str]) -> list[dict[str, float]]:
+    rows: list[dict[str, float]] = []
+    for task_id in task_ids:
+        base_runs = grouped.get((task_id, BASELINE_PLAYBOOK))
+        cand_runs = grouped.get((task_id, CANDIDATE_PLAYBOOK))
+        if not base_runs or not cand_runs:
+            continue  # a task missing either playbook cannot form a paired row
+        rows.append(
+            {
+                "v0": _metric_value(metric, base_runs),
+                "v1": _metric_value(metric, cand_runs),
+            }
+        )
+    return rows
+
+
+def build_report(
+    logs: list[dict[str, Any]],
+    *,
+    report_id: str,
+    num_resamples: int,
+    alpha: float,
+    seed: int,
+) -> dict[str, Any]:
+    metrics_mod = load_module("agent-evals/core/metrics.py", "agent_evals_metrics_report")
+    paired_bootstrap_ci, ci_provenance = _load_paired_bootstrap_ci()
+
+    grouped = _per_task_playbook(logs)
+    task_ids = sorted({task_id for (task_id, _playbook) in grouped})
+
+    metrics_block: dict[str, Any] = {}
+    n_for_notes = 0
+    for metric in CORE_METRICS:
+        rows = _paired_rows(metric, grouped, task_ids)
+        if not rows:
+            continue
+        delta = metrics_mod.paired_delta(
+            rows,
+            baseline_key="v0",
+            candidate_key="v1",
+            metric=metric,
+            baseline_name=BASELINE_PLAYBOOK,
+            candidate_name=CANDIDATE_PLAYBOOK,
+        )
+        row_mapping = delta.to_mapping()
+        n_for_notes = delta.n
+        if metrics_mod.underpowered(delta.n):
+            row_mapping["underpowered"] = True
+        else:
+            # Arg order is (candidate, baseline) so the CI band is on
+            # candidate - baseline, matching paired_delta's delta sign
+            # (candidate_mean - baseline_mean). eval.bootstrap.paired_bootstrap_ci
+            # computes mean(a) - mean(b), so a=v1 (candidate), b=v0 (baseline).
+            ci = paired_bootstrap_ci(
+                [r["v1"] for r in rows],
+                [r["v0"] for r in rows],
+                num_resamples=num_resamples,
+                alpha=alpha,
+                seed=seed,
+            )
+            if ci is not None:
+                row_mapping["ci_lo"] = round(float(ci["ci_lo"]), 6)
+                row_mapping["ci_hi"] = round(float(ci["ci_hi"]), 6)
+                row_mapping["num_resamples"] = int(ci["num_resamples"])
+                row_mapping["alpha"] = float(ci["alpha"])
+            else:
+                row_mapping["underpowered"] = True
+        metrics_block[metric] = row_mapping
+
+    notes = [
+        f"UNDERPOWERED N={n_for_notes}" if metrics_mod.underpowered(n_for_notes) else f"N={n_for_notes}",
+        "stub candidate + stub reviewer; no external egress",
+        "directional paired signal, not absolute leaderboard",
+        "aggregate counts only",
+        f"seeds: {', '.join(str(s) for s in DEFAULT_SEEDS)}",
+        f"n_min={metrics_mod.N_MIN_DEFAULT}",
+        f"ci source: {ci_provenance}",
+    ]
+
+    return {
+        "schema_version": 1,
+        "surface": "agent-evals-pr3",
+        "report_id": report_id,
+        "generated_by": "scripts/agent_evals_report.py",
+        "task_count": len(task_ids),
+        "playbooks": {"baseline": BASELINE_PLAYBOOK, "candidate": CANDIDATE_PLAYBOOK},
+        "metrics": metrics_block,
+        "scanner": {"content_scan": "pass", "path_allowlist": "PR3"},
+        "notes": notes,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runs-dir",
+        default=str(REPO_ROOT / "agent-evals" / "runs"),
+        help="GITIGNORED run-log dir (default: agent-evals/runs)",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(REPO_ROOT / "agent-evals" / "reports" / "holdout-v0-vs-v1.aggregate.json"),
+        help="committable aggregate report path",
+    )
+    parser.add_argument("--report-id", default="holdout-v0-vs-v1")
+    parser.add_argument("--num-resamples", type=int, default=1000)
+    parser.add_argument("--alpha", type=float, default=0.05)
+    parser.add_argument("--seed", type=int, default=17)
+    args = parser.parse_args(argv)
+
+    report_mod = load_module("agent-evals/core/report.py", "agent_evals_report_writer")
+    logs = _read_run_logs(Path(args.runs_dir))
+    if not logs:
+        parser.error(f"no run-logs found under {args.runs_dir} — run scripts/agent_evals_run.py first")
+
+    report = build_report(
+        logs,
+        report_id=args.report_id,
+        num_resamples=args.num_resamples,
+        alpha=args.alpha,
+        seed=args.seed,
+    )
+    out_path = Path(args.out)
+    rel_path = out_path.resolve().relative_to(REPO_ROOT).as_posix()
+    # write_aggregate_report uses its path argument for BOTH scanner validation
+    # (as a repo-relative string) and the on-disk write (relative to CWD). Pass the
+    # repo-relative path and run the write from REPO_ROOT so it is correct
+    # regardless of the process's invocation directory.
+    prev_cwd = Path.cwd()
+    os.chdir(REPO_ROOT)
+    try:
+        report_mod.write_aggregate_report(Path(rel_path), report)
+    finally:
+        os.chdir(prev_cwd)
+    print(f"wrote aggregate report to {rel_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_evals_run.py
+++ b/scripts/agent_evals_run.py
@@ -144,6 +144,15 @@ def run(
             run_log, oracle, public_attestation=public_attestation
         )
         written.append(runner.write_run_log(run_log, runs_dir=runs_dir))
+    # Record exactly which logs this matrix produced so the report scopes to THIS
+    # run and never folds in orphaned logs from an earlier, differently-shaped
+    # matrix (smaller task list / changed seeds at the same start_commit).
+    runner.write_run_manifest(
+        written,
+        runs_dir=runs_dir,
+        start_commit=start_commit,
+        tasks=tasks,
+    )
     return written
 
 

--- a/scripts/agent_evals_run.py
+++ b/scripts/agent_evals_run.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Orchestrate the agent-evals paired playbook matrix over holdout tasks.
+
+This CLI lives in ``scripts/`` (NOT under ``agent-evals/``) so it is not subject
+to the agent-evals deny-by-default gitignore / commit allowlist; it is ordinary
+repository tooling.  It loads the path-restricted agent-evals modules by file path
+(mirroring ``tests/test_agent_evals_core.py``'s ``load_module``) because the
+``agent-evals`` directory name is not an importable Python package.
+
+The default candidate is a built-in DETERMINISTIC STUB: it applies no repository
+change and returns fixed all-pass gate booleans.  ``--real`` is reserved for the
+real coding-agent invocation and is intentionally left as a clearly-marked stub
+(``NotImplementedError``) for now — wiring a live agent is a later PR.
+
+Verdicts are computed at run time through ``oracle.decide_verdict`` using the two
+fail-closed privacy gates:
+
+* ``--public-attestation`` opens the egress gate so a cross-family reviewer may be
+  consulted (without it, every run caps at NECESSARY_GATE_ONLY by construction).
+* the reviewer here is a deterministic STUB cross-family reviewer (no external
+  egress actually happens); it is the harness stand-in described in the report
+  notes, NOT a real model call.
+
+Run-logs are written to the GITIGNORED runs dir (``agent-evals/runs/`` by
+default), so no per-run artifact is ever committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Candidate family for the stub pipeline. The stub reviewer below is a different
+# (synthetic) family so the cross-family validity gate (ADR 0064) is satisfied and
+# acceptance is reachable in the smoke surface.
+STUB_CANDIDATE_FAMILY = "stub_candidate_family"
+STUB_REVIEWER_FAMILY = "stub_reviewer_family"
+SMOKE_HOLDOUT_TASKS = ("T-smoke-001", "T-smoke-002", "T-smoke-003")
+
+
+def load_module(rel_path: str, name: str):
+    """Load an agent-evals module by repo-relative path (hyphenated dir)."""
+
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub_cross_family_reviewer(*, playbook: str, task_id: str, seed: int) -> tuple[bool, str]:
+    """Deterministic stand-in for a real cross-family reviewer (NO external egress).
+
+    Encodes a modest, honest directional signal so the smoke report is not inert:
+    the spec-first playbook (``v1_spec_first``) is accepted on every holdout task,
+    while the naive playbook (``v0_naive``) is rejected on a deterministic subset.
+    This is a STUB verdict, clearly labelled in the report notes — not a measured
+    operator-skill result.
+    """
+
+    if playbook == "v1_spec_first":
+        return True, "ok"
+    # v0_naive: reject on tasks whose trailing id digit is odd (deterministic),
+    # accept otherwise — yields a non-trivial paired delta without claiming truth.
+    trailing = "".join(ch for ch in task_id if ch.isdigit())[-1:] or "0"
+    if int(trailing) % 2 == 1:
+        return False, "naive_contract_gap"
+    return True, "ok"
+
+
+def _verdict_for_run(run_log: dict[str, Any], oracle, *, public_attestation: bool) -> str:
+    """Compute and return the verdict tier name for one stub run-log."""
+
+    gr = run_log["gate_results"]
+    hard = tuple(gr.get("hard_gates", ()))
+    gates = oracle.GateResults(
+        hidden_test_gate=bool(gr.get("hidden_test_gate", False)),
+        pytest_pass=bool(gr.get("pytest_pass", False)),
+        regression_pass=bool(gr.get("regression_pass", False)),
+        hard_gates=hard,
+    )
+    reviewer = None
+    if public_attestation:
+        accepted, reason_code = _stub_cross_family_reviewer(
+            playbook=run_log["playbook"],
+            task_id=run_log["task_id"],
+            seed=run_log["seed"],
+        )
+        reviewer = oracle.ReviewerVerdict(
+            accepted=accepted,
+            reviewer_family=STUB_REVIEWER_FAMILY,
+            reason_code=reason_code,
+        )
+    tier = oracle.decide_verdict(
+        gates,
+        reviewer,
+        candidate_family=STUB_CANDIDATE_FAMILY,
+        public_attestation=public_attestation,
+    )
+    return tier.name
+
+
+def _real_candidate(*, worktree: Path, task_id: str, playbook: str, seed: int) -> dict[str, Any]:
+    """Reserved real coding-agent invocation — intentionally not implemented yet."""
+
+    raise NotImplementedError(
+        "the --real candidate (live coding-agent invocation) is a later PR; "
+        "use the default stub candidate for the smoke surface"
+    )
+
+
+def run(
+    *,
+    tasks: tuple[str, ...],
+    start_commit: str,
+    runs_dir: Path,
+    public_attestation: bool,
+    use_real: bool,
+    subprocess_run: Callable[..., Any] = subprocess.run,
+) -> list[Path]:
+    """Run the matrix and persist one run-log per (task, playbook, seed)."""
+
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_cli")
+    oracle = load_module("agent-evals/core/oracle.py", "agent_evals_oracle_cli")
+
+    candidate = _real_candidate if use_real else runner.stub_candidate
+    run_logs = runner.run_matrix(
+        tasks=tasks,
+        start_commit=start_commit,
+        repo_root=REPO_ROOT,
+        candidate=candidate,
+        subprocess_run=subprocess_run,
+    )
+    written: list[Path] = []
+    for run_log in run_logs:
+        run_log["gate_results"]["tier"] = _verdict_for_run(
+            run_log, oracle, public_attestation=public_attestation
+        )
+        written.append(runner.write_run_log(run_log, runs_dir=runs_dir))
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks",
+        nargs="*",
+        default=list(SMOKE_HOLDOUT_TASKS),
+        help="holdout task ids (default: the 3 smoke tasks)",
+    )
+    parser.add_argument(
+        "--start-commit",
+        default=None,
+        help="detached worktree start commit (default: current HEAD)",
+    )
+    parser.add_argument(
+        "--runs-dir",
+        default=str(REPO_ROOT / "agent-evals" / "runs"),
+        help="GITIGNORED output dir for run-logs (default: agent-evals/runs)",
+    )
+    parser.add_argument(
+        "--public-attestation",
+        action="store_true",
+        help="open the egress gate so the stub cross-family reviewer can accept",
+    )
+    parser.add_argument(
+        "--real",
+        action="store_true",
+        help="select the real coding-agent candidate (NotImplemented stub for now)",
+    )
+    args = parser.parse_args(argv)
+
+    start_commit = args.start_commit
+    if start_commit is None:
+        proc = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        start_commit = proc.stdout.strip()
+
+    written = run(
+        tasks=tuple(args.tasks),
+        start_commit=start_commit,
+        runs_dir=Path(args.runs_dir),
+        public_attestation=args.public_attestation,
+        use_real=args.real,
+    )
+    print(f"wrote {len(written)} run-log(s) to {args.runs_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -48,12 +50,36 @@ def test_paired_delta_rejects_empty_input() -> None:
         raise AssertionError("paired_delta accepted an empty same-task set")
 
 
+def _is_gitignored(rel_path: str) -> bool:
+    """True iff git ignores ``rel_path`` by pattern (ephemeral, non-committable)."""
+
+    result = subprocess.run(
+        ["git", "check-ignore", "--no-index", "--quiet", "--", rel_path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode in (0, 1), (
+        f"git check-ignore failed for {rel_path} (rc={result.returncode}); treat as failure."
+    )
+    return result.returncode == 0
+
+
 def test_scanner_accepts_current_pr2_surface_files() -> None:
     report = load_module("agent-evals/core/report.py", "agent_evals_report_accept_test")
+    # Only the *committable* surface is asserted clean. Gitignored, deny-by-default
+    # artifacts (e.g. ephemeral run-logs under agent-evals/runs/ that a local
+    # pipeline run leaves behind) are not surface files and are intentionally
+    # excluded — a clean CI checkout never has them, and they are *meant* to fail
+    # the path allowlist if force-added (covered by the gitignore guard tests).
     rel_paths = sorted(
-        path.relative_to(REPO_ROOT).as_posix()
-        for path in (REPO_ROOT / "agent-evals").rglob("*")
-        if path.is_file() and "__pycache__" not in path.parts
+        rel
+        for rel in (
+            path.relative_to(REPO_ROOT).as_posix()
+            for path in (REPO_ROOT / "agent-evals").rglob("*")
+            if path.is_file() and "__pycache__" not in path.parts
+        )
+        if not _is_gitignored(rel)
     )
 
     violations = []
@@ -295,3 +321,104 @@ def test_scanner_rejects_top_level_key_reused_below_root() -> None:
     violations = report.validate_agent_eval_file("agent-evals/reports/smoke.aggregate.json", text)
 
     assert any("unknown report key not in schema" in violation.reason for violation in violations)
+
+
+def test_scanner_accepts_pr3_paired_ci_nested_keys() -> None:
+    # PR3: a powered metric row carries the bootstrap-CI extension nested keys
+    # (underpowered / ci_lo / ci_hi / num_resamples / alpha). These must be in the
+    # nested allowlist so a legitimate CI-aware row passes the scanner.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_pr3_ci_keys_test")
+
+    text = json.dumps(
+        {
+            "schema_version": 1,
+            "surface": "agent-evals-pr3",
+            "metrics": {
+                "accepted_solve_rate": {
+                    "metric": "accepted_solve_rate",
+                    "baseline": "v0_naive",
+                    "candidate": "v1_spec_first",
+                    "n": 12,
+                    "baseline_mean": 0.4,
+                    "candidate_mean": 0.7,
+                    "delta": 0.3,
+                    "wins": 6,
+                    "losses": 1,
+                    "ties": 5,
+                    "underpowered": False,
+                    "ci_lo": 0.1,
+                    "ci_hi": 0.5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05,
+                }
+            },
+        }
+    )
+    violations = report.validate_agent_eval_file("agent-evals/reports/holdout.aggregate.json", text)
+
+    assert [violation.render() for violation in violations] == []
+
+
+def test_scanner_rejects_raw_sink_nested_under_metric_row() -> None:
+    # PR3: extending the nested allowlist with CI keys must NOT open a hole — a raw
+    # sink nested inside a metric row (metrics.<name>.pr_title) is still rejected by
+    # the recursive denylist.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_pr3_nested_sink_test")
+
+    text = json.dumps(
+        {
+            "schema_version": 1,
+            "metrics": {"accepted_solve_rate": {"pr_title": "raw upstream pr title"}},
+        }
+    )
+    violations = report.validate_agent_eval_file("agent-evals/reports/holdout.aggregate.json", text)
+
+    assert any(
+        "forbidden data key" in violation.reason and "pr_title" in violation.reason
+        for violation in violations
+    )
+
+
+def test_generated_holdout_report_passes_scanner_and_is_aggregate_only() -> None:
+    # PR3: the committed holdout report must clear the content scanner and contain
+    # none of the raw/private sink tokens (aggregate-only boundary, ADR 0005).
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_holdout_scan_test")
+    rel_path = "agent-evals/reports/holdout-v0-vs-v1.aggregate.json"
+    text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+    violations = report.validate_agent_eval_file(rel_path, text)
+    assert [violation.render() for violation in violations] == []
+
+    forbidden_tokens = (
+        "pr_title",
+        "issue_title",
+        "rfp_excerpt",
+        "patch",
+        "diff --git",
+        "/Users/",
+        "run-log",
+        "captured.diff",
+    )
+    lowered = text.lower()
+    for token in forbidden_tokens:
+        assert token.lower() not in lowered, f"forbidden token leaked into holdout report: {token}"
+
+
+def test_generated_holdout_report_is_underpowered_with_no_ci_band() -> None:
+    # PR3: the N=3 smoke holdout is below n_min, so every metric row must be flagged
+    # underpowered and must OMIT the CI band (no ci_lo/ci_hi).
+    rel_path = "agent-evals/reports/holdout-v0-vs-v1.aggregate.json"
+    data = json.loads((REPO_ROOT / rel_path).read_text(encoding="utf-8"))
+
+    assert data["surface"] == "agent-evals-pr3"
+    assert data["task_count"] == 3
+    assert set(data["metrics"]) == {
+        "accepted_solve_rate",
+        "difficulty_weighted_rate",
+        "human_min_per_accepted",
+        "cost_per_accepted",
+    }
+    for name, row in data["metrics"].items():
+        assert row.get("underpowered") is True, f"{name} should be underpowered at N=3"
+        assert "ci_lo" not in row and "ci_hi" not in row, f"{name} must omit CI band when underpowered"
+    assert any(note.startswith("UNDERPOWERED N=") for note in data["notes"])

--- a/tests/test_agent_evals_gitignore.py
+++ b/tests/test_agent_evals_gitignore.py
@@ -52,8 +52,10 @@ DENIED = [
     "agent-evals/reports/2026-smoke-run-log.json",        # "smoke" in name but not allowed
     "agent-evals/reports/2026-smoke-captured-diff.json",
     "agent-evals/reports/raw-v0-vs-v1.json",
-    # Unanticipated shallow .py files are denied too — exact PR2 module allowlists close the
-    # "shallow code path could be a raw sink" bypass (no generalizable .py pattern to match):
+    # Unanticipated shallow .py files are denied too — exact module allowlists close the
+    # "shallow code path could be a raw sink" bypass (no generalizable .py pattern to match).
+    # PR3 widened the allowlist to oracle/runner/oracle_bidmate by EXACT name only, so an
+    # arbitrary shallow .py (raw_dump.py) must still be denied:
     "agent-evals/core/raw_dump.py",
     "agent-evals/adapters/bidmate/raw_dump.py",
     "agent-evals/core/runs/2026/raw_dump.py",
@@ -67,8 +69,11 @@ ALLOWED = [
     "agent-evals/core/schema.py",
     "agent-evals/core/metrics.py",
     "agent-evals/core/report.py",
+    "agent-evals/core/oracle.py",
     "agent-evals/adapters/bidmate/__init__.py",
     "agent-evals/adapters/bidmate/task_mining.py",
+    "agent-evals/adapters/bidmate/runner.py",
+    "agent-evals/adapters/bidmate/oracle_bidmate.py",
     "agent-evals/playbooks/v0_naive.md",
     "agent-evals/playbooks/v1_spec_first.md",
     "agent-evals/splits.yaml",
@@ -87,9 +92,9 @@ ALLOWED = [
 COMMITTABLE_RE = [
     re.compile(r"^agent-evals/README\.md\Z"),
     re.compile(r"^agent-evals/core/__init__\.py\Z"),
-    re.compile(r"^agent-evals/core/(schema|metrics|report)\.py\Z"),
+    re.compile(r"^agent-evals/core/(schema|metrics|report|oracle)\.py\Z"),
     re.compile(r"^agent-evals/adapters/bidmate/__init__\.py\Z"),
-    re.compile(r"^agent-evals/adapters/bidmate/task_mining\.py\Z"),
+    re.compile(r"^agent-evals/adapters/bidmate/(task_mining|runner|oracle_bidmate)\.py\Z"),
     re.compile(r"^agent-evals/playbooks/v(0_naive|1_spec_first)\.md\Z"),
     re.compile(r"^agent-evals/splits\.yaml\Z"),
     re.compile(r"^agent-evals/tasks/[^/]+/task\.yaml\Z"),
@@ -167,8 +172,13 @@ def test_precommit_hook_enforces_agent_evals_boundary() -> None:
     assert r"'^agent-evals/README\.md$'" in allowed, (
         "pre-commit ALLOWED_PATTERNS must permit agent-evals/README.md."
     )
-    assert r"'^agent-evals/core/(schema|metrics|report)\.py$'" in allowed, (
-        "pre-commit ALLOWED_PATTERNS must permit exact PR2 core modules."
+    assert r"'^agent-evals/core/(schema|metrics|report|oracle)\.py$'" in allowed, (
+        "pre-commit ALLOWED_PATTERNS must permit exact core modules (PR2 schema/metrics/report "
+        "plus PR3 oracle)."
+    )
+    assert r"'^agent-evals/adapters/bidmate/(task_mining|runner|oracle_bidmate)\.py$'" in allowed, (
+        "pre-commit ALLOWED_PATTERNS must permit exact bidmate adapter modules (PR2 task_mining "
+        "plus PR3 runner/oracle_bidmate)."
     )
     assert r"'^agent-evals/reports/[^/]+\.aggregate\.json$'" in allowed, (
         "pre-commit ALLOWED_PATTERNS must permit aggregate reports only."

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -776,3 +776,78 @@ def test_report_refuses_mixed_start_commits() -> None:
     ]
     with pytest.raises(ValueError, match="multiple start_commit"):
         report_script.build_report(logs, report_id="p2", num_resamples=50, alpha=0.05, seed=17)
+
+
+def _write_log(runner, runs_dir: Path, task: str, playbook: str, seed: int) -> Path:
+    """Persist a minimal run-log via the runner's own writer (real filename scheme)."""
+
+    return runner.write_run_log(
+        {
+            "task_id": task,
+            "playbook": playbook,
+            "seed": seed,
+            "start_commit": "c0",
+            "gate_results": {"tier": "ACCEPTED"},
+            "human_minutes": 1.0,
+            "cost": {"usd": 0.0},
+        },
+        runs_dir=runs_dir,
+    )
+
+
+def test_report_manifest_scopes_to_current_run_only(tmp_path) -> None:
+    # PR-bot P2 (completion): the report must read EXACTLY the current matrix. A later
+    # run with a smaller task list / changed seeds (same start_commit) leaves orphaned
+    # logs on disk; the start_commit guard cannot catch them. The run_manifest scopes
+    # reads to the files THIS run wrote, so orphans are skipped — not folded in.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_manifest_scope")
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_manifest_scope")
+    runs_dir = tmp_path / "runs"
+
+    # Current run: one task, both playbooks, one seed -> 2 logs + a manifest.
+    current = [
+        _write_log(runner, runs_dir, "T-keep", "v0_naive", 17),
+        _write_log(runner, runs_dir, "T-keep", "v1_spec_first", 17),
+    ]
+    runner.write_run_manifest(current, runs_dir=runs_dir, start_commit="c0", tasks=["T-keep"])
+    # Orphan from an earlier, larger matrix at the SAME start_commit: still on disk,
+    # NOT in the manifest. A whole-dir glob would fold it into task_count.
+    _write_log(runner, runs_dir, "T-stale", "v0_naive", 17)
+    _write_log(runner, runs_dir, "T-stale", "v1_spec_first", 17)
+
+    logs = report_script._read_run_logs(runs_dir)
+    task_ids = sorted({log["task_id"] for log in logs})
+    assert task_ids == ["T-keep"]  # orphan excluded; manifest is authoritative
+    # The manifest file itself is never parsed as a run-log (no task_id KeyError).
+    assert all("task_id" in log for log in logs)
+
+
+def test_report_manifest_missing_log_fails_loud(tmp_path) -> None:
+    # If the manifest references a log that is not on disk, the runs dir is
+    # inconsistent; the report must fail loudly rather than silently under-report.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_manifest_missing")
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_manifest_missing")
+    runs_dir = tmp_path / "runs"
+    kept = _write_log(runner, runs_dir, "T-a", "v0_naive", 17)
+    runner.write_run_manifest(
+        [kept, runs_dir / "T-a__v1_spec_first__seed17.json"],  # second never written
+        runs_dir=runs_dir,
+        start_commit="c0",
+        tasks=["T-a"],
+    )
+    with pytest.raises(FileNotFoundError, match="not on disk"):
+        report_script._read_run_logs(runs_dir)
+
+
+def test_report_glob_fallback_when_no_manifest(tmp_path) -> None:
+    # Legacy / hand-populated dir with no manifest: fall back to globbing every
+    # *.json. (The cross-commit guard in build_report remains the safety net there.)
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_no_manifest")
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_no_manifest")
+    runs_dir = tmp_path / "runs"
+    _write_log(runner, runs_dir, "T-x", "v0_naive", 17)
+    _write_log(runner, runs_dir, "T-x", "v1_spec_first", 17)
+    # No manifest written.
+    logs = report_script._read_run_logs(runs_dir)
+    assert sorted({log["task_id"] for log in logs}) == ["T-x"]
+    assert len(logs) == 2

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -447,6 +449,75 @@ def test_evaluate_returns_sanitized_verdict_dict_only() -> None:
     assert set(out) == {"tier", "candidate_family", "reviewer_family", "egress", "reason_code"}
 
 
+def test_evaluate_skips_egress_when_hard_gate_fires() -> None:
+    # PR-bot P1: a hard gate (e.g. added_secrets) makes rejection certain, so the
+    # issue+patch payload — which may contain exactly the detected secret — must NOT
+    # be handed to the external reviewer. evaluate must short-circuit egress entirely.
+    ob = _oracle_bidmate()
+
+    class _Proc:
+        returncode = 0
+
+    def fake_run(_cmd, **_kwargs):
+        return _Proc()
+
+    def exploding_provider():
+        raise AssertionError("payload_provider must NOT be invoked once a gate has failed")
+
+    out = ob.evaluate(
+        Path("/tmp/x"),
+        task={"task_id": "T-sec"},
+        candidate_family="cand",
+        public_attestation=True,
+        reviewer_family="other",
+        payload_provider=exploding_provider,
+        hidden_test_cmd=["h"],
+        pytest_cmd=["p"],
+        regression_cmd=["r"],
+        diff_summary={"added_secrets": True},
+        runner_subprocess=fake_run,
+        reviewer_call=lambda _p: (True, "ok"),
+    )
+    assert out["tier"] == "REJECTED_HARD_GATE"
+    assert out["egress"] == "skipped"
+    assert out["reviewer_family"] is None
+    assert out["reason_code"] is None
+
+
+def test_evaluate_skips_egress_when_necessary_gate_fails() -> None:
+    # PR-bot P1: same short-circuit when a NECESSARY gate fails (no hard gate). A
+    # candidate that already failed must not have its payload leave the boundary.
+    ob = _oracle_bidmate()
+
+    class _Proc:
+        def __init__(self, rc):
+            self.returncode = rc
+
+    rc_by_first = {"h": 0, "p": 1, "r": 0}  # pytest fails
+
+    def fake_run(cmd, **_kwargs):
+        return _Proc(rc_by_first[cmd[0]])
+
+    def exploding_provider():
+        raise AssertionError("payload_provider must NOT be invoked when a gate failed")
+
+    out = ob.evaluate(
+        Path("/tmp/x"),
+        task={"task_id": "T-fail"},
+        candidate_family="cand",
+        public_attestation=True,
+        reviewer_family="other",
+        payload_provider=exploding_provider,
+        hidden_test_cmd=["h"],
+        pytest_cmd=["p"],
+        regression_cmd=["r"],
+        runner_subprocess=fake_run,
+        reviewer_call=lambda _p: (True, "ok"),
+    )
+    assert out["tier"] == "REJECTED_NECESSARY_GATE"
+    assert out["egress"] == "skipped"
+
+
 # --------------------------------------------------------------------------- #
 # runner.run_one — real detached worktree at HEAD + cleanup                    #
 # --------------------------------------------------------------------------- #
@@ -657,3 +728,51 @@ def test_report_powered_path_attaches_sign_aligned_ci_band() -> None:
     assert [v.render() for v in violations] == []
     assert any(note.startswith("N=12") for note in report["notes"])
     assert not any("UNDERPOWERED" in note for note in report["notes"])
+
+
+def _cost_log(task: str, playbook: str, accepted: bool, usd: float, commit: str = "c0") -> dict:
+    return {
+        "task_id": task,
+        "playbook": playbook,
+        "seed": 17,
+        "start_commit": commit,
+        "gate_results": {"tier": "ACCEPTED" if accepted else "NECESSARY_GATE_ONLY"},
+        "human_minutes": 1.0,
+        "cost": {"usd": usd},
+    }
+
+
+def test_report_zero_solve_cost_is_not_scored_as_free() -> None:
+    # PR-bot P3: a playbook that accepts NOTHING must not score 0.0 cost (which would
+    # look cheapest/best and let a zero-solve baseline win the cost metric). The
+    # undefined (task, playbook) is dropped from the cost/human-min paired sample.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_p3_test")
+    logs = [
+        # task A: both accept -> cost defined on both sides -> one valid cost pair
+        _cost_log("T-a", "v0_naive", True, 5.0),
+        _cost_log("T-a", "v1_spec_first", True, 3.0),
+        # task B: baseline accepts nothing (cost UNDEFINED), candidate accepts at cost
+        _cost_log("T-b", "v0_naive", False, 0.0),
+        _cost_log("T-b", "v1_spec_first", True, 4.0),
+    ]
+    report = report_script.build_report(logs, report_id="p3", num_resamples=50, alpha=0.05, seed=17)
+
+    # Only task A forms a valid cost pair; task B's zero-solve baseline is dropped
+    # (NOT folded in as a free 0.0 that would beat the candidate's nonzero cost).
+    assert report["metrics"]["cost_per_accepted"]["n"] == 1
+    assert report["metrics"]["human_min_per_accepted"]["n"] == 1
+    # accepted_solve_rate is always defined, so it still covers BOTH tasks.
+    assert report["metrics"]["accepted_solve_rate"]["n"] == 2
+
+
+def test_report_refuses_mixed_start_commits() -> None:
+    # PR-bot P2: run-logs from different start_commit values in one (gitignored) runs
+    # dir would silently fold stale measurements into one aggregate and corrupt
+    # task_count / means / deltas. build_report must refuse loudly, not corrupt.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_p2_test")
+    logs = [
+        _cost_log("T", "v0_naive", True, 1.0, commit="aaaa"),
+        _cost_log("T", "v1_spec_first", True, 1.0, commit="bbbb"),
+    ]
+    with pytest.raises(ValueError, match="multiple start_commit"):
+        report_script.build_report(logs, report_id="p2", num_resamples=50, alpha=0.05, seed=17)

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# oracle.decide_verdict — exhaustive fail-closed decision table                #
+# --------------------------------------------------------------------------- #
+
+
+def _oracle():
+    return load_module("agent-evals/core/oracle.py", "agent_evals_oracle_runner_test")
+
+
+def test_decide_verdict_hard_gate_rejects_outright() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(
+        hidden_test_gate=True,
+        pytest_pass=True,
+        regression_pass=True,
+        hard_gates=(oracle.HardGate.SECRET_LEAK,),
+    )
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.REJECTED_HARD_GATE
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_necessary_gate_failure_rejects() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=False, regression_pass=True)
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.REJECTED_NECESSARY_GATE
+
+
+def test_decide_verdict_egress_closed_caps_at_necessary_gate_only() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+    # Even with an accepting cross-family reviewer object, a closed egress gate must
+    # cap the tier — the payload never left, so acceptance is unprovable.
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=False,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+
+
+def test_decide_verdict_public_but_no_reviewer_caps_at_necessary_gate_only() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+    tier = oracle.decide_verdict(
+        gates,
+        None,
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+
+
+def test_decide_verdict_same_family_reviewer_is_neutralized() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+    # Same-family self-judge (ADR 0064): even an accepting verdict is neutralized.
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="cand", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+
+
+def test_decide_verdict_cross_family_reject() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=False, reviewer_family="other", reason_code="contract_gap"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.REJECTED_BY_REVIEWER
+
+
+def test_decide_verdict_cross_family_accept_is_only_accepted_path() -> None:
+    oracle = _oracle()
+    gates = oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.ACCEPTED
+    assert oracle.is_accepted(tier)
+
+
+# --------------------------------------------------------------------------- #
+# oracle.decide_verdict — fail-OPEN regression guards (cross-family review)     #
+#                                                                              #
+# A cross-family Codex review of this surface found two fail-open bypasses:     #
+# (1) a truthy non-bool gate value (the string "false") slipped past the        #
+#     necessary-gate check, and (2) a cosmetic case variant of the family       #
+# label ("Codex" vs "codex") bypassed the same-family self-judge gate. Both     #
+# returned ACCEPTED. These tests reproduce the exact bypasses and pin the now   #
+# strict ``is True`` / normalized-family behavior; the same hardening also      #
+# covers the adjacent truthy-non-bool attestation and accepted-flag vectors.    #
+# --------------------------------------------------------------------------- #
+
+
+def _all_pass_gates(oracle):
+    return oracle.GateResults(hidden_test_gate=True, pytest_pass=True, regression_pass=True)
+
+
+def test_decide_verdict_truthy_nonbool_gate_does_not_fail_open() -> None:
+    # Codex finding #1: gate fields typed as bool but checked with truthiness.
+    # The string "false" is truthy, so ``not (g1 and g2 and g3)`` used to be False
+    # and the necessary gate falsely "passed" -> ACCEPTED. Strict ``is True`` must
+    # treat any non-bool as a failed gate (fail-closed).
+    oracle = _oracle()
+    gates = oracle.GateResults(
+        hidden_test_gate="false", pytest_pass="false", regression_pass="false"
+    )
+    tier = oracle.decide_verdict(
+        gates,
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.REJECTED_NECESSARY_GATE
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_case_variant_same_family_does_not_fail_open() -> None:
+    # Codex finding #2: the same-family self-judge gate used a case-sensitive ==,
+    # so reviewer_family='Codex' vs candidate_family='codex' bypassed it -> ACCEPTED.
+    # The comparison must be case-insensitive so the self-judge is neutralized.
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="Codex", reason_code="ok"),
+        candidate_family="codex",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_whitespace_variant_same_family_does_not_fail_open() -> None:
+    # Same self-judge gate, whitespace variant: ' codex ' must still neutralize a
+    # 'codex' candidate's reviewer.
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family=" codex ", reason_code="ok"),
+        candidate_family="codex",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+
+
+def test_decide_verdict_truthy_nonbool_attestation_does_not_open_egress() -> None:
+    # Adjacent vector hardened in the same fix: the egress gate must open only on a
+    # strict ``public_attestation is True``. A truthy non-bool (the string "true")
+    # must NOT open egress -> caps at NECESSARY_GATE_ONLY (fail-closed).
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation="true",
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+
+
+def test_decide_verdict_truthy_nonbool_accepted_does_not_fail_open() -> None:
+    # Adjacent vector hardened in the same fix: acceptance requires a strict
+    # ``reviewer.accepted is True``. A truthy non-bool accepted flag (the string
+    # "yes") must fail closed to a reviewer rejection, never ACCEPTED.
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted="yes", reviewer_family="other", reason_code="ok"),
+        candidate_family="cand",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.REJECTED_BY_REVIEWER
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_bytes_reviewer_family_does_not_fail_open() -> None:
+    # Second-round Codex finding: a bytes family label bypasses the self-judge gate
+    # because str(b'codex') == "b'codex'" != "codex". A bytes reviewer_family that
+    # is really the SAME family as the candidate must still neutralize -> the family
+    # must be a usable str or the verdict fails closed.
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family=b"codex", reason_code="ok"),
+        candidate_family="codex",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_bytes_candidate_family_does_not_fail_open() -> None:
+    # Same second-round finding, bytes on the candidate_family side.
+    oracle = _oracle()
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family="codex", reason_code="ok"),
+        candidate_family=b"codex",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_empty_family_label_fails_closed() -> None:
+    # A blank / whitespace family label is malformed and cannot establish a valid
+    # cross-family reviewer; fail closed to NECESSARY_GATE_ONLY, never ACCEPTED.
+    oracle = _oracle()
+    for reviewer_family, candidate_family in (("", "codex"), ("   ", "codex"), ("claude", "")):
+        tier = oracle.decide_verdict(
+            _all_pass_gates(oracle),
+            oracle.ReviewerVerdict(accepted=True, reviewer_family=reviewer_family, reason_code="ok"),
+            candidate_family=candidate_family,
+            public_attestation=True,
+        )
+        assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY, (reviewer_family, candidate_family)
+
+
+def test_decide_verdict_str_subclass_dunder_spoof_does_not_fail_open() -> None:
+    # Third-round Codex finding: a str SUBCLASS whose __str__ (or strip/lower) is
+    # overridden could spoof the canonical token. SpoofStr('codex') has real value
+    # 'codex' (same family as the candidate) but __str__ -> 'claude', so a str()-based
+    # normalization read it as cross-family -> ACCEPTED. The unbound base-str
+    # normalization must use the real buffer ('codex') and neutralize the self-judge.
+    oracle = _oracle()
+
+    class SpoofStr(str):
+        def __str__(self) -> str:  # noqa: D401 - spoof
+            return "claude"
+
+        def strip(self, *args, **kwargs):  # type: ignore[override]
+            return "claude"
+
+        def lower(self):  # type: ignore[override]
+            return "claude"
+
+    tier = oracle.decide_verdict(
+        _all_pass_gates(oracle),
+        oracle.ReviewerVerdict(accepted=True, reviewer_family=SpoofStr("codex"), reason_code="ok"),
+        candidate_family="codex",
+        public_attestation=True,
+    )
+    assert tier is oracle.VerdictTier.NECESSARY_GATE_ONLY
+    assert not oracle.is_accepted(tier)
+
+
+def test_decide_verdict_legit_cross_family_with_falsy_hard_gates_still_accepts() -> None:
+    # Guard against over-correction: the second-round Codex probe also listed
+    # hard_gates=None/0/False as "reaches ACCEPTED", but those are LEGITIMATE accepts
+    # (a genuine cross-family 'claude' reviewer accepting a 'codex' candidate with no
+    # hard gate). A falsy hard_gates means "no hard gate", identical to the default
+    # (). This must remain ACCEPTED — failing it closed would reject every clean
+    # candidate (whose default hard_gates=() is also falsy).
+    oracle = _oracle()
+    for falsy in (None, 0, False, ()):
+        gates = oracle.GateResults(
+            hidden_test_gate=True, pytest_pass=True, regression_pass=True, hard_gates=falsy
+        )
+        tier = oracle.decide_verdict(
+            gates,
+            oracle.ReviewerVerdict(accepted=True, reviewer_family="claude", reason_code="ok"),
+            candidate_family="codex",
+            public_attestation=True,
+        )
+        assert tier is oracle.VerdictTier.ACCEPTED, falsy
+        assert oracle.is_accepted(tier)
+
+
+# --------------------------------------------------------------------------- #
+# oracle_bidmate — egress discipline + injected gates                          #
+# --------------------------------------------------------------------------- #
+
+
+def _oracle_bidmate():
+    return load_module(
+        "agent-evals/adapters/bidmate/oracle_bidmate.py", "agent_evals_oracle_bidmate_test"
+    )
+
+
+def test_cross_family_review_no_egress_when_attestation_closed() -> None:
+    ob = _oracle_bidmate()
+
+    calls = {"provider": 0, "reviewer": 0}
+
+    def provider():
+        calls["provider"] += 1
+        raise AssertionError("payload_provider must NOT be invoked when egress is closed")
+
+    def reviewer_call(_payload):
+        calls["reviewer"] += 1
+        return True, "ok"
+
+    verdict = ob.cross_family_review(
+        provider,
+        public_attestation=False,
+        candidate_family="cand",
+        reviewer_family="other",
+        reviewer_call=reviewer_call,
+    )
+    assert verdict is None
+    assert calls == {"provider": 0, "reviewer": 0}
+
+
+def test_cross_family_review_egress_when_attestation_open() -> None:
+    ob = _oracle_bidmate()
+
+    seen = {}
+
+    def provider():
+        return "issue+patch payload"
+
+    def reviewer_call(payload):
+        seen["payload"] = payload
+        return True, "ok"
+
+    verdict = ob.cross_family_review(
+        provider,
+        public_attestation=True,
+        candidate_family="cand",
+        reviewer_family="other_family",
+        reviewer_call=reviewer_call,
+    )
+    assert verdict is not None
+    assert verdict.accepted is True
+    assert verdict.reviewer_family == "other_family"
+    assert verdict.reason_code == "ok"
+    assert seen["payload"] == "issue+patch payload"
+
+
+def test_run_necessary_gates_maps_returncodes_with_injected_subprocess() -> None:
+    ob = _oracle_bidmate()
+
+    class _Proc:
+        def __init__(self, rc):
+            self.returncode = rc
+
+    # hidden -> 0 (pass), pytest -> 1 (fail), regression -> 0 (pass)
+    rc_by_first_arg = {"hidden": 0, "pytest": 0, "regression": 1}
+
+    def fake_run(cmd, **_kwargs):
+        return _Proc(rc_by_first_arg[cmd[0]])
+
+    gates = ob.run_necessary_gates(
+        Path("/tmp/does-not-matter"),
+        hidden_test_cmd=["hidden"],
+        pytest_cmd=["pytest"],
+        regression_cmd=["regression"],
+        runner_subprocess=fake_run,
+    )
+    assert gates.hidden_test_gate is True
+    assert gates.pytest_pass is True
+    assert gates.regression_pass is False
+    assert gates.hard_gates == ()
+
+
+def test_detect_hard_gates_maps_sanitized_summary() -> None:
+    ob = _oracle_bidmate()
+    # Compare against the SAME oracle module oracle_bidmate loaded internally
+    # (``ob.oracle``); a separate path-load would create a distinct HardGate enum
+    # class whose members are not identity-equal to the returned ones.
+    HardGate = ob.oracle.HardGate
+    gates = ob.detect_hard_gates(
+        {
+            "added_secrets": True,
+            "unauthorized_migration": True,
+            "deleted_paths": 2,
+            "build_failure": False,
+        }
+    )
+    assert HardGate.SECRET_LEAK in gates
+    assert HardGate.UNAUTHORIZED_MIGRATION in gates
+    assert HardGate.DESTRUCTIVE in gates
+    assert HardGate.BUILD_FAILURE not in gates
+
+
+def test_evaluate_returns_sanitized_verdict_dict_only() -> None:
+    ob = _oracle_bidmate()
+
+    class _Proc:
+        returncode = 0
+
+    def fake_run(cmd, **_kwargs):
+        return _Proc()
+
+    out = ob.evaluate(
+        Path("/tmp/x"),
+        task={"task_id": "T-1"},
+        candidate_family="cand",
+        public_attestation=True,
+        reviewer_family="other",
+        payload_provider=lambda: "payload",
+        hidden_test_cmd=["h"],
+        pytest_cmd=["p"],
+        regression_cmd=["r"],
+        runner_subprocess=fake_run,
+        reviewer_call=lambda _p: (True, "ok"),
+    )
+    assert out == {
+        "tier": "ACCEPTED",
+        "candidate_family": "cand",
+        "reviewer_family": "other",
+        "egress": "performed",
+        "reason_code": "ok",
+    }
+    # No payload/prose keys leaked into the verdict dict.
+    assert set(out) == {"tier", "candidate_family", "reviewer_family", "egress", "reason_code"}
+
+
+# --------------------------------------------------------------------------- #
+# runner.run_one — real detached worktree at HEAD + cleanup                    #
+# --------------------------------------------------------------------------- #
+
+
+def _runner():
+    return load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_test")
+
+
+def test_run_one_creates_and_cleans_up_detached_worktree() -> None:
+    runner = _runner()
+    head = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    captured = {}
+
+    def stub_candidate(*, worktree, task_id, playbook, seed):
+        # The detached worktree must really exist on disk while the candidate runs.
+        captured["worktree"] = Path(worktree)
+        captured["existed_during_run"] = Path(worktree).is_dir()
+        captured["is_git_worktree"] = (Path(worktree) / ".git").exists()
+        return {
+            "intervention_count": 2,
+            "cost": {"input_tokens": 10, "output_tokens": 5, "usd": 0.0},
+            "human_minutes": 1.5,
+            "gate_results": {
+                "hidden_test_gate": True,
+                "pytest_pass": True,
+                "regression_pass": True,
+                "hard_gates": [],
+            },
+        }
+
+    run_log = runner.run_one(
+        start_commit=head,
+        task_id="T-smoke-001",
+        playbook="v1_spec_first",
+        seed=17,
+        candidate=stub_candidate,
+        repo_root=REPO_ROOT,
+        clock=lambda: 42.0,
+    )
+
+    # Run-log shape.
+    assert run_log["task_id"] == "T-smoke-001"
+    assert run_log["playbook"] == "v1_spec_first"
+    assert run_log["seed"] == 17
+    assert run_log["start_commit"] == head
+    assert run_log["intervention_count"] == 2
+    assert run_log["human_minutes"] == 1.5
+    assert run_log["timestamps"] == {"started": 42.0, "finished": 42.0}
+    assert run_log["gate_results"]["hidden_test_gate"] is True
+
+    # The worktree really existed during the run...
+    assert captured["existed_during_run"] is True
+    assert captured["is_git_worktree"] is True
+
+    # ...and is fully cleaned up afterward.
+    assert not captured["worktree"].exists()
+    listed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "worktree", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert str(captured["worktree"]) not in listed
+
+
+def test_run_one_cleans_up_worktree_even_if_candidate_raises() -> None:
+    runner = _runner()
+    head = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    captured = {}
+
+    def boom(*, worktree, task_id, playbook, seed):
+        captured["worktree"] = Path(worktree)
+        raise RuntimeError("candidate failed mid-run")
+
+    try:
+        runner.run_one(
+            start_commit=head,
+            task_id="T-smoke-002",
+            playbook="v0_naive",
+            seed=18,
+            candidate=boom,
+            repo_root=REPO_ROOT,
+            clock=lambda: 0.0,
+        )
+    except RuntimeError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("run_one should propagate the candidate failure")
+
+    assert not captured["worktree"].exists()
+    listed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "worktree", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert str(captured["worktree"]) not in listed
+
+
+def test_write_run_log_targets_gitignored_runs_dir(tmp_path) -> None:
+    runner = _runner()
+    run_log = {
+        "task_id": "T-smoke-003",
+        "playbook": "v1_spec_first",
+        "seed": 19,
+        "gate_results": {"tier": "ACCEPTED"},
+    }
+    out = runner.write_run_log(run_log, runs_dir=tmp_path / "runs")
+    assert out.name == "T-smoke-003__v1_spec_first__seed19.json"
+    assert out.exists()
+    # The default runs dir is the gitignored agent-evals/runs tree.
+    assert "agent-evals/runs/" in (runner.write_run_log.__doc__ or "")
+
+
+def test_run_matrix_default_uses_at_least_three_seeds() -> None:
+    runner = _runner()
+    assert len(runner.DEFAULT_SEEDS) >= 3
+    assert runner.DEFAULT_SEEDS == (17, 18, 19)
+    assert runner.DEFAULT_PLAYBOOKS == ("v0_naive", "v1_spec_first")
+
+
+# --------------------------------------------------------------------------- #
+# metrics.underpowered                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_underpowered_threshold() -> None:
+    metrics = load_module("agent-evals/core/metrics.py", "agent_evals_metrics_underpowered_test")
+    assert metrics.N_MIN_DEFAULT == 10
+    assert metrics.underpowered(3) is True
+    assert metrics.underpowered(9) is True
+    assert metrics.underpowered(10) is False
+    assert metrics.underpowered(11) is False
+    assert metrics.underpowered(5, n_min=4) is False
+
+
+# --------------------------------------------------------------------------- #
+# scripts/agent_evals_report.build_report — powered (n>=n_min) bootstrap path  #
+# --------------------------------------------------------------------------- #
+
+
+def _synth_paired_logs(n_tasks: int, n_ties: int) -> list[dict]:
+    """Synthesize paired run-logs: candidate wins on (n_tasks - n_ties), ties on n_ties.
+
+    A "win" is candidate accepted + baseline not; a "tie" is both accepted. One seed
+    per (task, playbook) so each task contributes exactly one paired row, giving
+    n == n_tasks paired rows for the report's bootstrap.
+    """
+
+    logs: list[dict] = []
+    for i in range(n_tasks):
+        baseline_accepted = i < n_ties  # first n_ties tasks tie (both accepted)
+        for playbook, accepted in (("v0_naive", baseline_accepted), ("v1_spec_first", True)):
+            logs.append(
+                {
+                    "task_id": f"T-pow-{i:03d}",
+                    "playbook": playbook,
+                    "seed": 17,
+                    "gate_results": {"tier": "ACCEPTED" if accepted else "NECESSARY_GATE_ONLY"},
+                    "human_minutes": 1.0,
+                    "cost": {"usd": 0.0},
+                }
+            )
+    return logs
+
+
+def test_report_powered_path_attaches_sign_aligned_ci_band() -> None:
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_powered_test")
+    report_mod = load_module("agent-evals/core/report.py", "agent_evals_report_powered_scan")
+
+    logs = _synth_paired_logs(n_tasks=12, n_ties=3)  # n=12 >= n_min=10 -> powered
+    report = report_script.build_report(
+        logs, report_id="powered-test", num_resamples=200, alpha=0.05, seed=17
+    )
+
+    row = report["metrics"]["accepted_solve_rate"]
+    assert row["n"] == 12
+    # Powered: a real CI band, never the underpowered flag.
+    assert "underpowered" not in row
+    for key in ("ci_lo", "ci_hi", "num_resamples", "alpha"):
+        assert key in row, f"powered metric row missing {key}"
+    # Candidate (v1) beats baseline (v0), so delta and the CI band must share the
+    # positive (candidate - baseline) sign. A flipped paired_bootstrap_ci arg order
+    # would push the band negative (ci_hi <= 0), so this guards the sign fix.
+    assert row["delta"] > 0
+    assert row["ci_lo"] >= 0.0
+    assert row["ci_hi"] > 0.0
+    assert row["ci_lo"] <= row["ci_hi"]
+
+    # The powered report must still pass the aggregate-only content scanner.
+    serialized = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    violations = report_mod.validate_agent_eval_file(
+        "agent-evals/reports/powered-test.aggregate.json", serialized
+    )
+    assert [v.render() for v in violations] == []
+    assert any(note.startswith("N=12") for note in report["notes"])
+    assert not any("UNDERPOWERED" in note for note in report["notes"])


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #2374

ADR 0100 operator-skill eval 의 PR3 — 실행 + 채점 + 리포팅 엔진. PR1(privacy scaffold)/PR2(core + content scanner)에 이어, 후보를 격리 worktree 에서 돌리고(`git worktree add --detach`, ≥3 seed), **fail-closed acceptance oracle** 로 판정하고, paired-bootstrap holdout 리포트를 생성한다. ACCEPTED 는 (1) public-attestation egress gate + (2) cross-family validity gate(ADR 0064) 를 모두 통과해야만 도달 — 둘 다 기본 fail-closed. 이 표면 자신의 thesis(cross-family adversarial review = oracle)를 dogfood: 로컬 Codex 교차 리뷰가 `decide_verdict` 의 fail-open 결함들을 4 라운드에 걸쳐 찾아냈고 전부 수정, 마지막 라운드는 NO IN-SCOPE FAIL-OPEN.

## 2. 영향 파일

신규 (committable, scanner-backed):
- `agent-evals/core/oracle.py` — stdlib-only fail-closed verdict 로직
- `agent-evals/adapters/bidmate/oracle_bidmate.py` — 유일한 egress 레이어 (sanitized booleans/tokens 만 core 로)
- `agent-evals/adapters/bidmate/runner.py` — detached worktree 실행 + finally teardown
- `agent-evals/reports/holdout-v0-vs-v1.aggregate.json` — n=3 underpowered smoke

신규 (scripts/, 비-committable-allowlist):
- `scripts/agent_evals_run.py`, `scripts/agent_evals_report.py`

수정:
- `agent-evals/core/metrics.py` (`N_MIN_DEFAULT` + `underpowered`)
- `agent-evals/core/report.py` (allowlist + nested CI keys)
- `.gitignore`, `.githooks/pre-commit`, `tests/test_agent_evals_gitignore.py` (4-mirror sync)
- `tests/test_agent_evals_core.py`, `tests/test_agent_evals_runner.py` (테스트)

**load-bearing 경로 없음** — agent-evals 는 `scripts/_governance.py:LOAD_BEARING_PATHS` 비포함(ADR 0100). `scripts/agent_evals_*.py` 는 `build_index.py` 아님.

## 3. 리스크

가장 가능성 높은 깨짐: oracle 의 **fail-OPEN**(판정이 ACCEPTED 로 새는 것) — 이 표면의 핵심 보안 계약. 배제 확인:
- 모든 ACCEPTED-opener 를 strict `is True` 로 검사 (truthy non-bool 차단)
- family 비교는 non-empty `str` 검증 + unbound base `str` 정규화 (case/whitespace/bytes/str-subclass `__str__`/`strip`/`lower` override 무력화)
- 97 단위 테스트 + 로컬 Codex 4-round 교차 리뷰 수렴(R1 truthiness+family case → R2 bytes → R3 subclass spoof → R4 clean)
- runner 의 detached worktree 는 `finally` triple teardown(candidate 예외 시에도 정리 — 테스트로 검증), 순차 matrix 로 디스크 안전

## 4. 테스트

`tests/test_agent_evals_runner.py`(신규) — oracle 7-branch decision table + **fail-open 회귀**(Codex 발견 결함 재현: truthy gate/attestation/accepted, case/whitespace/bytes/str-subclass family) + oracle_bidmate egress discipline + runner real-detached-worktree+cleanup + report powered-path(n≥10) sign-aligned CI band. `tests/test_agent_evals_core.py` — PR3 nested-CI accept/reject. 회귀 테스트는 변경 전 ACCEPTED(fail-open) → 변경 후 NECESSARY_GATE_ONLY/REJECTED 로 fail→pass 검증. **전체 97 passed.** 단일 worktree, overlap-preflight: agent-evals 전용 신규 디렉터리 + 동일 표면 열린 PR 0.

## 5. Eval 영향

All `·` — RAG/eval 파이프라인 외 변경. load-bearing 경로 미변경(agent-evals 는 독립 측정 표면; `rag_core`/`rag_retrieval`/`rag_verifier`/`rag_answer`/`rag_query`/`ingestion`/`eval`/`api`/`docs/adr`/`build_index` 무관). private real-eval 영향 없음. agent-evals 자체 산출물(holdout aggregate)은 stub candidate + stub reviewer + **no external egress** 의 n=3 underpowered smoke — 절대 leaderboard 아님(ADR 0100 aggregate-only, underpowered 시 CI band 생략).

## 6. 하위 호환

신규 표면 — 기존 계약/스키마/CLI 깨짐 없음. ADR 0003 답변 계약 무관. PR2 의 content scanner / `task.yaml` 계약 보존(allowlist 확장만; nested CI 키는 `schema.py` 미러 아님 → drift 안전).

## 7. 범위 외

- **실규모 egress holdout**(real candidate + real Codex reviewer 로 v0-vs-v1 paired delta n≥10) — follow-up. 이 PR 은 stub-DI 로 엔진 자체를 검증(CI green, no egress).
- family 라벨의 **unicode-homoglyph / alias·substring 매칭** — 의도적 out-of-scope(라벨은 harness 가 설정하는 신뢰 토큰, attacker free-text 아님). 정규화는 case/whitespace/type/subclass-override 만 처리.
- real candidate 경로(`_real_candidate`)는 `NotImplementedError` stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
