### PR TITLE
test(planner): cover unknown backend fallback

### DIFF
--- a/tests/test_planner_protocol_regression.py
+++ b/tests/test_planner_protocol_regression.py
@@ -156,6 +156,12 @@ def test_default_planner_factory_returns_fresh_instances():
     assert p1 is not p2
 
 
+def test_default_planner_unknown_backend_falls_back_static(monkeypatch):
+    monkeypatch.setenv("BIDMATE_PLANNER_BACKEND", "not-a-real-backend")
+    planner = default_planner()
+    assert isinstance(planner, StaticPlanner)
+
+
 def test_default_planner_preset_kwargs_forwarded():
     planner = default_planner(preset_kwargs={"rerank": False})
     next_action, _ = planner.plan_next(


### PR DESCRIPTION
## 1. Summary
- Add regression coverage that an unknown `BIDMATE_PLANNER_BACKEND` value falls back to `StaticPlanner`.
- Keeps the planner factory deterministic/offline unless a known opt-in backend is selected.

## 2. Issue
Closes #2429

## 3. Changes
- `tests/test_planner_protocol_regression.py`: add unknown-backend fallback assertion using `monkeypatch`.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_planner_protocol_regression.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — test-only planner factory contract coverage; no retrieval, answer, index, or eval behavior changed.

## 6. Overlap / multi-session preflight
- Selected file was clear of open PRs and scanned Codex/Claude worktrees before issue creation.
- Latest `origin/main` drift before push touched `tests/test_parse_scale_expr.py`; overlap with this PR: none.

## 7. Risks / follow-ups
N/A
