### PR TITLE
test(governance): cover malformed ADR markers

### DIFF
--- a/tests/test_governance_adr_verification.py
+++ b/tests/test_governance_adr_verification.py
@@ -56,6 +56,12 @@ def test_extract_markers_none(tmp_path: Path) -> None:
     assert extract_adr_verification_markers(f) == []
 
 
+def test_extract_markers_ignores_missing_key(tmp_path: Path) -> None:
+    body = "## Verification\n<!-- verifies-key: reports/eval_summary.json: -->\n"
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert extract_adr_verification_markers(f) == []
+
+
 def test_extract_markers_single(tmp_path: Path) -> None:
     body = (
         "## Verification\n"


### PR DESCRIPTION
## Summary
- add regression coverage that malformed `verifies-key` comments without a key are ignored by ADR verification marker extraction

## Issue
Closes #2458

## Validation
- [x] `python3 -m pytest -q tests/test_governance_adr_verification.py` → 18 passed
- [x] `git diff --check`
- [x] `make check-branch`

## Eval impact
N/A — test-only governance lint coverage; no retrieval/answer/eval behavior change.
