### PR TITLE
fix(agent-evals): post-merge cross-family review hardening (fail-closed boundaries + per-accepted metric)

### DIFF
--- a/agent-evals/adapters/bidmate/oracle_bidmate.py
+++ b/agent-evals/adapters/bidmate/oracle_bidmate.py
@@ -135,24 +135,32 @@ def cross_family_review(
 ) -> Any:  # oracle.ReviewerVerdict | None — oracle is importlib-loaded, not a static type
     """Run a cross-family reviewer over the candidate payload, egress-gated.
 
-    Egress happens ONLY when ``public_attestation`` is True.  When it is False this
-    returns ``None`` and ``payload_provider`` is NOT invoked, so no payload (issue +
-    patch) is ever built or sent.  The family validity check is intentionally NOT
-    done here; it is enforced downstream in ``oracle.decide_verdict`` so that even a
-    same-family reviewer's verdict is neutralized to ``NECESSARY_GATE_ONLY``.
+    Egress happens ONLY when ``public_attestation`` is exactly ``True``.  For any
+    other value — ``False`` *or a truthy non-bool such as the string ``"false"``* —
+    this returns ``None`` and ``payload_provider`` is NOT invoked, so no payload
+    (issue + patch) is ever built or sent.  The strict ``is True`` test mirrors the
+    fail-closed discipline in ``oracle.decide_verdict``: a truthiness check here
+    would let a malformed truthy value open egress *before* the downstream verdict
+    caps the tier, leaking the payload the caller never attested as public (ADR
+    0005).  The family validity check is intentionally NOT done here; it is enforced
+    downstream in ``oracle.decide_verdict`` so even a same-family reviewer's verdict
+    is neutralized to ``NECESSARY_GATE_ONLY``.
 
     ``reviewer_call`` is injectable; tests pass a fake so the real codex egress path
     is never exercised by the suite.  ``candidate_family`` is accepted for interface
     symmetry / future provenance and is not used to short-circuit egress.
     """
 
-    if not public_attestation:
+    if public_attestation is not True:
         return None
     call = reviewer_call if reviewer_call is not None else _default_codex_reviewer
     payload = payload_provider()
     accepted, reason_code = call(payload)
     return oracle.ReviewerVerdict(
-        accepted=bool(accepted),
+        # Strict identity, not bool(): a reviewer_call returning a truthy non-bool
+        # (e.g. the string "false") must NOT be widened to acceptance past
+        # decide_verdict's ``accepted is True`` guard.
+        accepted=accepted is True,
         reviewer_family=reviewer_family,
         reason_code=str(reason_code),
     )

--- a/agent-evals/adapters/bidmate/runner.py
+++ b/agent-evals/adapters/bidmate/runner.py
@@ -126,9 +126,13 @@ def run_one(
             "usd": float(cost.get("usd", 0.0)),
         },
         "gate_results": {
-            "hidden_test_gate": bool(gate_results.get("hidden_test_gate", False)),
-            "pytest_pass": bool(gate_results.get("pytest_pass", False)),
-            "regression_pass": bool(gate_results.get("regression_pass", False)),
+            # Strict identity, not bool(): a candidate may return a non-bool truthy
+            # value for a FAILED gate (e.g. the string "false"); bool() would coerce
+            # that to a pass and let the verdict reach ACCEPTED. A gate passes only
+            # when the candidate reports exactly True — anything else is fail-closed.
+            "hidden_test_gate": gate_results.get("hidden_test_gate") is True,
+            "pytest_pass": gate_results.get("pytest_pass") is True,
+            "regression_pass": gate_results.get("regression_pass") is True,
             "hard_gates": list(gate_results.get("hard_gates", [])),
             "tier": gate_results.get("tier"),
         },

--- a/scripts/agent_evals_report.py
+++ b/scripts/agent_evals_report.py
@@ -102,6 +102,17 @@ def _read_run_logs(runs_dir: Path) -> list[dict[str, Any]]:
     manifest = runner.read_run_manifest(runs_dir)
     if manifest is not None:
         names = manifest.get("run_logs") or []
+        # Enforce the "listed basenames only" contract before joining. A non-basename
+        # entry (``../old.json``, an absolute path, or a nested ``a/b.json``) would
+        # let ``runs_dir / name`` escape the runs dir and read a stale log outside the
+        # current run — defeating the manifest-scoping invariant. Reject loudly.
+        bad = [n for n in names if not isinstance(n, str) or n == "" or Path(n).name != n]
+        if bad:
+            raise ValueError(
+                f"run_manifest.json lists non-basename entries {bad[:3]}"
+                f"{'...' if len(bad) > 3 else ''}; the manifest contract is plain "
+                "basenames within the runs dir only."
+            )
         missing = [name for name in names if not (runs_dir / name).exists()]
         if missing:
             preview = missing[:3]
