### PR TITLE
test(latency): cover stage timer exception path

### DIFF
--- a/tests/test_latency_instrumentation.py
+++ b/tests/test_latency_instrumentation.py
@@ -25,6 +25,14 @@ class StageTimerTest(unittest.TestCase):
             time.sleep(0.001)
         self.assertGreater(bucket["stage_ms"], first)
 
+    def test_records_elapsed_when_block_raises(self) -> None:
+        bucket: dict[str, float] = {}
+        with self.assertRaises(RuntimeError):
+            with _StageTimer(bucket, "stage_ms"):
+                raise RuntimeError("boom")
+        self.assertIn("stage_ms", bucket)
+        self.assertGreaterEqual(bucket["stage_ms"], 0.0)
+
 
 class RunRagQueryTimingTest(unittest.TestCase):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## 1. Summary
- Add regression coverage that `_StageTimer` records elapsed time even when the timed block raises.
- Keeps failed-stage diagnostics observable without production changes.

## 2. Issue
Closes #2437

## 3. Changes
- `tests/test_latency_instrumentation.py`: add exception-path `_StageTimer` assertion.

## 4. Validation
- [x] `python3 -m pytest -q tests/test_latency_instrumentation.py`
- [x] `git diff --check`
- [x] `make check-branch`

## 5. Eval impact
N/A — test-only observability contract coverage; no retrieval, answer, index, or eval behavior changed.

## 6. Overlap / multi-session preflight
- Selected file was clear of open PRs and scanned Codex/Claude worktrees before issue creation.
- Branch was created from latest `origin/main`; final pre-push drift overlap: none.

## 7. Risks / follow-ups
N/A
