### PR TITLE
test(agent-evals): cover scan_staged ADR 0005 commit enforcer (flags denied + judges staged blob)

### DIFF
--- a/tests/test_agent_evals_core.py
+++ b/tests/test_agent_evals_core.py
@@ -422,3 +422,69 @@ def test_generated_holdout_report_is_underpowered_with_no_ci_band() -> None:
         assert row.get("underpowered") is True, f"{name} should be underpowered at N=3"
         assert "ci_lo" not in row and "ci_hi" not in row, f"{name} must omit CI band when underpowered"
     assert any(note.startswith("UNDERPOWERED N=") for note in data["notes"])
+
+
+def _init_repo(tmp_path) -> Path:
+    """Create an isolated git repo for scan_staged tests (no real-repo coupling)."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.test")
+    _git("config", "user.name", "agent-evals-test")
+    return repo
+
+
+def test_scan_staged_flags_denied_staged_agent_eval_path(tmp_path) -> None:
+    # scan_staged is the ADR 0005 commit-time enforcer the pre-commit hook invokes
+    # via `report.py --check-staged`. Existing coverage only asserts the hook TEXT
+    # references it; this asserts the enforcement actually fires — a staged file
+    # outside the committable allowlist (a raw run-log) must be flagged.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_scan_staged_denied")
+    repo = _init_repo(tmp_path)
+
+    raw = repo / "agent-evals" / "runs"
+    raw.mkdir(parents=True)
+    (raw / "leak.json").write_text('{"captured_patch": "x"}', encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "agent-evals/runs/leak.json"],
+        check=True,
+        capture_output=True,
+    )
+
+    violations = report.scan_staged(repo)
+
+    assert [v.path for v in violations] == ["agent-evals/runs/leak.json"]
+    assert "outside the PR2 committable allowlist" in violations[0].reason
+
+
+def test_scan_staged_judges_staged_blob_not_worktree(tmp_path) -> None:
+    # scan_staged must validate what will be COMMITTED — the staged blob read via
+    # `git show :path` — not the current working-tree text. Stage a clean aggregate,
+    # then dirty the worktree with content that WOULD be flagged: the scan must still
+    # pass, because _read_staged_text reads the index, not the worktree. This locks
+    # the staged-vs-worktree correctness of the commit boundary.
+    report = load_module("agent-evals/core/report.py", "agent_evals_report_scan_staged_blob")
+    repo = _init_repo(tmp_path)
+
+    reports_dir = repo / "agent-evals" / "reports"
+    reports_dir.mkdir(parents=True)
+    clean = (REPO_ROOT / "agent-evals" / "reports" / "holdout-v0-vs-v1.aggregate.json").read_text(
+        encoding="utf-8"
+    )
+    target = reports_dir / "x.aggregate.json"
+    target.write_text(clean, encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "agent-evals/reports/x.aggregate.json"],
+        check=True,
+        capture_output=True,
+    )
+
+    # Dirty the worktree AFTER staging; the index still holds the clean blob.
+    target.write_text('{"captured_patch": "secret leak"}', encoding="utf-8")
+
+    assert report.scan_staged(repo) == []


### PR DESCRIPTION
## 1. 무엇을 / 왜

`agent-evals/core/report.py::scan_staged` 는 ADR 0005 commit-time privacy enforcer (`.githooks/pre-commit` → `report.py --check-staged`). 내용 검증 `validate_agent_eval_file` 는 두텁게 커버되나 **`scan_staged` 오케스트레이션 자체는 직접 미테스트**였다:

- 기존 `test_precommit_hook_enforces_agent_evals_boundary` 는 hook **텍스트**가 `--check-staged` 를 부르는지만 검사 → "hook 이 wire 됨".
- 그러나 scan_staged 가 staged 파일 열거(`git diff --cached`) + **staged blob**(`git show :path`) read + validate 하는 **실제 enforcement** 는 미검증 → "작동함" ≠ "wire 됨" (run.py egress-wiring(#2484)과 동일 class).

## 2. 어떻게 (테스트 전용)

`tests/test_agent_evals_core.py` 에 real-git tmp repo 테스트 2건 (기존 `test_run_one_*` real-git 패턴 동류, 격리 tmp repo — real-repo 결합 0):

1. **`test_scan_staged_flags_denied_staged_agent_eval_path`**: staged `agent-evals/runs/leak.json`(allowlist 밖) → scan_staged 가 해당 경로 flag. enforcement 발동 증명.
2. **`test_scan_staged_judges_staged_blob_not_worktree`**: clean aggregate staged 후 worktree 를 raw 내용으로 dirty → scan_staged 통과(staged blob 판정). `_read_staged_text` 가 worktree 대신 `:path`(index)를 읽는 commit-경계 correctness 잠금 — clean-staged/dirty-tree split commit 또는 dirty-unstaged false-flag 회귀 차단.

## 3. 테스트

- 신규 2건 통과; agent-evals 4개 파일 128건 회귀 0.
- `python3 -m pytest tests/test_agent_evals_core.py -k scan_staged -q` → 2 passed.

## 4. 범위

- **비 load-bearing**: `tests/` 만. 소스 무변경. 신규 import 0 (core 테스트는 이미 subprocess/importlib 보유).
- One concern: scan_staged commit-enforcer 동작 커버리지.

## 5. Eval 영향

N/A — 테스트 전용, 소스 동작 변경 0. load-bearing real-data 경로 무관이라 real-eval 델타 불요.

closes #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)