### PR TITLE
test(agent-evals): cover is_mineable signals gates + mine_tasks holdout-target warning

### DIFF
--- a/tests/test_agent_evals_task_mining.py
+++ b/tests/test_agent_evals_task_mining.py
@@ -113,3 +113,57 @@ def test_non_allowlisted_category_is_not_mineable() -> None:
             "signals": ["would be too unconstrained"],
         }
     )
+
+
+def test_string_signals_is_not_mineable() -> None:
+    # signals must be a non-string Sequence. A bare string would otherwise satisfy
+    # a naive truthiness check and then be iterated character-by-character into the
+    # acceptance contract, so is_mineable rejects it outright.
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_str_signals_test")
+
+    assert not mining.is_mineable(
+        {
+            "number": 1500,
+            "merged": True,
+            "category": "hook_privacy",
+            "signals": "deny-by-default guard",
+        }
+    )
+
+
+def test_empty_signals_is_not_mineable() -> None:
+    # A record with no signals carries no behavior to preserve, so it is not a
+    # usable task contract even when every other gate passes.
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_empty_signals_test")
+
+    assert not mining.is_mineable(
+        {
+            "number": 1500,
+            "merged": True,
+            "category": "hook_privacy",
+            "signals": [],
+        }
+    )
+
+
+def test_mine_tasks_warns_when_holdout_target_exceeds_mineable_count() -> None:
+    # The holdout-target warning is a DISTINCT contract from the mineable-floor
+    # warning (existing coverage only trips the floor warning with holdout == count).
+    # When the requested holdout split is larger than the mineable set, mine_tasks
+    # must surface it so an undersized holdout is never claimed silently. Set the
+    # floor low enough to be met, isolating the holdout warning.
+    mining = load_module("agent-evals/adapters/bidmate/task_mining.py", "agent_evals_task_mining_holdout_warn_test")
+
+    tasks, summary = mining.mine_tasks(
+        [
+            {"number": 1, "merged": True, "category": "eval_guard", "signals": ["paired delta primitive"]},
+            {"number": 2, "merged": True, "category": "eval_guard", "signals": ["min-N guard"]},
+        ],
+        mineable_floor=1,
+        holdout_target=5,
+    )
+
+    assert len(tasks) == 2
+    assert summary.mineable_count == 2
+    assert summary.holdout_target == 5
+    assert summary.warnings == ("holdout target exceeds mineable count: 5 > 2",)


### PR DESCRIPTION
## 1. 무엇을 / 왜

`agent-evals/adapters/bidmate/task_mining.py` 의 intake/sanitization 게이트 `is_mineable` 는 admission 분기 5개 중 일부만 커버됐다. 기존 테스트 대조로 **중복 회피**: privacy 게이트(`contains_raw_payload`)·unmerged 게이트·mineable-floor 경고는 `test_task_mining_uses_sanitized_metadata_only` 가 mine_tasks 통합으로 이미 검증 → 재작성 안 함.

**genuinely 미커버였던 distinct 분기 3개를 잠근다:**

1. **string-signals 타입 게이트** — `isinstance(signals, (str, bytes)) → not mineable`. bare string 이 char 단위로 acceptance 계약에 iterate 돼 들어가는 footgun 차단. string signals 를 넣는 테스트가 없었음.
2. **empty-signals** — `return bool(signals)` → `[]` not mineable. 기존 테스트는 항상 non-empty.
3. **mine_tasks holdout-target 경고** (floor 경고와 별개 계약) — 기존 테스트는 `holdout_target == count` 라 `holdout_target > len(tasks)` 분기가 미발동. floor 를 충족시키고 holdout 만 초과시켜 이 경고를 isolate → undersized holdout 이 조용히 주장되지 않음을 보장.

## 2. 테스트

- 신규 3건 통과; `tests/test_agent_evals_task_mining.py`+`core`+`runner` 82건 회귀 0.
- 기존 4건과 중복 0.

## 3. 범위

- **비 load-bearing**: `tests/` 만. 소스 무변경.
- One concern: task_mining is_mineable/mine_tasks 미커버 분기 커버리지.

## 4. Eval 영향

N/A — 테스트 전용, 소스 동작 변경 0. load-bearing real-data 경로 무관이라 real-eval 델타 불요.

closes #2494

🤖 Generated with [Claude Code](https://claude.com/claude-code)