@@ -140,6 +151,12 @@ def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float | None:
     the cost metric: a baseline that solves nothing would tie or beat a candidate
     that solves at nonzero cost. An undefined value is dropped from the paired
     sample (see ``_paired_rows``) rather than scored as free.
+
+    The per-accepted numerator is the TOTAL effort across ALL seed runs in the group
+    (accepted AND rejected), divided by the accepted count — a cost-efficiency
+    metric: "effort spent to obtain one accepted solve". Summing only the accepted
+    runs' effort would understate cost, since the failed attempts also consumed
+    human-minutes / spend (matches the module docstring's "total / accepted count").
     """
 
     n_runs = len(runs)
@@ -152,12 +169,12 @@ def _metric_value(metric: str, runs: list[dict[str, Any]]) -> float | None:
         return ((n_accepted / n_runs) * weight) if n_runs else 0.0
     if metric == "human_min_per_accepted":
         if n_accepted == 0:
-            return None  # undefined: no accepted run to amortize human-minutes over
-        return sum(float(r.get("human_minutes", 0.0)) for r in accepted_runs) / n_accepted
+            return None  # undefined: no accepted run to amortize total effort over
+        return sum(float(r.get("human_minutes", 0.0)) for r in runs) / n_accepted
     if metric == "cost_per_accepted":
         if n_accepted == 0:
-            return None  # undefined: no accepted run to amortize cost over
-        return sum(float(r.get("cost", {}).get("usd", 0.0)) for r in accepted_runs) / n_accepted
+            return None  # undefined: no accepted run to amortize total spend over
+        return sum(float(r.get("cost", {}).get("usd", 0.0)) for r in runs) / n_accepted
     raise ValueError(f"unknown metric: {metric}")
 
 

--- a/scripts/agent_evals_run.py
+++ b/scripts/agent_evals_run.py
@@ -80,14 +80,16 @@ def _verdict_for_run(run_log: dict[str, Any], oracle, *, public_attestation: boo
 
     gr = run_log["gate_results"]
     hard = tuple(gr.get("hard_gates", ()))
+    # Strict identity to match the fail-closed run-log writer (runner.run_one): a
+    # gate counts as passing only when it is exactly True, never a coerced truthy.
     gates = oracle.GateResults(
-        hidden_test_gate=bool(gr.get("hidden_test_gate", False)),
-        pytest_pass=bool(gr.get("pytest_pass", False)),
-        regression_pass=bool(gr.get("regression_pass", False)),
+        hidden_test_gate=gr.get("hidden_test_gate") is True,
+        pytest_pass=gr.get("pytest_pass") is True,
+        regression_pass=gr.get("regression_pass") is True,
         hard_gates=hard,
     )
     reviewer = None
-    if public_attestation:
+    if public_attestation is True:
         accepted, reason_code = _stub_cross_family_reviewer(
             playbook=run_log["playbook"],
             task_id=run_log["task_id"],

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -851,3 +851,164 @@ def test_report_glob_fallback_when_no_manifest(tmp_path) -> None:
     logs = report_script._read_run_logs(runs_dir)
     assert sorted({log["task_id"] for log in logs}) == ["T-x"]
     assert len(logs) == 2
+
+
+# --------------------------------------------------------------------------- #
+# #2441 — post-merge cross-family review hardening (fail-closed + metric)      #
+# --------------------------------------------------------------------------- #
+
+
+def test_cross_family_review_non_true_attestation_returns_none() -> None:
+    # #2441 P1a: egress opens ONLY on `public_attestation is True`. A truthy non-bool
+    # (e.g. the string "false") must NOT invoke payload_provider or the reviewer.
+    ob = _oracle_bidmate()
+
+    def exploding_provider():
+        raise AssertionError("provider must not run when attestation is not exactly True")
+
+    assert (
+        ob.cross_family_review(
+            exploding_provider,
+            public_attestation="false",  # truthy, but not True
+            candidate_family="cand",
+            reviewer_family="other",
+            reviewer_call=lambda _p: (True, "ok"),
+        )
+        is None
+    )
+
+
+def test_evaluate_truthy_attestation_does_not_egress() -> None:
+    # #2441 P1a end-to-end: gates pass, so only the attestation gate stands between
+    # the patch and the external reviewer; a non-True attestation must skip egress.
+    ob = _oracle_bidmate()
+
+    class _Proc:
+        returncode = 0
+
+    def fake_run(_cmd, **_kwargs):
+        return _Proc()
+
+    def exploding_provider():
+        raise AssertionError("payload must NOT egress under a non-True attestation")
+
+    out = ob.evaluate(
+        Path("/tmp/x"),
+        task={"task_id": "T-attest"},
+        candidate_family="cand",
+        public_attestation="false",  # truthy, but not exactly True
+        reviewer_family="other",
+        payload_provider=exploding_provider,
+        hidden_test_cmd=["h"],
+        pytest_cmd=["p"],
+        regression_cmd=["r"],
+        runner_subprocess=fake_run,
+        reviewer_call=lambda _p: (True, "ok"),
+    )
+    assert out["egress"] == "skipped"
+    assert out["tier"] == "NECESSARY_GATE_ONLY"
+    assert out["reviewer_family"] is None
+
+
+def test_cross_family_review_truthy_accepted_is_strict_false() -> None:
+    # #2441 P1b: a reviewer_call returning a truthy NON-bool "accepted" (e.g. the
+    # string "false") must not be widened past decide_verdict's `accepted is True`.
+    ob = _oracle_bidmate()
+    verdict = ob.cross_family_review(
+        lambda: "payload",
+        public_attestation=True,
+        candidate_family="cand",
+        reviewer_family="other",
+        reviewer_call=lambda _p: ("false", "reject"),
+    )
+    assert verdict is not None
+    assert verdict.accepted is False  # strict identity, not bool("false") == True
+
+
+def test_run_one_non_bool_gate_is_fail_closed() -> None:
+    # #2441 P1c (write side): a candidate returning a non-bool truthy FAILED gate
+    # (e.g. "false") must be recorded as a fail, never coerced to a pass.
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_failclosed_write")
+
+    class _Proc:
+        returncode = 0
+
+    def cand(**_kwargs):
+        return {
+            "gate_results": {
+                "hidden_test_gate": "false",
+                "pytest_pass": "false",
+                "regression_pass": "false",
+                "hard_gates": [],
+            },
+            "cost": {"usd": 0.0},
+            "human_minutes": 0.0,
+        }
+
+    log = runner.run_one(
+        start_commit="HEAD",
+        task_id="T",
+        playbook="v1_spec_first",
+        seed=17,
+        candidate=cand,
+        repo_root=Path("/tmp"),
+        subprocess_run=lambda *a, **k: _Proc(),
+        workdir_factory=lambda **k: "/tmp/agent-evals-failclosed-nonexistent",
+    )
+    gr = log["gate_results"]
+    assert gr["hidden_test_gate"] is False
+    assert gr["pytest_pass"] is False
+    assert gr["regression_pass"] is False
+
+
+def test_verdict_for_run_non_bool_gate_fails_closed() -> None:
+    # #2441 P1c (read side): even a run-log carrying a non-bool truthy gate value must
+    # be treated as a fail by _verdict_for_run, never ACCEPTED.
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_failclosed_read")
+    oracle = _oracle()
+    run_log = {
+        "task_id": "T-2",
+        "playbook": "v1_spec_first",
+        "seed": 17,
+        "gate_results": {
+            "hidden_test_gate": "false",
+            "pytest_pass": "false",
+            "regression_pass": "false",
+            "hard_gates": [],
+        },
+    }
+    tier = run_script._verdict_for_run(run_log, oracle, public_attestation=True)
+    assert tier != "ACCEPTED"
+
+
+def test_report_manifest_rejects_non_basename_entries(tmp_path) -> None:
+    # #2441 P2: a manifest entry that is not a plain basename (../, absolute, nested)
+    # would let the reader escape the runs dir; it must be rejected loudly.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_basename")
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_basename")
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir(parents=True)
+    _write_log(runner, runs_dir, "T-a", "v0_naive", 17)
+    (runs_dir / runner.RUN_MANIFEST_NAME).write_text(
+        json.dumps({"run_logs": ["../escape.json", "T-a__v0_naive__seed17.json"]}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-basename"):
+        report_script._read_run_logs(runs_dir)
+
+
+def test_metric_per_accepted_counts_total_effort() -> None:
+    # #2441 P3: human_min_per_accepted / cost_per_accepted divide TOTAL effort across
+    # ALL seed runs (accepted AND rejected) by the accepted count — failed attempts
+    # cost effort too. Summing only accepted runs would understate per-accepted cost.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_total_effort")
+    runs = [
+        {"gate_results": {"tier": "ACCEPTED"}, "cost": {"usd": 3.0}, "human_minutes": 2.0},
+        {"gate_results": {"tier": "NECESSARY_GATE_ONLY"}, "cost": {"usd": 5.0}, "human_minutes": 4.0},
+    ]
+    assert report_script._metric_value("cost_per_accepted", runs) == 8.0  # (3+5)/1, not 3/1
+    assert report_script._metric_value("human_min_per_accepted", runs) == 6.0  # (2+4)/1
+    # zero accepted stays UNDEFINED (dropped), never 0.0.
+    zero = [{"gate_results": {"tier": "NECESSARY_GATE_ONLY"}, "cost": {"usd": 5.0}, "human_minutes": 4.0}]
+    assert report_script._metric_value("cost_per_accepted", zero) is None
+    assert report_script._metric_value("human_min_per_accepted", zero) is None


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

머지된 PR3 (#2411, squash `48c8bce9`) 에 대한 **post-merge 로컬 cross-family adversarial review** (`codex exec --sandbox read-only` — agent-evals 가 측정하려는 thesis 메커니즘 그 자체) 가 잔존 결함 6개를 표면화했다. PR3 세션은 `decide_verdict` 의 truthy-bypass class 는 고쳤으나 **인접한 adapter/runner 경계**에는 같은 fail-closed 규율을 적용하지 못했고, 두 per-accepted 지표가 자신의 docstring 과 모순됐다. 6개 모두 stub smoke 경로(stub 은 실제 bool + 0 비용/시간 방출)에는 영향이 없어 커밋된 holdout aggregate 는 byte-identical — malformed 입력 / nonzero-rejected 입력에서만 드러나는 fail-open · validity edge 다.

Closes #2441

## 2. 영향 파일

- `agent-evals/adapters/bidmate/oracle_bidmate.py` — egress gate `is True` + reviewer acceptance `is True` (P1a/P1b). **비 load-bearing** (`scripts/_governance.py:LOAD_BEARING_PATHS` 미포함)
- `agent-evals/adapters/bidmate/runner.py` — `run_one` candidate gate `is True` (P1c write). 비 load-bearing
- `scripts/agent_evals_run.py` — `_verdict_for_run` gate/attestation `is True` (P1c read). 비 load-bearing
- `scripts/agent_evals_report.py` — manifest basename 검증 (P2) + per-accepted total-effort numerator (P3). 비 load-bearing
- `tests/test_agent_evals_runner.py` — finding별 회귀 테스트 7개

## 3. 리스크

가장 가능성 높은 깨짐 경로 = stub smoke 경로의 동작이 바뀌어 holdout aggregate 가 변하는 것. 배제 확인: stub candidate 는 실제 `True` 게이트 + 0.0 비용/시간을 방출하므로 `is True` 게이트는 그대로 통과하고, total-over-all-runs == accepted-only-sum == 0.0 으로 동일. 재생성한 aggregate 가 `git diff` 빈 결과(byte-identical)임을 확인. 둘째 경로 = manifest basename 가드가 정상 basename 을 오탐. `Path(n).name != n` 은 평범한 `<task>__<playbook>__seed<seed>.json` 에 대해 거짓이므로 정상 엔트리는 통과 (테스트로 확인).

## 4. 테스트

finding별 회귀 테스트 7개 추가 (변경 전 fail / 후 pass):
- P1a: `test_cross_family_review_non_true_attestation_returns_none` (직접) + `test_evaluate_truthy_attestation_does_not_egress` (e2e, exploding provider 가 호출되면 fail)
- P1b: `test_cross_family_review_truthy_accepted_is_strict_false`
- P1c: `test_run_one_non_bool_gate_is_fail_closed` (write) + `test_verdict_for_run_non_bool_gate_fails_closed` (read)
- P2: `test_report_manifest_rejects_non_basename_entries`
- P3: `test_metric_per_accepted_counts_total_effort`

`python3 -m pytest tests/test_agent_evals_runner.py tests/test_agent_evals_core.py tests/test_agent_evals_gitignore.py -q` → **111 passed**.

Multi-session/parallel worktree: overlap-preflight evidence = `reports/agent_loop/overlap_preflight.md` (Blockers 없음, agent-evals 표면 동시 작업 0).

## 5. Eval 영향

**All `·` (RAG 외 변경).** agent-evals 표면은 load-bearing 아님 — `rag_*`/`ingestion`/`eval/`/`api/`/`docs/adr`/`build_index.py` 어느 것도 건드리지 않음. 커밋된 holdout smoke aggregate (`agent-evals/reports/holdout-v0-vs-v1.aggregate.json`) 는 수정 후 재생성해도 byte-identical (위 §3). private real-eval 표면 무관, README metric 무관.

## 6. 하위 호환

깨짐 없음. 답변 계약(ADR 0003)·CLI flag·스키마 변경 없음. `run_manifest.json` 포맷 불변(reader 만 basename 계약을 강제하도록 강화 — 기존 writer 는 이미 basename 만 방출). per-accepted 지표 의미는 docstring 에 명시된 "total / accepted count" 로 코드를 일치시킨 것(계약 변경 아님, 코드-문서 불일치 수정).

## 7. 범위 외

- 머지된 PR3 (#2411) 자체는 되돌리지 않음 — 이 finding 들은 머지 이후 발견되어 별도 follow-up 으로 추적(one concern).
- `_default_codex_reviewer` 실제 egress 경로는 여전히 테스트 미적용(설계상 — 테스트는 `reviewer_call` 주입). 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
