### PR TITLE
test(agent-tools): pin tool description contract

### DIFF
--- a/tests/test_agent_tools_regression.py
+++ b/tests/test_agent_tools_regression.py
@@ -102,6 +102,15 @@ def test_agent_react_tools_names():
     ], f"Unexpected order: {names}"
 
 
+def test_agent_react_tools_descriptions_nonempty():
+    # Anthropic tool definitions are shown to the LLM; an empty description
+    # silently weakens tool selection even when the JSON schema is valid.
+    for tool in AGENT_REACT_TOOLS:
+        description = tool.get("description")
+        assert isinstance(description, str)
+        assert len(description.strip()) > 20, tool["name"]
+
+
 # ---------------------------------------------------------------------------
 # 3. AGENT_TOOL_NAMES / is_valid_tool_name
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ReAct agent tool 정의는 JSON schema뿐 아니라 LLM에게 보여지는 tool-selection prompt이므로, 모든 `AGENT_REACT_TOOLS` 항목이 실질적인 description을 유지한다는 계약을 회귀 테스트로 고정했습니다.

Closes #2501

## 2. 영향 파일

- `tests/test_agent_tools_regression.py` — agent tool description contract regression test 추가

## 3. 리스크

- 리스크: test-only 변경이라 런타임 동작 변화는 없습니다.
- 확인: targeted agent tools regression test 전체가 통과했고, diff whitespace 및 branch/issue convention을 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_agent_tools_regression.py` → 19 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: latest `origin/main` 기반 별도 worktree/branch 생성, open PR 5개 + worktree 103개 스캔 결과 `tests/test_agent_tools_regression.py` 겹침 없음

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. Test-only agent tool registry regression이라 public fixture/private real100_v2 eval 영향 없음. Legacy real100/v1 evidence 사용 안 함.

## 6. 하위 호환

기존 tool schema/name/order/runtime behavior 변경 없음. 현재 description 존재 계약만 테스트로 고정합니다.

## 7. 범위 외

- production tool definition 변경 없음
- ReAct loop wiring 변경 없음
