### PR TITLE
test(hooks): cover ADR-template malformed JSON fail-open

### DIFF
--- a/tests/test_hook_pretooluse_adr_template.py
+++ b/tests/test_hook_pretooluse_adr_template.py
@@ -132,6 +132,16 @@ class TestPreToolUseAdrTemplate(unittest.TestCase):
         )
         self.assertEqual(r.returncode, 0)
 
+    def test_malformed_json_payload_is_noop(self) -> None:
+        """Invalid hook stdin fails open without operator-facing noise."""
+        r = subprocess.run(
+            ["bash", str(self._hook)],
+            input="{not-json", text=True, capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+
     # ------------------------------------------------------------------
     # Block cases
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add malformed-JSON stdin regression coverage for the ADR-template PreToolUse hook
- pin the fail-open/no-stderr contract alongside the existing empty-payload case

## Tests
- `python3 -m pytest -q tests/test_hook_pretooluse_adr_template.py`
- `git diff --check`
- `make check-branch`

## Issue
Closes #2465