### PR TITLE
test(agent-evals): cover report.py main() empty-logs guard + cwd restoration

### DIFF
--- a/tests/test_agent_evals_runner.py
+++ b/tests/test_agent_evals_runner.py
@@ -1198,3 +1198,51 @@ def test_main_defaults_start_commit_to_resolved_head(tmp_path) -> None:
     ]
     assert logs  # matrix ran
     assert {log["start_commit"] for log in logs} == {resolved}
+
+
+def test_report_main_errors_on_empty_runs_dir(tmp_path) -> None:
+    # report.main() must fail LOUD (parser.error -> SystemExit) when there are no
+    # run-logs, rather than silently writing an empty/degenerate aggregate.
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_main_empty")
+    empty = tmp_path / "runs"
+    empty.mkdir()
+    with pytest.raises(SystemExit):
+        report_script.main(["--runs-dir", str(empty)])
+
+
+def test_report_main_restores_cwd_when_scanner_rejects_out_path(tmp_path, monkeypatch) -> None:
+    # report.main() chdir's to REPO_ROOT around the scanner-gated write and MUST
+    # restore the prior cwd in a finally even when the write raises. Drop that
+    # finally and a scanner rejection would strand the process in REPO_ROOT,
+    # silently corrupting any later relative-path work.
+    #
+    # Trigger the post-chdir failure with an in-repo --out whose name is not
+    # *.aggregate.json: it passes the relative_to(REPO_ROOT) check (so the chdir
+    # happens) but the content scanner rejects the PATH, so write_aggregate_report
+    # raises BEFORE writing anything (scan-before-write => no file leaks into the
+    # real tree).
+    run_script = load_module("scripts/agent_evals_run.py", "agent_evals_run_for_report_cwd")
+    report_script = load_module("scripts/agent_evals_report.py", "agent_evals_report_main_cwd")
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    runs_dir = tmp_path / "runs"
+    run_script.run(
+        tasks=run_script.SMOKE_HOLDOUT_TASKS,
+        start_commit="deadbeefcafe1234",
+        runs_dir=runs_dir,
+        public_attestation=True,
+        use_real=False,
+        subprocess_run=lambda *a, **k: _Proc(),
+    )
+
+    monkeypatch.chdir(tmp_path)
+    before = Path.cwd()
+    bad_out = REPO_ROOT / "agent-evals" / "reports" / "not_aggregate.json"
+    with pytest.raises(ValueError):
+        report_script.main(["--runs-dir", str(runs_dir), "--out", str(bad_out)])
+    assert Path.cwd() == before  # finally restored cwd despite the write failing
+    assert not bad_out.exists()  # scan-before-write => nothing was written


### PR DESCRIPTION
## 1. 무엇을 / 왜

#2484 (run.py main() 커버리지) 의 자매 PR. `scripts/agent_evals_report.py::main()` 의 진입점 wiring 이 무테스트였다. 회귀 시 조용히 깨지는 두 동작을 잠근다:

1. **빈 run-log guard.** `if not logs: parser.error(...)` → `SystemExit`. run-log 없이 실행 시 degenerate aggregate 를 쓰는 대신 명확히 실패해야 하는 사용자 계약.
2. **cwd 복원 (correctness).** main() 은 `os.chdir(REPO_ROOT)` 후 `try: write_aggregate_report(...); finally: os.chdir(prev_cwd)`. write 가 실패(scanner 거부)해도 cwd 를 복원해야 — 이 `finally` 가 회귀로 빠지면 프로세스 cwd 가 REPO_ROOT 에 고착돼 후속 relative-path 작업이 조용히 오염된다.

## 2. 어떻게 (테스트 전용)

`report.main()` 은 git/subprocess 미사용·디스크 read/write 만 → DI 불요, 순수 테스트 추가.

- `test_report_main_errors_on_empty_runs_dir`: 빈 runs-dir → `SystemExit`.
- `test_report_main_restores_cwd_when_scanner_rejects_out_path`: 유효 run-log 채운 뒤 `--out` 을 wrong-name 경로(`agent-evals/reports/not_aggregate.json`)로 호출. relative_to(REPO_ROOT) 통과(chdir 발생) → scanner 가 PATH 거부 → `write_aggregate_report` ValueError → `finally` 가 cwd 복원함을 검증. scanner 는 scan-before-write 이라 거부 시 파일 미생성 — 테스트가 real tree 에 leak 0 임도 assert.

## 3. 테스트

- 신규 2건 통과; `tests/test_agent_evals_runner.py` + `tests/test_agent_evals_core.py` 75건 회귀 0.
- `git status` 클린(`M tests/...`만) — cwd 테스트가 real `agent-evals/reports/` 에 아무것도 안 씀 확인.

## 4. 범위

- **비 load-bearing**: `tests/` 만. 소스 무변경.
- One concern: report.py CLI 진입점 커버리지 (#2484 의 자매).

## 5. Eval 영향

N/A — 테스트 전용, 소스 동작 변경 0. load-bearing real-data 경로 무관이라 real-eval 델타 불요.

closes #2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)