### PR TITLE
test(metadata): pin unknown payload field boundary

### DIFF
--- a/tests/test_metadata_extraction_regression.py
+++ b/tests/test_metadata_extraction_regression.py
@@ -152,6 +152,23 @@ class PayloadCoercionTest(unittest.TestCase):
         result = _payload_to_extraction({})
         self.assertEqual(MetadataExtraction().as_dict(), result.as_dict())
 
+    def test_unknown_payload_fields_are_ignored(self) -> None:
+        # Tool schemas disallow additionalProperties, but defensive coercion
+        # still receives arbitrary JSON from external SDKs. Unknown fields must
+        # not leak into the stable eight-field MetadataExtraction contract.
+        result = _payload_to_extraction(
+            {
+                "agency": "기관 X",
+                "project_name": "사업 X",
+                "hallucinated_priority": "긴급",
+                "raw_unstructured_text": "원문 조각",
+            }
+        )
+        self.assertEqual("기관 X", result.agency)
+        self.assertEqual("사업 X", result.project_name)
+        self.assertNotIn("hallucinated_priority", result.as_dict())
+        self.assertNotIn("raw_unstructured_text", result.as_dict())
+
     def test_unparseable_budget_dropped_to_none(self) -> None:
         result = _payload_to_extraction({"budget_amount": "약 5억원"})
         self.assertIsNone(result.budget_amount)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

LLM/tool-call payload가 스키마 밖 JSON 키를 포함해도 `MetadataExtraction`의 안정적인 8-field 계약으로 흘러들지 않는다는 방어적 coercion 경계를 회귀 테스트로 고정했습니다.

Closes #2486

## 2. 영향 파일

- `tests/test_metadata_extraction_regression.py` — metadata payload coercion regression test 추가

## 3. 리스크

- 리스크: test-only 변경이라 런타임 동작 변화는 없습니다.
- 확인: targeted metadata extraction regression test 전체가 통과했고, diff whitespace 및 branch/issue convention을 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_metadata_extraction_regression.py` → 21 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: latest `origin/main` 기반 별도 worktree/branch 생성, open PR 7개 + worktree 103개 스캔 결과 `tests/test_metadata_extraction_regression.py` 겹침 없음

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. Test-only metadata coercion regression이라 public fixture/private real100_v2 eval 영향 없음. Legacy real100/v1 evidence 사용 안 함.

## 6. 하위 호환

기존 계약/스키마/CLI flag 변경 없음. `MetadataExtraction.as_dict()` 8-field 계약을 그대로 확인합니다.

## 7. 범위 외

- production coercion 로직 변경 없음
- 신규 metadata field/schema_version 추가 없음
