### PR TITLE
test(table): pin null cell text normalization

### DIFF
--- a/tests/test_compare_table_parsers.py
+++ b/tests/test_compare_table_parsers.py
@@ -59,6 +59,12 @@ def test_normalize_text_preserves_punctuation() -> None:
     assert cmp._normalize_text("FR-007") == "fr-007"
 
 
+def test_normalize_text_none_to_empty_string() -> None:
+    # Nullable table-cell text appears in extractor JSON. Treat it as blank
+    # rather than the literal string "none" so empty cells compare cleanly.
+    assert cmp._normalize_text(None) == ""  # type: ignore[arg-type]
+
+
 # --- diff_pair ---------------------------------------------------------
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Table extractor JSON에서 nullable cell text가 들어와도 비교 정규화가 이를 빈 셀로 취급한다는 `_normalize_text(None) == ""` 계약을 회귀 테스트로 고정했습니다.

Closes #2492

## 2. 영향 파일

- `tests/test_compare_table_parsers.py` — compare-table parser text normalization regression test 추가

## 3. 리스크

- 리스크: test-only 변경이라 런타임 동작 변화는 없습니다.
- 확인: targeted compare table parser test 전체가 통과했고, diff whitespace 및 branch/issue convention을 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_compare_table_parsers.py` → 14 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: latest `origin/main` 기반 별도 worktree/branch 생성, open PR 7개 + worktree 104개 스캔 결과 `tests/test_compare_table_parsers.py` 겹침 없음

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. Test-only off-pipeline table parser comparison regression이라 public fixture/private real100_v2 eval 영향 없음. Legacy real100/v1 evidence 사용 안 함.

## 6. 하위 호환

기존 CLI/schema/출력 계약 변경 없음. nullable cell text를 빈 문자열로 비교하는 현행 동작만 테스트로 고정합니다.

## 7. 범위 외

- production parser/comparison 로직 변경 없음
- table extraction schema 변경 없음
