### PR TITLE
test(commit-hook): cover issue branch without slug

### DIFF
--- a/tests/test_hook_commit_msg.py
+++ b/tests/test_hook_commit_msg.py
@@ -62,6 +62,15 @@ class TestCommitMsgHook:
         )
         assert code == 0
 
+    def test_passes_when_issue_branch_has_no_slug(self, tmp_path: Path) -> None:
+        """ADR 0007 allows the slug suffix to be omitted: test/issue-2416."""
+        code, _ = _run_hook(
+            branch="test/issue-2416",
+            message="test: cover optional slug branch\n\nCloses #2416\n",
+            tmp_path=tmp_path,
+        )
+        assert code == 0
+
     def test_rejects_when_commit_missing_issue_reference(self, tmp_path: Path) -> None:
         """The core guard: branch claims #99 but message has no reference."""
         code, stderr = _run_hook(


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0007 branch convention의 slug 없는 형태(`<type>/issue-<N>`)에서도 commit-msg hook이 올바른 issue reference를 통과시키는지 회귀 테스트로 고정합니다.

Closes #2416

## 2. 영향 파일

- `tests/test_hook_commit_msg.py` — test-only, load-bearing 아님

## 3. 리스크

- 리스크: hook/branch regex refactor 시 slug 없는 issue branch가 skip 또는 reject될 수 있음.
- 배제 근거: production `.githooks/commit-msg`를 temp git repo에서 직접 실행해 `test/issue-2416` + `Closes #2416` happy path를 검증함.

## 4. 테스트

- `python3 -m pytest -q tests/test_hook_commit_msg.py` → 25 passed
- `git diff --check` → pass
- `make check-branch` → pass
- Overlap preflight: latest `origin/main`=`114b72b828f39d7ea63657ff3d0786115e1bfa69`; branch file `tests/test_hook_commit_msg.py`; main-side files empty; overlap empty; selection scan found no open PR or active Codex/Claude worktree touching this file.

## 5. Eval 영향

RAG/eval load-bearing 경로 변경 없음. Test-only hook governance coverage라 public/private eval 동작 변화 없음.

## 6. 하위 호환

하위 호환 영향 없음. Runtime hook behavior, branch convention, CLI flag 변경 없음.

## 7. 범위 외

- `.githooks/commit-msg` runtime behavior 변경 없음.
- ADR 0007 문서/브랜치 checker 변경 없음.
