### PR TITLE
test(indexing): pin local export manifest skip

### DIFF
--- a/tests/test_rag_indexing_raw_documents.py
+++ b/tests/test_rag_indexing_raw_documents.py
@@ -17,6 +17,15 @@ def test_load_raw_documents_skips_local_export_manifest(tmp_path):
     assert [doc["doc_id"] for doc in docs] == ["doc_001"]
 
 
+def test_load_raw_documents_skips_invalid_local_export_manifest_before_json_parse(tmp_path):
+    (tmp_path / "doc_001.md").write_text("# Doc 1\n\nBody\n", encoding="utf-8")
+    (tmp_path / "export_manifest.local.json").write_text("{not valid json", encoding="utf-8")
+
+    docs = load_raw_documents(tmp_path)
+
+    assert [doc["doc_id"] for doc in docs] == ["doc_001"]
+
+
 def test_load_raw_documents_skips_metadata_siblings_and_hidden_files(tmp_path):
     (tmp_path / ".hidden.md").write_text("# Hidden\n\nNot a corpus doc\n", encoding="utf-8")
     (tmp_path / "README.md").write_text("# Local corpus notes\n", encoding="utf-8")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`load_raw_documents()` treats local export manifests as metadata siblings, not corpus documents. This PR pins that skip-before-parse ordering by proving a malformed `export_manifest.local.json` is ignored instead of parsed as raw JSON.

Closes #2514

## 2. 영향 파일

- `tests/test_rag_indexing_raw_documents.py` — adds invalid local export manifest skip coverage.

## 3. 리스크

- Risk: future loader changes could parse local export metadata as a corpus JSON document and fail on malformed bookkeeping files.
- Mitigation: focused regression asserts a valid Markdown document still loads while malformed `export_manifest.local.json` is skipped.

## 4. 테스트

- `python3 -m pytest -q tests/test_rag_indexing_raw_documents.py` — 3 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main` worktree; open PRs scanned=4; Codex/Claude/external worktrees with busy files=107; busy paths=791; selected file `tests/test_rag_indexing_raw_documents.py` was clear.

## 5. Eval 영향

No eval behavior change. This is test-only coverage for raw document loader metadata-sibling semantics; no RAG/eval implementation path changed and no real-eval run was needed.

## 6. 하위 호환

No contract/schema/CLI changes. Existing loader behavior is preserved.

## 7. 범위 외

- No production change to `rag_indexing.py`.
- No private eval/index rebuild.
