### PR TITLE
test(synthesis): _render_with_synthesis/_build_user_prompt 렌더링·프롬프트 조립 커버리지

### DIFF
--- a/tests/test_synthesis_render_and_prompt.py
+++ b/tests/test_synthesis_render_and_prompt.py
@@ -1,0 +1,147 @@
+"""Unit coverage for ``rag_synthesis`` 합성-단계 문자열 조립 헬퍼.
+
+``_render_with_synthesis`` 는 요약 + verified claims + 근거부족(insufficiency)
+블록을 사람이 읽는 답변 문자열로 렌더링하고, ``_build_user_prompt`` 는 synthesis
+LLM 에 넘길 프롬프트(헤더 + claims + evidence + 고정 instruction)를 조립한다.
+둘 다 순수·결정적이지만 직접 단위 테스트가 없어, 조립 결과 전체 문자열과 조건부
+가지(citation suffix 필터, insufficiency 부분 조각, 빈 줄 필터, placeholder,
+고정 footer)를 oracle 로 고정한다.
+
+모든 기대값은 소스 실행으로 캡처했다.
+"""
+
+from __future__ import annotations
+
+from rag_synthesis import _build_user_prompt, _render_with_synthesis
+
+
+# ----------------------------------------------------------------------
+# _render_with_synthesis
+# ----------------------------------------------------------------------
+
+
+def test_render_lists_claims_with_filtered_citation_ids() -> None:
+    answer = {
+        "claims": [
+            {
+                "target": "입찰 마감",
+                "claim": "2026-07-01",
+                "citations": [{"chunk_id": "d::c1"}, {"chunk_id": "d::c2"}],
+            },
+            # 빈 chunk_id citation 은 필터되어 suffix 가 붙지 않는다
+            {"target": "사업 금액", "claim": "5천만원", "citations": [{"chunk_id": ""}]},
+            # citations 키 없음 → suffix 없음
+            {"target": "담당", "claim": "조달청"},
+        ]
+    }
+    assert _render_with_synthesis("요약문", answer) == (
+        "요약문\n"
+        "- 입찰 마감: 2026-07-01 [d::c1, d::c2]\n"
+        "- 사업 금액: 5천만원\n"
+        "- 담당: 조달청"
+    )
+
+
+def test_render_filters_empty_chunk_id_among_real_citations() -> None:
+    # real + 빈 chunk_id 혼합 시 빈 것만 제거되고 trailing ', ' 가 남지 않는다.
+    # (단일 빈 citation 만으로는 join 결과가 '' 라 필터 유무가 구분되지 않으므로 혼합으로 pin.)
+    answer = {
+        "claims": [
+            {"target": "혼합", "claim": "v", "citations": [{"chunk_id": "d::c3"}, {"chunk_id": ""}]}
+        ]
+    }
+    assert _render_with_synthesis("S", answer) == "S\n- 혼합: v [d::c3]"
+
+
+def test_render_appends_insufficiency_with_reasons_and_missing_targets() -> None:
+    # reasons/missing_targets 모두 2원소 — 두 join separator(', ')를 함께 pin 한다
+    # (단일 원소면 '|' 등으로 바뀌어도 출력이 같아 회귀가 보이지 않는다).
+    answer = {
+        "claims": [{"target": "X", "claim": "Y", "citations": []}],
+        "insufficiency": {
+            "reasons": ["근거 없음", "모호"],
+            "missing_targets": ["예산", "일정"],
+        },
+    }
+    assert _render_with_synthesis("요약", answer) == (
+        "요약\n- X: Y\n- 근거 부족: 사유: 근거 없음, 모호; 확인 필요 대상: 예산, 일정"
+    )
+
+
+def test_render_insufficiency_reasons_only() -> None:
+    assert _render_with_synthesis("S", {"insufficiency": {"reasons": ["r1"]}}) == (
+        "S\n- 근거 부족: 사유: r1"
+    )
+
+
+def test_render_insufficiency_missing_targets_only() -> None:
+    assert _render_with_synthesis("S", {"insufficiency": {"missing_targets": ["t1"]}}) == (
+        "S\n- 근거 부족: 확인 필요 대상: t1"
+    )
+
+
+def test_render_empty_insufficiency_emits_no_shortage_line() -> None:
+    # reasons/missing_targets 둘 다 없으면 '근거 부족' 줄 자체가 생략된다(falsy {} → L306 단락).
+    assert _render_with_synthesis("S", {"insufficiency": {}}) == "S"
+
+
+def test_render_truthy_but_empty_insufficiency_omits_shortage_line() -> None:
+    # truthy 하지만 reasons/missing_targets 가 빈 리스트면 L314 'if details' 가지에서
+    # 줄이 생략된다(falsy {} 가 아니라 빈 조각 경로를 직접 도달시켜 pin).
+    answer = {"insufficiency": {"reasons": [], "missing_targets": []}}
+    assert _render_with_synthesis("S", answer) == "S"
+
+
+def test_render_empty_answer_returns_summary_only() -> None:
+    assert _render_with_synthesis("only summary", {}) == "only summary"
+
+
+def test_render_filters_empty_summary_line() -> None:
+    # 빈 summary 줄은 falsy 라 출력에서 제외된다(claim 줄만 남는다).
+    assert _render_with_synthesis("", {"claims": [{"target": "a", "claim": "b"}]}) == "- a: b"
+
+
+# ----------------------------------------------------------------------
+# _build_user_prompt
+# ----------------------------------------------------------------------
+
+_FOOTER = (
+    "Rewrite the summary in 2-4 natural Korean sentences. Cite by "
+    "[chunk_id]. Do not add facts beyond the claims. Call emit_summary."
+)
+
+
+def test_build_user_prompt_full_assembly() -> None:
+    analysis = {"query_type": "deadline", "entities": ["조달청", "입찰"]}
+    answer = {"claims": [{"target": "마감", "claim": "7월", "citations": [{"chunk_id": "d::c1"}]}]}
+    evidence = [{"chunk_id": "d::c1", "doc_id": "d", "agency": "조달청", "text": "본문"}]
+    assert _build_user_prompt("질의?", analysis, answer, evidence) == (
+        "Query: 질의?\n"
+        "Query type: deadline\n"
+        "Entities: 조달청, 입찰\n\n"
+        "Verified claims (you must respect these):\n"
+        "- 마감: 7월 [d::c1]\n\n"
+        "Evidence chunks (your only citation universe):\n"
+        "[d::c1] doc=d agency=조달청\n본문\n\n"
+        + _FOOTER
+    )
+
+
+def test_build_user_prompt_empty_inputs_use_placeholders() -> None:
+    # query_type 누락 → 'unknown', entities 누락 → 'none', claims/evidence 없음 → placeholder.
+    assert _build_user_prompt("q", {}, {}, []) == (
+        "Query: q\n"
+        "Query type: unknown\n"
+        "Entities: none\n\n"
+        "Verified claims (you must respect these):\n"
+        "(no claims)\n\n"
+        "Evidence chunks (your only citation universe):\n"
+        "(no evidence)\n\n"
+        + _FOOTER
+    )
+
+
+def test_build_user_prompt_ends_with_fixed_instruction_footer() -> None:
+    # footer 는 입력과 무관한 불변 계약이다.
+    prompt = _build_user_prompt("아무 질의", {"query_type": "x"}, {}, [])
+    assert prompt.endswith(_FOOTER)


