### PR TITLE
test(boundary): pin redacted egress profile closure

### DIFF
--- a/tests/test_bidmate_data_boundary.py
+++ b/tests/test_bidmate_data_boundary.py
@@ -21,6 +21,14 @@ def test_approved_private_egress_profile_allows_when_surface_unset(monkeypatch: 
     assert boundary.external_egress_allowed()
 
 
+def test_redacted_external_profile_still_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(boundary.DATA_SURFACE_ENV, raising=False)
+    monkeypatch.setenv(boundary.EGRESS_PROFILE_ENV, "redacted_external_api")
+
+    assert boundary.resolve_egress_profile() == "redacted_external_api"
+    assert not boundary.external_egress_allowed()
+
+
 def test_unattested_external_payload_fails_closed_with_channel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(boundary.DATA_SURFACE_ENV, "private_local")
     monkeypatch.setenv(boundary.EGRESS_PROFILE_ENV, "connected_no_egress")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`redacted_external_api` is intentionally not an approved egress attestation: current external backends can send payload text, not a proven-redacted payload. This PR pins that fail-closed boundary with focused test coverage only.

Closes #2516

## 2. 영향 파일

- `tests/test_bidmate_data_boundary.py` — adds fail-closed coverage for `BIDMATE_EGRESS_PROFILE=redacted_external_api`.

## 3. 리스크

- Risk: future allowlist edits could accidentally permit a redaction-named profile before redaction is enforceable at every egress site.
- Mitigation: test asserts the profile resolves but does not allow external egress without public-surface attestation.

## 4. 테스트

- `python3 -m pytest -q tests/test_bidmate_data_boundary.py` — 4 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: latest `origin/main` worktree; open PRs scanned=4; Codex/Claude/external worktrees with busy files=108; busy paths=792; selected file `tests/test_bidmate_data_boundary.py` was clear.

## 5. Eval 영향

No eval behavior change. This is test-only coverage for data-boundary policy semantics; no RAG/eval implementation path changed and no real-eval run was needed.

## 6. 하위 호환

No contract/schema/CLI changes. Existing fail-closed behavior is preserved.

## 7. 범위 외

- No production change to `bidmate_data_boundary.py`.
- No new egress profile or external API behavior.
