### PR TITLE
test(hooks): cover plan slug malformed JSON

### DIFF
--- a/tests/test_plan_slug_race_hook_regression.py
+++ b/tests/test_plan_slug_race_hook_regression.py
@@ -68,6 +68,20 @@ class TestPlanSlugRaceHook(_BaseHookCase):
         result = self._run({"tool_name": "Edit", "tool_input": {"file_path": "x"}})
         self.assertEqual(0, result.returncode, result.stderr)
 
+    def test_malformed_json_is_allowed(self) -> None:
+        env = os.environ.copy()
+        env["HOME"] = str(self._home)
+        result = subprocess.run(
+            ["bash", str(HOOK)],
+            input="{not-json",
+            text=True,
+            capture_output=True,
+            env=env,
+            cwd=str(self._wt_root),
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
     def test_write_outside_plans_dir_is_allowed(self) -> None:
         target = Path(self._tmp) / "outside.md"
         result = self._run({"tool_name": "Write", "tool_input": {"file_path": str(target)}})


### PR DESCRIPTION
## Summary
- add regression coverage that `plan-slug-race.sh` fails open on malformed PreToolUse JSON

## Issue
Closes #2447

## Validation
- [x] `python3 -m pytest -q tests/test_plan_slug_race_hook_regression.py` → 10 passed
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only hook contract coverage; no retrieval/answer/eval behavior change.
