### PR TITLE
test(agent-evals): cover run.py main() egress-flag wiring + HEAD resolution

### DIFF
--- a/scripts/agent_evals_run.py
+++ b/scripts/agent_evals_run.py
@@ -158,7 +158,11 @@ def run(
     return written
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    subprocess_run: Callable[..., Any] = subprocess.run,
+) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--tasks",
@@ -190,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:
 
     start_commit = args.start_commit
     if start_commit is None:
-        proc = subprocess.run(
+        proc = subprocess_run(
             ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
@@ -204,6 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         runs_dir=Path(args.runs_dir),
         public_attestation=args.public_attestation,
         use_real=args.real,
+        subprocess_run=subprocess_run,
     )
     print(f"wrote {len(written)} run-log(s) to {args.runs_dir}")
     return 0

--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -1103,3 +1103,98 @@ def test_committed_holdout_aggregate_reproduced_by_stub_pipeline(tmp_path) -> No
         )
     )
     assert report == committed
+
+
+def _fake_git_run(resolved_head: str):
+    """Fake ``subprocess_run`` for ``agent_evals_run.main()``.
+
+    Resolves ``git rev-parse HEAD`` to a fixed commit and treats every worktree op
+    (add/remove/prune) as a no-op success, so ``main()`` runs end-to-end with NO
+    real git side effects. The default stub candidate applies no repo change, so the
+    detached worktree is never actually needed.
+    """
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+
+        def __init__(self, stdout: str = "") -> None:
+            self.stdout = stdout
+
+    def _run(cmd, *args, **kwargs):
+        if "rev-parse" in cmd:
+            return _Proc(resolved_head + "\n")
+        return _Proc("")
+
+    return _run
+
+
+def test_main_without_attestation_caps_all_runs_at_necessary_gate_only(tmp_path) -> None:
+    # main() is the documented CLI entrypoint, yet its flag wiring was untested (no
+    # test called .main()). Without --public-attestation the egress gate must stay
+    # CLOSED end-to-end: every persisted trial caps at NECESSARY_GATE_ONLY, never
+    # ACCEPTED. Faked git => no real worktree churn.
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_main_noattest")
+    runs_dir = tmp_path / "runs"
+    rc = run_script.main(
+        ["--runs-dir", str(runs_dir), "--start-commit", "deadbeefcafe1234"],
+        subprocess_run=_fake_git_run("deadbeefcafe1234"),
+    )
+    assert rc == 0
+    logs = [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in sorted(runs_dir.glob("T-smoke-*.json"))
+    ]
+    assert len(logs) == 18  # 3 tasks x 2 playbooks x 3 seeds
+    assert {log["gate_results"]["tier"] for log in logs} == {"NECESSARY_GATE_ONLY"}
+
+
+def test_main_public_attestation_flag_is_wired_through_to_egress(tmp_path) -> None:
+    # The security-relevant assertion: passing --public-attestation must thread the
+    # flag main() -> run() -> _verdict_for_run -> decide_verdict so the cross-family
+    # reviewer can move trials to ACCEPTED. If the flag were dropped in main()'s
+    # wiring (the ADR 0099 "opt-in is inert unless wired to the CLI flag" failure),
+    # the tier set would stay capped at NECESSARY_GATE_ONLY and this fails.
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_main_attest")
+    runs_dir = tmp_path / "runs"
+    rc = run_script.main(
+        [
+            "--runs-dir",
+            str(runs_dir),
+            "--start-commit",
+            "deadbeefcafe1234",
+            "--public-attestation",
+        ],
+        subprocess_run=_fake_git_run("deadbeefcafe1234"),
+    )
+    assert rc == 0
+    logs = [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in sorted(runs_dir.glob("T-smoke-*.json"))
+    ]
+    # v1_spec_first is accepted by the stub reviewer on every holdout task, so with
+    # egress open ALL v1 trials reach ACCEPTED (proves the flag is wired, not inert).
+    v1_tiers = {
+        log["gate_results"]["tier"] for log in logs if log["playbook"] == "v1_spec_first"
+    }
+    assert v1_tiers == {"ACCEPTED"}
+
+
+def test_main_defaults_start_commit_to_resolved_head(tmp_path) -> None:
+    # With no --start-commit, main() must resolve the detached-worktree start commit
+    # from `git rev-parse HEAD` and thread it into every run-log. A regression that
+    # dropped/garbled this default would silently eval against the wrong tree.
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_main_head")
+    runs_dir = tmp_path / "runs"
+    resolved = "0123456789abcdef0123456789abcdef01234567"
+    rc = run_script.main(
+        ["--runs-dir", str(runs_dir)],
+        subprocess_run=_fake_git_run(resolved),
+    )
+    assert rc == 0
+    logs = [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in sorted(runs_dir.glob("T-smoke-*.json"))
+    ]
+    assert logs  # matrix ran
+    assert {log["start_commit"] for log in logs} == {resolved}


### PR DESCRIPTION
## 1. 무엇을 / 왜

`scripts/agent_evals_run.py::main()` — agent-evals orchestration 의 문서화된 CLI 진입점 — 의 wiring 이 무테스트였다 (`grep '.main(' tests/test_agent_evals*.py` → 0건). 회귀 시 조용히 깨지는 두 동작을 잠근다:

1. **`--public-attestation` egress wiring (보안 관련).** flag 가 `main() → run() → _verdict_for_run → decide_verdict` 까지 thread 돼야 cross-family reviewer egress 게이트(이 표면의 핵심 privacy 계약)가 의도대로 열린다. drop 되면 진입점에서 게이트가 조용히 열/닫히는데 어떤 단위 테스트도 못 잡는다 (ADR 0099 교훈: opt-in 은 CLI flag 까지 wire 돼야 inert 아님).
2. **`--start-commit` 기본 `git rev-parse HEAD` resolution.** 깨지면 잘못된 tree 에 eval.

## 2. 어떻게

- `run()/run_one()/run_matrix()` 가 모두 가진 `subprocess_run` DI param 을 **`main()` 만 누락** → rev-parse 하드코딩 + `run()` 에 미전달이라 실제 git worktree 부작용 없이 테스트 불가했다. param 추가(기본값 `subprocess.run` → **production byte-identical**), rev-parse + `run()` 호출 양쪽에 thread. 모듈의 기존 DI 컨벤션 완성.
- focused 테스트 3건 (실 git·egress 없음): (a) attestation 닫힘 → 전 18 trial `NECESSARY_GATE_ONLY` 캡 (b) `--public-attestation` → v1_spec_first 전부 `ACCEPTED` (flag wired 증명) (c) `--start-commit` 미지정 → resolved HEAD 가 전 run-log 로 흐름.

## 3. 테스트

- 신규 3건 통과; `tests/test_agent_evals_runner.py` + `tests/test_agent_evals_core.py` 73건 회귀 0.
- `python3 -m pytest tests/test_agent_evals_runner.py -k test_main_ -q` → 3 passed.

## 4. 범위

- **비 load-bearing**: `scripts/agent_evals_run.py`(ordinary tooling, `LOAD_BEARING_PATHS` 외) + `tests/` 만. `core/`·`adapters/` 무변경.
- One concern: CLI 진입점 wiring 커버리지. report.py main() 커버리지는 별도 follow-up 후보(이 PR 범위 밖).

## 5. Eval 영향

N/A — 동작 변경 0 (DI 기본값 = `subprocess.run`, production byte-identical). load-bearing real-data 경로 무변경이라 real-eval 델타 불요.

closes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)