### PR TITLE
test(agent-evals): regression-lock committed holdout-v0-vs-v1 smoke aggregate

### DIFF
--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -1048,3 +1048,58 @@ def test_detect_hard_gates_non_numeric_deleted_paths_fails_closed() -> None:
     for falsy in ("0", 0, "", None):
         assert HardGate.DESTRUCTIVE not in ob.detect_hard_gates({"deleted_paths": falsy})
     assert HardGate.DESTRUCTIVE not in ob.detect_hard_gates({})
+
+
+# --------------------------------------------------------------------------- #
+# committed holdout-v0-vs-v1 smoke aggregate — e2e reproduction lock (#2470)   #
+# --------------------------------------------------------------------------- #
+
+
+def test_committed_holdout_aggregate_reproduced_by_stub_pipeline(tmp_path) -> None:
+    # agent-evals/reports/holdout-v0-vs-v1.aggregate.json is a committed BEHAVIOR
+    # artifact (the canonical PR3 stub-surface smoke), but until now it was only
+    # verified by hand across PRs. Lock the byte-identical contract end-to-end: run
+    # the matrix (deterministic stub candidate + in-process stub cross-family
+    # reviewer) and the report, then require the rebuilt aggregate dict to EQUAL the
+    # committed one. A future change to the runner / report / stub logic that silently
+    # drifts the committed aggregate fails here, forcing an intentional regeneration.
+    #
+    # No real git and no external egress: subprocess_run is faked, so the per-trial
+    # `git worktree add --detach` / `remove` / `prune` calls are no-ops (the stub
+    # candidate makes no repo change), and the reviewer is the in-process stub. This
+    # complements test_agent_evals_core.test_generated_holdout_report_passes_scanner_*,
+    # which guards the privacy/aggregate-only boundary rather than reproduction.
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_holdout_repro")
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_holdout_repro")
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    runs_dir = tmp_path / "runs"
+    written = run_script.run(
+        tasks=run_script.SMOKE_HOLDOUT_TASKS,
+        # start_commit does not appear in the aggregate; any fixed value is fine and
+        # keeps the test independent of the checkout's real HEAD.
+        start_commit="deadbeefcafe1234",
+        runs_dir=runs_dir,
+        # public attestation must be open or the stub reviewer is never consulted and
+        # every trial caps at NECESSARY_GATE_ONLY (no ACCEPTED -> different aggregate).
+        public_attestation=True,
+        use_real=False,
+        subprocess_run=lambda *a, **k: _Proc(),
+    )
+    # 3 smoke tasks x 2 playbooks (v0_naive, v1_spec_first) x 3 default seeds.
+    assert len(written) == 18
+
+    logs = report_script._read_run_logs(runs_dir)
+    report = report_script.build_report(
+        logs, report_id="holdout-v0-vs-v1", num_resamples=1000, alpha=0.05, seed=17
+    )
+    committed = json.loads(
+        (REPO_ROOT / "agent-evals" / "reports" / "holdout-v0-vs-v1.aggregate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report == committed


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`agent-evals/reports/holdout-v0-vs-v1.aggregate.json` 은 PR3 stub-surface 의 canonical smoke aggregate 로 commit 된 **behavior 산출물**이지만, byte-identical 계약을 지키는 자동 테스트가 없어 그동안 5개 PR(#2411/#2446/#2455 등)에서 **손으로만** 재현 검증돼 왔다. runner/report/stub 로직 변경이 committed aggregate 를 조용히 drift 시켜도 CI 가 못 잡는다. "동작 변경 ↔ 테스트 변경" 원칙상 behavior 산출물은 가드 테스트가 있어야 하므로, e2e 재현 회귀 테스트를 추가한다.

Closes #2470

## 2. 영향 파일

- `tests/test_agent_evals_runner.py` — 회귀 테스트 1개 추가(+55 LOC): stub 파이프라인(run matrix → report)이 committed `holdout-v0-vs-v1.aggregate.json` 을 재현하는지 assert. **비 load-bearing** (테스트 전용; agent-evals 런타임/스크립트 로직 무변경).

## 3. 리스크

- 깨질 경로: 거의 없음 — 테스트 추가만. 프로덕션 코드 무변경.
- 확인: focused 테스트 pass(0.17s), 전체 agent-evals 스위트(runner+core) **70 passed**, `py_compile` OK, `git diff --check` clean. 실제 git/외부 egress 0 (subprocess_run fake → `git worktree add/remove/prune` no-op; stub candidate 는 repo 변경 없음; reviewer 는 in-process stub). Pyright "not accessed" 진단은 전부 기존 test-double 파라미터(라인 274–479, 추가분 이전)로 idiomatic non-gating.

## 4. 테스트

- 신규 회귀 테스트 `test_committed_holdout_aggregate_reproduced_by_stub_pipeline`: 18 run-log(3 task × 2 playbook × 3 seed) → manifest scoping → `build_report` 결과 dict == committed aggregate. drift 시 fail(의도적 regeneration 강제). 기존 `test_agent_evals_core.test_generated_holdout_report_passes_scanner_*`(privacy/aggregate-only 경계)와 보완 — 이쪽은 재현(no-drift) guard.
- overlap-preflight: `python3 scripts/agent_loop.py overlap-preflight --issue 2470 --branch test/issue-2470-holdout-aggregate-repro-lock --paths tests/test_agent_evals_runner.py` → `[OK]` (base=origin/main c86cf17d). `git grep` 사전 대조 — 기존 재현 테스트 부재 확인.

## 5. Eval 영향

All `·` (no eval impact). load-bearing path 무변경 — 테스트 파일 1개 추가. agent-evals 는 비 load-bearing surface 이고 RAG/eval/ingestion/answer/api 런타임 무관. stub 합성 표면이라 private real-eval 무관 (real-eval 미실행).

## 6. 하위 호환

- 깨짐 없음. 테스트 추가만 — 계약/스키마/CLI flag/answer-contract (ADR 0003) 무관. committed aggregate 파일 자체도 무변경.

## 7. 범위 외

- 실제 코딩-에이전트 후보(`--real`, 현재 NotImplemented stub) / external-reviewer 실 egress(`_default_codex_reviewer`, public-attestation-only) 경로는 범위 밖 — 여전히 stub/inject. real-candidate wiring 은 후속 PR(deferred axis).
- `smoke.aggregate.json`(별도 counts-only aggregate) 재현 lock 은 이 PR 범위 밖 — 필요 시 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)