### PR TITLE
test(bm25): pin tokenizer override casefolding

### DIFF
--- a/tests/test_bm25_kiwi_tokenizer.py
+++ b/tests/test_bm25_kiwi_tokenizer.py
@@ -117,6 +117,18 @@ class ConfigSurfaceTest(unittest.TestCase):
         )
         self.assertEqual(config["bm25_tokenizer"], "kiwi")
 
+    def test_resolve_lowercases_tokenizer_override(self) -> None:
+        # CLI / YAML values sometimes arrive with human casing. The resolver
+        # normalizes before allow-list validation so `KIWI` is the same
+        # explicit opt-in as `kiwi`.
+        config = resolve_pipeline_config(
+            {
+                "pipeline": "agentic_full",
+                "bm25_tokenizer": "KIWI",
+            }
+        )
+        self.assertEqual(config["bm25_tokenizer"], "kiwi")
+
     def test_resolve_defaults_to_regex_when_missing(self) -> None:
         config = resolve_pipeline_config({"pipeline": "naive_baseline"})
         self.assertEqual(config["bm25_tokenizer"], "regex")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Human-authored YAML/CLI override에서 `bm25_tokenizer: KIWI`처럼 대문자 값이 들어와도 `resolve_pipeline_config`가 소문자로 정규화해 동일한 opt-in으로 처리한다는 계약을 회귀 테스트로 고정했습니다.

Closes #2504

## 2. 영향 파일

- `tests/test_bm25_kiwi_tokenizer.py` — BM25 tokenizer override casefold regression test 추가

## 3. 리스크

- 리스크: test-only 변경이라 런타임 동작 변화는 없습니다.
- 확인: targeted BM25 tokenizer regression test 전체가 통과했고, diff whitespace 및 branch/issue convention을 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_bm25_kiwi_tokenizer.py` → 19 passed, 5 subtests passed
- `git diff --check`
- `make check-branch`
- overlap preflight: latest `origin/main` 기반 별도 worktree/branch 생성, open PR 5개 + worktree 103개 스캔 결과 `tests/test_bm25_kiwi_tokenizer.py` 겹침 없음

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. Test-only pipeline config regression이라 public fixture/private real100_v2 eval 영향 없음. Legacy real100/v1 evidence 사용 안 함.

## 6. 하위 호환

기존 preset/config 값과 runtime behavior 변경 없음. 현재 `bm25_tokenizer` lower-case normalization 계약만 테스트로 고정합니다.

## 7. 범위 외

- production resolver 변경 없음
- BM25 tokenizer implementation 변경 없음
