### PR TITLE
test(governance): ignore ADR-like directories

### DIFF
--- a/tests/test_governance_adr_numbers.py
+++ b/tests/test_governance_adr_numbers.py
@@ -42,6 +42,12 @@ def test_existing_adr_numbers_ignores_non_adr_files(tmp_path: Path) -> None:
     assert existing_adr_numbers(tmp_path) == {1, 2}
 
 
+def test_existing_adr_numbers_ignores_matching_directories(tmp_path: Path) -> None:
+    (tmp_path / "0003-directory.md").mkdir()
+    _touch(tmp_path, "0004-real-file.md")
+    assert existing_adr_numbers(tmp_path) == {4}
+
+
 def test_existing_adr_numbers_strict_filename_pattern(tmp_path: Path) -> None:
     # 4 digits exactly + kebab slug starting with [a-zA-Z0-9]. Issue #818
     # widened the character class to accept uppercase so the scanner does


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR number scanner가 `NNNN-slug.md` 패턴과 같은 이름의 디렉터리를 ADR 파일로 세지 않는다는 계약을 회귀 테스트로 고정합니다.

Closes #2412

## 2. 영향 파일

- `tests/test_governance_adr_numbers.py` — test-only, load-bearing 아님

## 3. 리스크

- 리스크: 향후 scanner refactor가 `Path.iterdir()` 결과에서 file/directory 구분을 잃으면 ADR 번호 계산이 오염될 수 있음.
- 배제 근거: matching directory + real ADR file 조합으로 `existing_adr_numbers()` 결과를 직접 검증함.

## 4. 테스트

- `python3 -m pytest -q tests/test_governance_adr_numbers.py` → 15 passed
- `git diff --check` → pass
- `make check-branch` → pass
- Overlap preflight: latest `origin/main`=`3d57c2e6793b9cfdcc3f9582e437e92902076c1e`; branch file `tests/test_governance_adr_numbers.py`; main-side files empty; overlap empty; selection scan found no open PR or active Codex/Claude worktree touching this file.

## 5. Eval 영향

RAG/eval load-bearing 경로 변경 없음. Test-only governance coverage라 public/private eval 동작 변화 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 파일, runtime scanner behavior, CLI flag 변경 없음.

## 7. 범위 외

- ADR 파일 생성/수정 없음.
- `scripts/_governance.py` runtime behavior 변경 없음.
