### PR TITLE
test(agent-react): cover react loop stage budget

### DIFF
--- a/tests/test_agent_react_regression.py
+++ b/tests/test_agent_react_regression.py
@@ -93,6 +93,13 @@ def test_agent_react_stage_latency_has_react_loop_ms():
     assert "react_loop_ms" in stages, f"react_loop_ms missing: {list(stages)}"
 
 
+def test_agent_react_react_loop_stage_budget_is_positive_number():
+    config = _load_config()
+    budget = config["stage_latency_budgets"]["agent_react"]["react_loop_ms"]["p95_ms"]
+    assert isinstance(budget, (int, float))
+    assert budget > 0
+
+
 # ---------------------------------------------------------------------------
 # 4. ADR 0042 file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. Summary
- Add regression coverage that `agent_react` has a positive numeric `react_loop_ms.p95_ms` stage latency budget.
- Keeps the existing config shape pinned without production changes.

## 2. Issue
Closes #2433

## 3. Changes
- `tests/test_agent_react_regression.py`: assert `stage_latency_budgets.agent_react.react_loop_ms.p95_ms` is numeric and positive.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_agent_react_regression.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — test-only config contract coverage; no retrieval, answer, index, or eval runtime behavior changed.

## 6. Overlap / multi-session preflight
- Selected file was clear of open PRs and scanned Codex/Claude worktrees before issue creation.
- Latest `origin/main` drift before push touched `tests/test_synthesis_render_and_prompt.py`; overlap with this PR: none.

## 7. Risks / follow-ups
N/A
