### PR TITLE
test(answer): cover status reason verified bool

### DIFF
--- a/tests/test_answer_status_reason_enum.py
+++ b/tests/test_answer_status_reason_enum.py
@@ -101,6 +101,16 @@ class TestAnswerStatusReasonEnum(unittest.TestCase):
         )
         self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
 
+    def test_verified_flag_is_normalized_to_bool(self) -> None:
+        for raw_verified, expected in ((1, True), (0, False)):
+            with self.subTest(raw_verified=raw_verified):
+                result = answer_status_reason(
+                    status=ANSWER_STATUS_SUPPORTED,
+                    verified=raw_verified,
+                    verification_reasons=[],
+                )
+                self.assertIs(result["verified"], expected)
+
     def test_clarification_codes_pass_through_via_override(self) -> None:
         # rag_clarification uses the ``code=`` override to disambiguate
         # *why* a query was abstained from. Both clarification codes


### PR DESCRIPTION
## 1. Summary
- Add regression coverage that `answer_status_reason` stores `status_reason.verified` as a real boolean.
- Covers truthy and falsey caller values without changing production behavior.

## 2. Issue
Closes #2425

## 3. Changes
- `tests/test_answer_status_reason_enum.py`: add bool-normalization regression for `status_reason.verified`.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_answer_status_reason_enum.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — test-only contract coverage; no retrieval, answer generation, index, or eval behavior changed.

## 6. Overlap / multi-session preflight
- Selected file was clear of open PRs and scanned Codex/Claude worktrees before issue creation.
- Latest `origin/main` drift before push touched `tests/test_make_chunk_record.py`; overlap with this PR: none.

## 7. Risks / follow-ups
N/A
