### PR TITLE
fix(agent-evals): review round 3 — manifest parent-ref guard + destructive-gate fail-closed

### DIFF
--- a/agent-evals/adapters/bidmate/oracle_bidmate.py
+++ b/agent-evals/adapters/bidmate/oracle_bidmate.py
@@ -112,7 +112,9 @@ def detect_hard_gates(diff_summary: Mapping[str, Any]) -> tuple[Any, ...]:
     "added_secrets": bool, "destructive": bool, "unrelated_churn": bool,
     "unauthorized_migration": bool, "instruction_violation": bool,
     "deleted_paths": int}``) — never raw diff text.  ``deleted_paths`` is treated
-    as a destructive signal when positive.
+    as a destructive signal when positive.  Detection is fail-closed on a security
+    gate: a serialized count (``"1"``) or any other truthy-but-malformed value still
+    trips DESTRUCTIVE rather than being silently ignored for not being a clean int.
     """
 
     gates: list[Any] = []
@@ -120,8 +122,16 @@ def detect_hard_gates(diff_summary: Mapping[str, Any]) -> tuple[Any, ...]:
         if bool(diff_summary.get(key)):
             gates.append(gate)
     deleted = diff_summary.get("deleted_paths")
-    if isinstance(deleted, (int, float)) and deleted > 0 and oracle.HardGate.DESTRUCTIVE not in gates:
-        gates.append(oracle.HardGate.DESTRUCTIVE)
+    if deleted is not None and oracle.HardGate.DESTRUCTIVE not in gates:
+        try:
+            deleted_positive = float(deleted) > 0
+        except (TypeError, ValueError):
+            # Present but non-numeric (e.g. a malformed serialized value): treat any
+            # truthy value as a destructive signal — fail-closed, never fail-open, on
+            # a security gate. ("" / [] / 0-like values stay non-destructive.)
+            deleted_positive = bool(deleted)
+        if deleted_positive:
+            gates.append(oracle.HardGate.DESTRUCTIVE)
     return tuple(gates)
 
 

--- a/scripts/agent_evals_report.py
+++ b/scripts/agent_evals_report.py
@@ -105,8 +105,14 @@ def _read_run_logs(runs_dir: Path) -> list[dict[str, Any]]:
         # Enforce the "listed basenames only" contract before joining. A non-basename
         # entry (``../old.json``, an absolute path, or a nested ``a/b.json``) would
         # let ``runs_dir / name`` escape the runs dir and read a stale log outside the
-        # current run — defeating the manifest-scoping invariant. Reject loudly.
-        bad = [n for n in names if not isinstance(n, str) or n == "" or Path(n).name != n]
+        # current run — defeating the manifest-scoping invariant. Reject loudly. The
+        # explicit ``.``/``..`` cases are needed because ``Path("..").name == ".."``
+        # (a bare parent ref slips the ``Path(n).name != n`` check on POSIX).
+        bad = [
+            n
+            for n in names
+            if not isinstance(n, str) or n in ("", ".", "..") or Path(n).name != n
+        ]
         if bad:
             raise ValueError(
                 f"run_manifest.json lists non-basename entries {bad[:3]}"

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -1012,3 +1012,39 @@ def test_metric_per_accepted_counts_total_effort() -> None:
     zero = [{"gate_results": {"tier": "NECESSARY_GATE_ONLY"}, "cost": {"usd": 5.0}, "human_minutes": 4.0}]
     assert report_script._metric_value("cost_per_accepted", zero) is None
     assert report_script._metric_value("human_min_per_accepted", zero) is None
+
+
+# --------------------------------------------------------------------------- #
+# #2452 — review round 3: manifest parent-ref guard + destructive fail-closed  #
+# --------------------------------------------------------------------------- #
+
+
+def test_report_manifest_rejects_parent_ref_entries(tmp_path) -> None:
+    # #2452 F3: a bare ".." (and ".") slips the `Path(n).name != n` check on POSIX
+    # (Path("..").name == ".."); the basename guard must still reject parent refs.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_parentref")
+    runner = load_module("agent-evals/adapters/bidmate/runner.py", "agent_evals_runner_parentref")
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir(parents=True)
+    _write_log(runner, runs_dir, "T-a", "v0_naive", 17)
+    for entry in ("..", "."):
+        (runs_dir / runner.RUN_MANIFEST_NAME).write_text(
+            json.dumps({"run_logs": [entry, "T-a__v0_naive__seed17.json"]}) + "\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="non-basename"):
+            report_script._read_run_logs(runs_dir)
+
+
+def test_detect_hard_gates_non_numeric_deleted_paths_fails_closed() -> None:
+    # #2452 F4: deleted_paths is a destructive (security) signal. A serialized count
+    # ("1") or a malformed truthy value must still trip DESTRUCTIVE (fail-closed);
+    # clean-zero / "0" / "" / None / absent must not.
+    ob = _oracle_bidmate()
+    HardGate = ob.oracle.HardGate
+    assert HardGate.DESTRUCTIVE in ob.detect_hard_gates({"deleted_paths": "1"})  # was ignored
+    assert HardGate.DESTRUCTIVE in ob.detect_hard_gates({"deleted_paths": 3})  # numeric still trips
+    assert HardGate.DESTRUCTIVE in ob.detect_hard_gates({"deleted_paths": "yes"})  # malformed truthy
+    for falsy in ("0", 0, "", None):
+        assert HardGate.DESTRUCTIVE not in ob.detect_hard_gates({"deleted_paths": falsy})
+    assert HardGate.DESTRUCTIVE not in ob.detect_hard_gates({})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#2446 이후 agent-evals 표면에 대한 **3차 post-merge cross-family review** (codex, xhigh) 가 4개 후보를 표면화했다. validity 판정(concrete trigger + live 도달성, contrived/premature 회피) 후 real+live 2개만 여기서 수정. 나머지는 1개 defer(latent, 미배선 live-egress 경로), 1개 decline(contrived, 현실 벡터 없음) — 표면이 수렴 중임을 보여준다(남은 edge 는 새 구조 class 아님).

Closes #2452

## 2. 영향 파일

- `agent-evals/adapters/bidmate/oracle_bidmate.py` — `detect_hard_gates` deleted_paths fail-closed (F4). **비 load-bearing**
- `scripts/agent_evals_report.py` — `_read_run_logs` manifest basename guard 가 `.`/`..` 명시 거부 (F3). 비 load-bearing
- `tests/test_agent_evals_runner.py` — F3·F4 회귀 테스트 2개

## 3. 리스크

F3 가 정상 basename 을 오탐? `n in ("",".","..")` + `Path(n).name != n` 는 평범한 `<task>__<playbook>__seed<seed>.json` 에 거짓 → 정상 통과(테스트로 확인). F4 가 정상 0-deletion 을 destructive 오탐? `"0"`/`0`/`""`/`None`/absent 는 non-destructive 유지(테스트로 확인); 양수/truthy-malformed 만 trip. 둘 다 stub smoke 경로 미사용(detect_hard_gates 는 evaluate 경유 — stub run 은 _verdict_for_run 사용)이라 holdout aggregate 무영향.

## 4. 테스트

- F3: `test_report_manifest_rejects_parent_ref_entries` (`..`/`.` 둘 다 ValueError)
- F4: `test_detect_hard_gates_non_numeric_deleted_paths_fails_closed` (`"1"`/`3`/`"yes"` trips, `"0"`/`0`/`""`/`None`/`{}` 안 trip)

`pytest tests/test_agent_evals_{runner,core,gitignore}.py -q` → **113 passed**. overlap-preflight: `reports/agent_loop/overlap_preflight.md` (Blockers 없음).

## 5. Eval 영향

**All `·` (RAG 외).** agent-evals 는 load-bearing 아님. detect_hard_gates/manifest reader 변경은 stub smoke 경로 미사용 → 커밋된 holdout aggregate 재생성해도 byte-identical. private real-eval / README metric 무관.

## 6. 하위 호환

깨짐 없음. manifest 포맷 불변(reader 가 `.`/`..` 도 거부하도록만 강화 — writer 는 이미 basename 만 방출). detect_hard_gates 는 더 conservative 해질 뿐(fail-closed 강화), 기존 numeric-positive 동작 보존. 답변 계약/스키마/CLI 무변경.

## 7. 범위 외

- **Deferred** (이 PR 에서 안 함): `_default_codex_reviewer` 의 느슨한 `startswith("accept")` 파서 — 실제 reviewer 출력 계약이 필요한 live-egress 경로로 현재 어떤 run 도 호출 안 함(stub/injected reviewer). `--real` candidate 배선 시 처리(#2452 추적).
- **Declined** (won't-fix): 로컬 gitignored runs_dir 내 심링크 탈출 — runner 는 일반 파일만 작성, 심링크 주입 현실 벡터 없음. 모든 엔트리 resolve+containment 검사는 비위협 대상 over-engineering(#2452 문서화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
