### PR TITLE
test(scripts): render_verifier_false_negative_overlap 버킷·카디널리티 분류 헬퍼 커버리지

### DIFF
--- a/tests/test_verifier_fn_overlap_buckets.py
+++ b/tests/test_verifier_fn_overlap_buckets.py
@@ -1,0 +1,181 @@
+"""Unit coverage for ``scripts/render_verifier_false_negative_overlap.py`` 분류 헬퍼.
+
+verifier false-negative overlap 보드의 슬라이스 집계를 결정하는 순수 버킷·
+카디널리티 분류 헬퍼들이다. 경계가 조용히 회귀하면 슬라이스 카운트가 틀어지므로
+oracle 로 고정한다. 특히:
+
+- ``_retry_bucket`` 은 ``int()`` coerce 후 버킷팅 — bool 은 int 라 ``True→"1"``,
+  비숫자/음수는 ``"0"``, float 은 절삭(``2.9→"2"``).
+- ``_expected_coverage``/``_evidence_cardinality`` 는 ``str()`` 정규화 + set 으로
+  doc id 를 비교 — falsy 항목은 제외되고 중복은 dedup, ``[1]`` 과 ``["1"]`` 은 교차매치.
+- ``_specificity_bucket`` 은 SPECIFICITY_REGEX(얼마|구체적|기준은|몇\\s*%?|\\d+\\s*%) hit.
+- ``_p25`` 는 정렬 후 ``min(int(0.25*(n-1)), n-1)`` 인덱스(nearest-rank 변형).
+
+상위 ``build_aggregate``/``render_markdown`` 은 기존 테스트가 end-to-end 로 다루지만
+이 헬퍼들의 경계 자체는 미고정이었다. 모든 기대값은 pristine 소스 실행으로 캡처.
+``from scripts.render_verifier_false_negative_overlap import ...`` (implicit namespace).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.render_verifier_false_negative_overlap import (
+    _cardinality_bucket,
+    _count_list,
+    _evidence_cardinality,
+    _expected_coverage,
+    _p25,
+    _retry_bucket,
+    _specificity_bucket,
+)
+
+
+# ----------------------------------------------------------------------
+# _retry_bucket  (int-coerce 후 0/1/2/3plus; non-int -> 0)
+# ----------------------------------------------------------------------
+
+RETRY_BUCKET_CASES = [
+    (0, "0"),
+    (1, "1"),
+    (2, "2"),
+    (3, "3plus"),
+    (5, "3plus"),
+    (-1, "0"),        # 음수 → "0"
+    ("2", "2"),       # 정수 문자열 coerce
+    ("2.9", "0"),     # float 문자열: int("2.9") 가 ValueError → except → "0" (float 절삭 아님)
+    ("x", "0"),       # 비숫자 문자열 → except → 0
+    (None, "0"),      # None → TypeError → 0
+    (2.9, "2"),       # float 절삭(int(2.9)==2)
+    (True, "1"),      # bool 은 int subclass → int(True)==1
+    (False, "0"),
+]
+
+
+@pytest.mark.parametrize("value, expected", RETRY_BUCKET_CASES)
+def test_retry_bucket(value: Any, expected: str) -> None:
+    assert _retry_bucket(value) == expected
+
+
+# ----------------------------------------------------------------------
+# _cardinality_bucket  (int 직접 0/1/2/3plus)
+# ----------------------------------------------------------------------
+
+CARDINALITY_BUCKET_CASES = [
+    (-1, "0"),
+    (0, "0"),
+    (1, "1"),
+    (2, "2"),
+    (3, "3plus"),
+    (9, "3plus"),
+]
+
+
+@pytest.mark.parametrize("count, expected", CARDINALITY_BUCKET_CASES)
+def test_cardinality_bucket(count: int, expected: str) -> None:
+    assert _cardinality_bucket(count) == expected
+
+
+# ----------------------------------------------------------------------
+# _expected_coverage  (str 정규화 set 교차)
+# ----------------------------------------------------------------------
+
+EXPECTED_COVERAGE_CASES = [
+    ({}, "no_expected"),
+    ({"expected_doc_ids": []}, "no_expected"),
+    ({"expected_doc_ids": ["a"], "evidence_doc_ids": ["a", "b"]}, "expected_in_evidence"),
+    ({"expected_doc_ids": ["a"], "evidence_doc_ids": ["b"]}, "expected_not_in_evidence"),
+    # falsy 항목(None, "") 제외 후에도 expected 가 남으면 not_in_evidence
+    ({"expected_doc_ids": ["a", None, ""], "evidence_doc_ids": []}, "expected_not_in_evidence"),
+    # expected 가 전부 falsy → 필터 후 빈 set → no_expected (not_in_evidence 아님)
+    ({"expected_doc_ids": [None, ""], "evidence_doc_ids": ["x"]}, "no_expected"),
+    # str() 정규화로 1 과 "1" 이 교차매치
+    ({"expected_doc_ids": [1], "evidence_doc_ids": ["1"]}, "expected_in_evidence"),
+]
+
+
+@pytest.mark.parametrize("case, expected", EXPECTED_COVERAGE_CASES)
+def test_expected_coverage(case: dict[str, Any], expected: str) -> None:
+    assert _expected_coverage(case) == expected
+
+
+# ----------------------------------------------------------------------
+# _evidence_cardinality  (set dedup; falsy 제외)
+# ----------------------------------------------------------------------
+
+EVIDENCE_CARDINALITY_CASES = [
+    ({}, "empty"),
+    ({"evidence_doc_ids": ["a"]}, "single_doc"),
+    ({"evidence_doc_ids": ["a", "b"]}, "multi_doc"),
+    ({"evidence_doc_ids": ["a", "a"]}, "single_doc"),   # 중복 dedup → 1
+    ({"evidence_doc_ids": [None, ""]}, "empty"),         # falsy 전부 제외 → empty
+]
+
+
+@pytest.mark.parametrize("case, expected", EVIDENCE_CARDINALITY_CASES)
+def test_evidence_cardinality(case: dict[str, Any], expected: str) -> None:
+    assert _evidence_cardinality(case) == expected
+
+
+# ----------------------------------------------------------------------
+# _specificity_bucket  (SPECIFICITY_REGEX hit)
+# ----------------------------------------------------------------------
+
+SPECIFICITY_HIT = ["얼마인가요", "구체적 기준", "기준은 무엇", "몇 개입니까", "30%", "3 %", "수수료 50 % 인가"]
+SPECIFICITY_MISS = ["", "2024년 별표 5", "일반 질문"]
+
+
+@pytest.mark.parametrize("query", SPECIFICITY_HIT)
+def test_specificity_bucket_hit(query: str) -> None:
+    assert _specificity_bucket({"query": query}) == "keyword_hit"
+
+
+@pytest.mark.parametrize("query", SPECIFICITY_MISS)
+def test_specificity_bucket_miss(query: str) -> None:
+    assert _specificity_bucket({"query": query}) == "no_hit"
+
+
+@pytest.mark.parametrize("case", [{}, {"query": None}, {"query": 123}])
+def test_specificity_bucket_non_string_query_no_hit(case: dict[str, Any]) -> None:
+    # query 누락/None/비문자열 → str(... or "")="" 또는 숫자 문자열 → 매치 없음.
+    assert _specificity_bucket(case) == "no_hit"
+
+
+# ----------------------------------------------------------------------
+# _p25  (정렬 후 min(int(0.25*(n-1)), n-1) 인덱스)
+# ----------------------------------------------------------------------
+
+P25_CASES = [
+    ([], None),
+    ([5.0], 5.0),
+    ([1.0, 2.0, 3.0, 4.0], 1.0),       # n=4 → idx=int(0.75)=0 → 정렬[0]=1.0
+    ([4.0, 1.0, 3.0, 2.0], 1.0),       # 정렬 후 동일
+    ([1.0, 2.0, 3.0, 4.0, 5.0], 2.0),  # n=5 → idx=int(1.0)=1 → 정렬[1]=2.0
+]
+
+
+@pytest.mark.parametrize("values, expected", P25_CASES)
+def test_p25(values: list[float], expected: float | None) -> None:
+    assert _p25(values) == expected
+
+
+# ----------------------------------------------------------------------
+# _count_list  (list 면 len, 아니면 0)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ([1, 2], 2),
+        ([], 0),
+        ("ab", 0),       # str 은 list 아님 → 0(문자 길이 아님)
+        (None, 0),
+        ({"a": 1}, 0),
+        ((1, 2), 0),     # tuple 은 list 아님 → 0
+    ],
+)
+def test_count_list(value: Any, expected: int) -> None:
+    assert _count_list(value) == expected


### PR DESCRIPTION
## 1. 무엇을 / 왜 (What & Why)

`scripts/render_verifier_false_negative_overlap.py` 의 순수 분류·버킷팅 헬퍼 7종(`_retry_bucket`, `_cardinality_bucket`, `_expected_coverage`, `_evidence_cardinality`, `_specificity_bucket`, `_p25`, `_count_list`)에 대한 **test-only** 단위 커버리지(55 케이스). 이 헬퍼들은 verifier false-negative overlap 보드의 슬라이스 카운트를 결정한다. bool-is-int coerce·`str()` 정규화 set 교차·dedup·SPECIFICITY_REGEX hit·percentile 인덱스 산식 등 미묘한 경계가 조용히 회귀하면 슬라이스 집계가 틀어진다.

## 2. 변경 범위 (Scope)

- 추가: `tests/test_verifier_fn_overlap_buckets.py` (55 parametrized 케이스)
- 소스 변경 없음 — 순수 characterization 테스트.

## 3. 어떻게 (How)

모든 기대값은 pristine 소스 실행(`python3 -c`)으로 캡처. `_retry_bucket` 의 int-coerce 경계(정수문자열 `"2"→"2"` vs float문자열 `"2.9"→"0"` except, bool `True→"1"`, float 절삭 `2.9→"2"`), `_expected_coverage` 의 falsy-필터 후 빈 set→`no_expected` 경계 + `str()` 교차매치(`1`≡`"1"`), `_evidence_cardinality` set dedup, `_p25` 의 `sorted`+`min(int(0.25*(n-1)), n-1)` 인덱스를 값으로 고정.

## 4. 테스트 (Tests)

- `pytest tests/test_verifier_fn_overlap_buckets.py` → 55 passed (0.11s)
- `ruff check` → clean, `pyright` → 0 errors
- import-safety: `import scripts.render_verifier_false_negative_overlap` 0.27s, heavy 모듈 0
- **Adversarial mutation review (code-reviewer, 별도 lane):** 14/16 prescribed mutant CAUGHT, 0 vacuous, tree byte-clean. 리뷰가 지적한 MEDIUM real-gap 2건(`_retry_bucket` float문자열 truncation 경계 미고정, `_expected_coverage` all-falsy-expected→no_expected 경계 미고정) 반영(`("2.9","0")` + falsy-expected 케이스 추가). proven semantic-equiv 3건(`_cardinality_bucket`/`_evidence_cardinality` 의 `==1`→`<=1` 가드 선행으로 unreachable, `_specificity_bucket` `or ""` 방어적)은 out-of-scope 제외.

## 5. Eval 영향 (Eval impact)

N/A — test-only. load-bearing 소스 변경 없음(`scripts/render_verifier_false_negative_overlap.py` 는 failure-inspection 렌더러, eval 파이프라인 비참여). real-data 델타 없음.

## 6. 롤백 (Rollback)

`tests/test_verifier_fn_overlap_buckets.py` 삭제로 무손실 복원. 소스 의존 없음.

## 7. 리뷰어 노트 (Reviewer notes)

상위 `build_aggregate`/`render_markdown` 은 기존 `tests/test_render_verifier_false_negative_overlap.py` 가 end-to-end 로 다루지만 이 헬퍼들의 경계 자체는 미고정이었다. `_top_score`/`_numeric` 등 동명 헬퍼는 grep 혼동·기존 커버 이유로 본 PR 범위 밖.

Closes #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)