### PR TITLE
test(synthesis): cover missing cost tokens

### DIFF
--- a/rag_synthesis.py
+++ b/rag_synthesis.py
@@ -126,6 +126,11 @@ def compute_cost_usd(
     pricing = _resolve_pricing(model)
     if pricing is None:
         return None
+    if all(
+        count is None
+        for count in (tokens_in, tokens_out, cache_read_tokens, cache_write_tokens)
+    ):
+        return None
     cost = 0.0
     if tokens_in:
         cost += (tokens_in / 1_000_000.0) * pricing["input"]

--- a/tests/test_synthesis_cost_telemetry.py
+++ b/tests/test_synthesis_cost_telemetry.py
@@ -68,6 +68,13 @@ class ComputeCostUsdTest(unittest.TestCase):
             rag_synthesis.compute_cost_usd(model=None, tokens_in=10, tokens_out=10)
         )
 
+    def test_missing_token_counts_for_priced_model_returns_none(self) -> None:
+        self.assertIsNone(
+            rag_synthesis.compute_cost_usd(
+                model="claude-sonnet-4-6", tokens_in=None, tokens_out=None
+            )
+        )
+
     def test_sonnet_input_output_only(self) -> None:
         # Sonnet 4.6: $3 / Mtok input, $15 / Mtok output.
         # 1_000_000 input + 1_000_000 output = $3 + $15 = $18.00.


### PR DESCRIPTION
## Summary
- add regression coverage that `compute_cost_usd` returns `None` for a priced model when all usage token counts are missing
- update the cost calculator so missing usage telemetry is treated as unknown spend, not zero-dollar spend

## Issue
Closes #2451

## Review response
- Addressed unresolved review thread: priced backends with missing token usage now return `None` instead of `0.0`.

## Validation
- [x] `python3 -m pytest -q tests/test_synthesis_cost_telemetry.py` → 12 passed
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
No retrieval/answer/eval ranking change. Synthesis telemetry only: missing usage fields now surface as unknown cost (`None`) rather than `0.0`.
