### PR TITLE
test(scripts): page_metadata_recovery_audit region/bbox/page 술어 헬퍼 커버리지

### DIFF
--- a/tests/test_page_metadata_predicates.py
+++ b/tests/test_page_metadata_predicates.py
@@ -1,0 +1,157 @@
+"""Unit coverage for ``scripts/page_metadata_recovery_audit.py`` 구조 술어 헬퍼.
+
+페이지 메타데이터 복구 감사가 항목을 분류할 때 쓰는 순수 술어들이다. 경계가
+조용히 회귀하면 감사 집계(coverage_block)가 틀어지므로 oracle 로 고정한다. 특히:
+
+- ``bool`` 은 ``int`` 의 subclass 라 ``[True, False]`` 가 page_span 으로,
+  ``page_number=True`` 가 region page 로 **통과**한다(의도된 동작, 핀으로 고정).
+- ``_is_bbox`` 는 ``float()`` coercion 을 쓰므로 ``"1.0"`` 같은 숫자 문자열도 허용.
+- ``_regions`` 는 ``list`` 가 아니면 ``[]`` — tuple 도 제외된다(문자/엔트리 오판 방지).
+- ``_has_page_metadata`` 는 ``page_span`` 유효 **또는** region page 존재의 OR.
+
+모든 기대값은 pristine 소스 실행으로 캡처했다.
+``from scripts.page_metadata_recovery_audit import ...`` (implicit namespace).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.page_metadata_recovery_audit import (
+    _has_page_metadata,
+    _has_region_bbox,
+    _has_region_page,
+    _is_bbox,
+    _is_page_span,
+    _regions,
+)
+
+
+# ----------------------------------------------------------------------
+# _is_page_span  (정확히 길이 2의 int 리스트)
+# ----------------------------------------------------------------------
+
+PAGE_SPAN_CASES = [
+    ([1, 2], True),
+    ([1, 2, 3], False),       # 길이 != 2
+    ([1], False),             # 길이 != 2
+    ([], False),              # 길이 != 2
+    ([1, "x"], False),        # 전부 int 아님
+    ("x", False),             # list 아님
+    (None, False),            # list 아님
+    ([1.0, 2.0], False),      # float 은 int 아님
+    ([True, False], True),    # bool 은 int subclass → 통과(의도)
+    ([1, True], True),        # 혼합도 통과
+]
+
+
+@pytest.mark.parametrize("value, expected", PAGE_SPAN_CASES)
+def test_is_page_span(value: Any, expected: bool) -> None:
+    assert _is_page_span(value) is expected
+
+
+# ----------------------------------------------------------------------
+# _is_bbox  (정확히 길이 4의 float-coercible 리스트)
+# ----------------------------------------------------------------------
+
+BBOX_CASES = [
+    ([1, 2, 3, 4], True),
+    ([1.5, 2.5, 3.5, 4.5], True),
+    (["1.0", "2", "3", "4"], True),   # float-coercible 문자열 허용
+    ([1, 2, 3], False),               # 길이 != 4
+    ([1, 2, 3, 4, 5], False),         # 길이 != 4
+    ([1, 2, 3, "x"], False),          # float() ValueError arm
+    ([1, 2, 3, None], False),         # float(None) TypeError arm (양 except arm 핀)
+    ("x", False),                     # list 아님
+    (None, False),                    # list 아님
+]
+
+
+@pytest.mark.parametrize("value, expected", BBOX_CASES)
+def test_is_bbox(value: Any, expected: bool) -> None:
+    assert _is_bbox(value) is expected
+
+
+# ----------------------------------------------------------------------
+# _regions  (list 안의 Mapping 항목만 필터; 그 외 -> [])
+# ----------------------------------------------------------------------
+
+
+def test_regions_filters_non_mappings() -> None:
+    assert _regions([{"a": 1}, "x", 5, {"b": 2}]) == [{"a": 1}, {"b": 2}]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "x",            # str (list 아님)
+        None,           # None
+        [],             # 빈 list
+        [1, 2, 3],      # Mapping 없음
+        ({"a": 1},),    # tuple 은 list 아님 → []
+    ],
+)
+def test_regions_non_list_or_no_mapping_yields_empty(value: Any) -> None:
+    assert _regions(value) == []
+
+
+# ----------------------------------------------------------------------
+# _has_region_page  (regions 중 page_number 가 int 인 것 any)
+# ----------------------------------------------------------------------
+
+HAS_REGION_PAGE_CASES = [
+    ({"regions": [{"page_number": 5}]}, True),
+    ({"regions": [{"page_number": "5"}]}, False),          # str 은 int 아님
+    ({"regions": [{"page_number": True}]}, True),          # bool 은 int subclass
+    ({"regions": [{"x": 1}, {"page_number": 3}]}, True),   # any over 다수
+    ({"regions": []}, False),                              # 빈 regions
+    ({"regions": "x"}, False),                             # non-list regions → []
+    ({}, False),                                           # regions 키 없음
+]
+
+
+@pytest.mark.parametrize("item, expected", HAS_REGION_PAGE_CASES)
+def test_has_region_page(item: Any, expected: bool) -> None:
+    assert _has_region_page(item) is expected
+
+
+# ----------------------------------------------------------------------
+# _has_region_bbox  (regions 중 유효 bbox any)
+# ----------------------------------------------------------------------
+
+HAS_REGION_BBOX_CASES = [
+    ({"regions": [{"bbox": [1, 2, 3, 4]}]}, True),
+    ({"regions": [{"bbox": [1, 2]}]}, False),   # 무효 bbox(길이)
+    ({"regions": [{}]}, False),                 # bbox 키 없음 → _is_bbox(None)
+    ({"regions": "x"}, False),                  # non-list regions → []
+    ({}, False),                                # regions 키 없음
+]
+
+
+@pytest.mark.parametrize("item, expected", HAS_REGION_BBOX_CASES)
+def test_has_region_bbox(item: Any, expected: bool) -> None:
+    assert _has_region_bbox(item) is expected
+
+
+# ----------------------------------------------------------------------
+# _has_page_metadata  (page_span 유효 OR region page 존재)
+# ----------------------------------------------------------------------
+
+HAS_PAGE_METADATA_CASES = [
+    ({"page_span": [1, 2]}, True),                                   # page_span 분기
+    ({"regions": [{"page_number": 3}]}, True),                       # region 분기
+    # page_span 무효(길이 1)이어도 region 유효 → region 분기로 True
+    ({"page_span": [1], "regions": [{"page_number": 7}]}, True),
+    # page_span 유효 → regions 무효여도 short-circuit True
+    ({"page_span": [1, 2], "regions": "x"}, True),
+    # 양쪽 다 무효 → False
+    ({"page_span": [1], "regions": [{"page_number": "x"}]}, False),
+    ({}, False),
+]
+
+
+@pytest.mark.parametrize("item, expected", HAS_PAGE_METADATA_CASES)
+def test_has_page_metadata(item: Any, expected: bool) -> None:
+    assert _has_page_metadata(item) is expected


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`scripts/page_metadata_recovery_audit.py` 의 구조 술어 헬퍼 6종(`_is_page_span`, `_is_bbox`, `_regions`, `_has_region_page`, `_has_region_bbox`, `_has_page_metadata`)에 대한 **test-only** 단위 커버리지(43 케이스). 이 술어들은 페이지 메타데이터 복구 감사가 항목을 분류할 때 쓰는 경계를 결정한다. `bool` 이 `int` subclass 라 `[True,False]` 가 page_span 으로 통과하거나, `_is_bbox` 가 `"1.0"` 같은 float-coercible 문자열을 허용하거나, `_regions` 가 tuple 을 제외하는 등 미묘한 경계가 조용히 회귀하면 감사 집계(`coverage_block`)가 틀어진다.

## 2. 변경 범위 (Scope)

- 추가: `tests/test_page_metadata_predicates.py` (43 parametrized 케이스)
- 소스 변경 없음 — 순수 characterization 테스트.

## 3. 어떻게 (How)

모든 기대값은 pristine 소스 실행(`python3 -c`)으로 캡처. bool-is-int subclass 통과를 양방향 핀(`[True,False]→True` + 가드 mutant), `_is_bbox` 의 `except (TypeError, ValueError)` 양 arm(`"x"`=ValueError, `None`=TypeError) 모두 핀, `_regions` 의 tuple≠list 제외, `_has_page_metadata` 의 OR 분기 short-circuit 을 각 분기 독립 케이스로 고정.

## 4. 테스트 (Tests)

- `pytest tests/test_page_metadata_predicates.py` → 43 passed (0.10s)
- `ruff check` → clean, `pyright` → 0 errors
- import-safety: `import scripts.page_metadata_recovery_audit` 0.006s, heavy 모듈 0
- **Adversarial mutation review (code-reviewer, 별도 lane):** 26/26 behavior-changing mutant CAUGHT(prescribed 11 + supplementary 13 + 적용된 LOW finding으로 2 survivor→0), 0 vacuous, tree byte-clean. bool-subclass 의도는 `int→bool` mutant(T3/T4)로 양방향 enforce 확인. 리뷰가 지적한 `_is_bbox` TypeError-arm 미커버 LOW finding 반영(`[1,2,3,None]→False` 케이스 추가)으로 clean kill 도달. proven semantic-equiv(`Mapping`→`dict`, json 경로 unreachable)는 out-of-scope 제외.

## 5. Eval 영향 (Eval impact)

N/A — test-only. load-bearing 소스 변경 없음(`scripts/page_metadata_recovery_audit.py` 는 감사 렌더러, eval 파이프라인 비참여). real-data 델타 없음.

## 6. 롤백 (Rollback)

`tests/test_page_metadata_predicates.py` 삭제로 무손실 복원. 소스 의존 없음.

## 7. 리뷰어 노트 (Reviewer notes)

동 파일의 private-eval 가드 헬퍼(`_private_eval_index_guard`/`_embedding_block`)는 ADR 0005 경계상 본 PR 범위 밖 — 순수 구조 술어만 대상. `coverage_block` 등 집계 함수는 후속 PR 후보.

Closes #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)