### PR TITLE
test(ship): pin secret env prefix boundary

### DIFF
--- a/tests/test__ship_env.py
+++ b/tests/test__ship_env.py
@@ -1,6 +1,10 @@
 from scripts._ship_env import SHIP_SECRET_ENV_PREFIX, strip_ship_secret_env
 
 
+def test_ship_secret_env_prefix_keeps_trailing_separator() -> None:
+    assert SHIP_SECRET_ENV_PREFIX == "BIDMATE_SHIP_"
+
+
 def test_strip_ship_secret_env_removes_only_ship_prefixed_keys() -> None:
     env = {
         "BIDMATE_SHIP_TOKEN": "secret",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Ship-lane secret stripping is deny-by-prefix. The exact `BIDMATE_SHIP_` value, including the trailing underscore, keeps unrelated env names such as `BIDMATE_SHIPPING_LABEL` out of the deny set. This PR pins that boundary with a focused test only.

Closes #2510

## 2. 영향 파일

- `tests/test__ship_env.py` — adds exact-value coverage for `SHIP_SECRET_ENV_PREFIX`.

## 3. 리스크

- Risk: an overly broad prefix could strip non-secret env vars in runner subprocesses.
- Mitigation: test locks the exact trailing-underscore prefix; existing functional tests still verify non-secret `BIDMATE_SHIPPING_LABEL` preservation.

## 4. 테스트

- `python3 -m pytest -q tests/test__ship_env.py` — 3 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main` worktree; open PRs scanned=4; Codex/Claude/external worktrees scanned=105; busy paths=789; selected file `tests/test__ship_env.py` was clear.

## 5. Eval 영향

No eval behavior change. This is test-only coverage for ship env filtering; no RAG/eval implementation path changed and no real-eval run was needed.

## 6. 하위 호환

No contract/schema/CLI changes. Existing env filtering behavior is preserved.

## 7. 범위 외

- No production change to `scripts/_ship_env.py`.
- No changes to ship runner wiring.