### PR DESCRIPTION
## 1. 무엇을 / 왜
`rag_synthesis.py` 의 합성 단계 문자열 조립 헬퍼 2종(`_render_with_synthesis`, `_build_user_prompt`)은 순수·결정적이지만 직접 단위 테스트가 0건이었다 (`git grep -l -F` 로 origin/main 미커버 확인). 답변 dict/근거 list → 사람·LLM 대면 문자열을 만드는 경로라, citation 필터·근거부족 조립·고정 프롬프트 계약이 조용히 회귀하면 답변 표면이 틀어진다.

## 2. 변경 요약
- `tests/test_synthesis_render_and_prompt.py` 신규 (12 cases, test-only)
- `_render_with_synthesis`: claims 줄 + citation suffix(빈 chunk_id 필터, **real+empty 혼합으로 필터 직접 pin**), insufficiency 부분 조각(reasons/missing_targets **각 2원소로 separator pin**, falsy {} 및 truthy-empty 양쪽서 줄 생략), 빈 summary 줄 필터
- `_build_user_prompt`: 전체 프롬프트 문자열 byte 단위 고정(헤더 기본값 unknown/none + claims/evidence placeholder + 고정 instruction footer)

## 3. 어떻게 검증했나
- `pytest` → 12 passed, ruff/pyright clean, import-safety 확인
- 별도 레인 code-reviewer adversarial mutation pass: 23 mutant 실행 — 초기 10 케이스서 16/18 catch, vacuous 0. MEDIUM 2건(단일원소 citation 필터·missing_targets separator 미pin) + LOW 1건(truthy-empty insufficiency 미도달) 전부 반영해 해당 mutant 까지 catch 하도록 강화(10→12 cases).
- 모든 기대값은 소스 실행으로 캡처(oracle-backed)

## 4. 영향 범위 / 롤백
test-only. 소스 무수정 → 런타임/배포 영향 없음. 롤백 = 파일 삭제.

## 5. Eval 영향
N/A — test-only PR, load-bearing 소스 무수정(동작 변경 없음). 기존 렌더링/프롬프트 동작을 고정만 함.

## 6. 리스크 / 후속
리스크 낮음(순수 함수, 전체 문자열 단언). 하위 `_format_claims_for_prompt`/`_format_evidence_for_prompt` 는 기 커버.

## 7. 체크리스트
- [x] Issue 참조 (Closes #2428)
- [x] 컨벤션 브랜치 (`test/issue-2428-synthesis-render`)
- [x] 테스트 통과 (12 passed, ruff/pyright clean)
- [x] One PR one concern (합성 문자열 조립 = 한 concern)

Closes #2428

🤖 Generated with [Claude Code](https://claude.com/claude-code)