### PR TITLE
test(verifier): pin drift helper id normalization

### DIFF
--- a/tests/test_verifier_drift_check.py
+++ b/tests/test_verifier_drift_check.py
@@ -12,6 +12,10 @@ def test_gold_retrieved_is_false_for_missing_or_disjoint_gold_ids() -> None:
     assert gold_retrieved({"retrieved_chunk_ids": ["r1"]}) is False
 
 
+def test_gold_retrieved_normalizes_numeric_ids_before_comparison() -> None:
+    assert gold_retrieved({"gold_chunk_ids": [1001], "retrieved_chunk_ids": ["1001"]}) is True
+
+
 def test_doc_matched_requires_all_expected_docs_in_evidence() -> None:
     assert doc_matched({"expected_doc_ids": ["d1", "d2"], "evidence_doc_ids": ["d0", "d1", "d2"]}) is True
     assert doc_matched({"expected_doc_ids": ["d1", "d2"], "evidence_doc_ids": ["d1"]}) is False
@@ -20,3 +24,7 @@ def test_doc_matched_requires_all_expected_docs_in_evidence() -> None:
 def test_doc_matched_is_false_without_expected_docs() -> None:
     assert doc_matched({"expected_doc_ids": [], "evidence_doc_ids": ["d1"]}) is False
     assert doc_matched({"evidence_doc_ids": ["d1"]}) is False
+
+
+def test_doc_matched_normalizes_numeric_ids_before_comparison() -> None:
+    assert doc_matched({"expected_doc_ids": [2026], "evidence_doc_ids": ["d0", "2026"]}) is True


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Verifier drift helper inputs can mix numeric YAML/JSON ids with string ids from index/eval artifacts, and the helpers intentionally normalize via `str(...)` before comparing sets. This PR pins that type-insensitive comparison boundary with focused tests only.

Closes #2508

## 2. 영향 파일

- `tests/test_verifier_drift_check.py` — adds numeric-id normalization coverage for `gold_retrieved` and `doc_matched`.

## 3. 리스크

- Risk: test-only coverage could accidentally assert behavior different from the existing helper contract.
- Mitigation: verified against the current helper implementation and targeted test file; no production code changed.

## 4. 테스트

- `python3 -m pytest -q tests/test_verifier_drift_check.py` — 6 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main` worktree; open PRs scanned=4; Codex/Claude/external worktrees scanned=104; selected file `tests/test_verifier_drift_check.py` was clear.

## 5. Eval 영향

No eval behavior change. This is test-only coverage for helper semantics; no load-bearing RAG/eval implementation path changed and no real-eval run was needed.

## 6. 하위 호환

No contract/schema/CLI changes. Existing helper behavior is preserved and documented by tests.

## 7. 범위 외

- No rewrite of `scripts/component_eval/verifier_drift_check.py`.
- No private eval aggregate refresh.
