### PR TITLE
test(autotune): pin demo entrypoint order

### DIFF
--- a/tests/test_demo_lane_autotune.py
+++ b/tests/test_demo_lane_autotune.py
@@ -30,3 +30,11 @@ def test_demo_on_prints_auditor_strengthen_contract(capsys):
     assert "effort_overrides[('Auditor', 'codex')] = 'xhigh'" in out
     assert "cooldown_state['Auditor||codex'] = 2" in out
     assert "model_reasoning_effort=xhigh" in out
+
+
+def test_main_prints_off_before_on_demo(capsys):
+    demo.main()
+
+    out = capsys.readouterr().out
+
+    assert out.index("AUTOTUNE OFF") < out.index("AUTOTUNE ON")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

The lane autotune demo is a reader-facing script: `main()` should show the inert OFF/opt-in boundary before the actuated ON example. This PR pins that entrypoint ordering with focused test coverage only.

Closes #2512

## 2. 영향 파일

- `tests/test_demo_lane_autotune.py` — adds `main()` output ordering coverage.

## 3. 리스크

- Risk: future demo edits could accidentally present the actuated path before the opt-in OFF boundary.
- Mitigation: test asserts `AUTOTUNE OFF` appears before `AUTOTUNE ON` through the real `main()` entrypoint.

## 4. 테스트

- `python3 -m pytest -q tests/test_demo_lane_autotune.py` — 3 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main` worktree; open PRs scanned=4; Codex/Claude/external worktrees scanned=106; busy paths=790; selected file `tests/test_demo_lane_autotune.py` was clear.

## 5. Eval 영향

No eval behavior change. This is test-only coverage for a demo script; no RAG/eval implementation path changed and no real-eval run was needed.

## 6. 하위 호환

No contract/schema/CLI changes. Existing demo behavior is preserved.

## 7. 범위 외

- No production change to `scripts/demo_lane_autotune.py`.
- No lane autotune controller behavior changes.
