### PR TITLE
test(chunk-health): cover nested closing punctuation

### DIFF
--- a/tests/test_chunk_health.py
+++ b/tests/test_chunk_health.py
@@ -200,6 +200,7 @@ class TestIsMidSentenceCut(unittest.TestCase):
         # Common ending: ``이다."`` / ``이다.)`` → still clean
         self.assertFalse(_is_mid_sentence_cut('대상입니다."'))
         self.assertFalse(_is_mid_sentence_cut("의함)"))
+        self.assertFalse(_is_mid_sentence_cut("의함)』"))
 
     def test_empty_string_is_not_mid_cut(self):
         # Empty chunks are handled by the empty_chunks metric; this fn


### PR DESCRIPTION
## Summary
- add regression coverage for `_is_mid_sentence_cut` stripping multiple trailing closing punctuation characters

## Issue
Closes #2442

## Validation
- [x] `python3 -m pytest -q tests/test_chunk_health.py` → 18 passed
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only diagnostics coverage; no retrieval/answer/eval behavior change.
