### PR TITLE
fix(ingestion): canonical_doc_id casefold 주석-코드 정합 + 대소문자 보존 회귀

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -1923,8 +1923,13 @@ def canonical_doc_id(
     Priority:
       1. ``notice_id`` (+ optional ``notice_round``) if non-empty.
       2. File-name stem fallback.
-    Both branches NFC-normalize, casefold, and collapse whitespace so the
-    same source row produces the same id across runs and platforms.
+    Both branches NFC-normalize and collapse whitespace (via ``slug_part``)
+    so the same source row produces the same id across runs and platforms.
+    Case is **preserved**: ``RFP-001`` and ``rfp-001`` are distinct ids.
+    (Issue #2409 — an earlier docstring claimed casefold, but ``slug_part``
+    has never case-folded since #49; run/platform determinism needs only NFC +
+    whitespace collapse, and folding would change every doc_id and break the
+    ADR 0001 naive_baseline byte-identity, so it stays out of scope.)
     """
     notice = clean_cell(notice_id)
     if notice:

--- a/tests/test_ingestion_doc_id_rules.py
+++ b/tests/test_ingestion_doc_id_rules.py
@@ -73,3 +73,23 @@ def test_canonical_doc_id_none_when_all_empty() -> None:
     # notice·file 모두 비면 None(빈 문자열 아님).
     assert canonical_doc_id("", "", "") is None
     assert canonical_doc_id(None, None, None) is None
+
+
+# ---- case preservation (issue #2409) ----
+# docstring 의 옛 'casefold' 문구는 미구현이고(slug_part 는 #49 이래 한 번도
+# casefold 안 함), doc_id 는 대소문자를 보존한다. 아래 테스트가 그 계약을 pin —
+# 누가 slug_part 에 casefold/.lower() 를 넣으면 FAIL 하여 ADR 0001 naive_baseline
+# byte-identity 가 깨짐(모든 doc_id 변경)을 의식하게 만든다.
+
+def test_canonical_doc_id_preserves_case_in_notice() -> None:
+    # notice_id 경로: 대소문자 보존 — RFP-001 과 rfp-001 은 서로 다른 id.
+    assert canonical_doc_id("RFP-001", None, None) == "RFP-001"
+    assert canonical_doc_id("rfp-001", None, None) == "rfp-001"
+    assert canonical_doc_id("RFP-001", None, None) != canonical_doc_id("rfp-001", None, None)
+
+
+def test_canonical_doc_id_preserves_case_in_file_fallback() -> None:
+    # file_name stem fallback 경로도 대소문자 보존 — Document ≠ document.
+    assert canonical_doc_id(None, None, "Document.hwp") == "Document"
+    assert canonical_doc_id(None, None, "document.hwp") == "document"
+    assert canonical_doc_id(None, None, "Document.hwp") != canonical_doc_id(None, None, "document.hwp")


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`ingestion.py` `canonical_doc_id` docstring(line 1926)이 doc_id 생성 시 "NFC-normalize, **casefold**, collapse whitespace"를 명시했으나, 실제 코드 경로(`clean_cell`→`slug_part`)에 casefold/`.lower()`가 **없습니다**.

**측정 (코드 반증):**
- `canonical_doc_id("RFP-001",…)` → `"RFP-001"` vs `("rfp-001",…)` → `"rfp-001"` (casefold면 같아야)
- `("","","Document.hwp")` → `"Document"` ≠ `("","","document.hwp")` → `"document"`

**의도 (git pickaxe):** `git log -S casefold -- ingestion.py` → 단 한 커밋 f06282ff(#49 Phase 0)에서 **주석에만** 추가, `slug_part` 코드엔 같은 커밋부터 casefold 없음(제거 이력 0). casefold는 구현된 적 없는 aspirational 주석이고, docstring 명시 목적("same source row → same id across runs/platforms")은 NFC+strip+whitespace-collapse로 이미 충족 — casefold(대소문자 *다른* 입력 통합)는 그 목적과 무관하게 잘못 나열됐습니다.

**multi-agent 리스크:** 이 repo는 다수 agent(Codex 44 worktree 포함)가 동시 작업합니다. 거짓 주석을 믿고 "casefold로 대소문자 중복 처리됨"이라 가정하면 잠재 버그로 이어집니다.

## 2. 어떻게 (How)

1. **docstring 정합** — casefold 제거, 실제 동작(NFC + whitespace collapse, 대소문자 보존)과 git 근거·baseline 영향을 정확히 기술.
2. **characterization 회귀** — `tests/test_ingestion_doc_id_rules.py`에 doc_id 대소문자 보존 테스트 2개(notice 경로 + file_name fallback 경로). 미래에 누가 `slug_part`에 casefold/`.lower()`를 넣으면 FAIL → ADR 0001 naive_baseline byte-identity가 깨짐(모든 doc_id 변경)을 의식하게.

## 3. 테스트 (Tests)

- `tests/test_ingestion_doc_id_rules.py` 11개 전부 pass (기존 9 + 추가 2)
- **Mutation 비공허 증명**: `slug_part`에 `.casefold()` 주입 시 추가 테스트 2개가 정확히 FAIL(`'document' == 'Document'`), 원복 후 동일.

## 4. 범위 밖 (Out of scope)

- `ingestion.py`의 기존 Pyright `reportOptionalMemberAccess`/`reportArgumentType`(str|None) 경고는 docstring 변경이 파일 재분석을 유발해 표면화됐을 뿐 무관 — one-PR-one-concern으로 미수정.
- casefold *동작* 추가는 doc_id 변경 → 인덱스/ADR 0001 baseline 영향이라 별도 ADR 필요 (현재 영향 낮아 보류).

## 5. Eval 영향 (Eval impact)

load-bearing `ingestion.py` 변경이나 **동작 0변경**(docstring + test only):
- 코드 로직 무변경 → ADR 0001 naive_baseline **byte-identity 0영향**
- `parse_amounts`/`slug_part` 등 어떤 함수 동작도 안 바뀜 → fixture smoke "vs base" byte-identity 통과 예상
- doc_id 생성 결과 동일 (대소문자 보존은 *기존* 동작, 본 PR은 그것을 정확히 문서화+pin)

## 6. 체크리스트

- [x] Issue 참조: Closes #2409
- [x] 브랜치 컨벤션 (ADR 0007): `chore/issue-2409-doc-id-casefold`
- [x] 동작↔테스트: characterization 회귀 추가 + mutation 비공허
- [x] Codex adversarial pre-commit review 통과 (0 blocking / 0 informational)

Closes #2409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
