### PR TITLE
test(self-review): cover unslugged axis2 issue branch

### DIFF
--- a/tests/test_self_review_axis_2_regression.py
+++ b/tests/test_self_review_axis_2_regression.py
@@ -128,6 +128,13 @@ class TestCollectPrDiffStatsParsing(unittest.TestCase):
                 "mergedAt": "2026-05-14T12:00:00Z",
             },
             {
+                "number": 902,
+                "headRefName": "test/issue-902",
+                "additions": 55,
+                "deletions": 5,
+                "mergedAt": "2026-05-14T12:15:00Z",
+            },
+            {
                 "number": 901,
                 "headRefName": "main-revert",
                 "additions": 5,
@@ -147,11 +154,14 @@ class TestCollectPrDiffStatsParsing(unittest.TestCase):
         finally:
             sr.subprocess.run = original_run
 
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["number"], 718)
         self.assertEqual(result[0]["issue"], 718)
         self.assertEqual(result[0]["loc"], 100)
-        self.assertIsNone(result[1]["issue"])
+        self.assertEqual(result[1]["number"], 902)
+        self.assertEqual(result[1]["issue"], 902)
+        self.assertEqual(result[1]["loc"], 60)
+        self.assertIsNone(result[2]["issue"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Axis #2 self-review의 PR diff parser가 ADR 0007의 slug 없는 branch 형태(`test/issue-902`)에서도 issue number를 추출하는지 회귀 테스트로 고정합니다.

Closes #2421

## 2. 영향 파일

- `tests/test_self_review_axis_2_regression.py` — test-only, load-bearing 아님

## 3. 리스크

- 리스크: branch issue regex refactor 시 slug 없는 branch가 unmatched로 빠져 axis #2 denominator가 왜곡될 수 있음.
- 배제 근거: fake `gh pr list` JSON에 `test/issue-902`를 추가하고 `issue == 902`, `loc == 60`을 직접 검증함.

## 4. 테스트

- `python3 -m pytest -q tests/test_self_review_axis_2_regression.py` → 7 passed
- `git diff --check` → pass
- `make check-branch` → pass
- Overlap preflight: latest `origin/main`=`76de5ccf6cf3bb484d87efbe98f31ad655351032`; branch file `tests/test_self_review_axis_2_regression.py`; main-side files empty; overlap empty; selection scan found no open PR or active Codex/Claude worktree touching this file.

## 5. Eval 영향

RAG/eval load-bearing 경로 변경 없음. Test-only self-review collector coverage라 public/private eval 동작 변화 없음.

## 6. 하위 호환

하위 호환 영향 없음. Collector runtime behavior, output schema, CLI flag 변경 없음.

## 7. 범위 외

- `scripts/claude-hooks/_self_review.py` runtime behavior 변경 없음.
- Axis #2 threshold/metric definition 변경 없음.
