### PR TITLE
test(html): pin empty status-card detail

### DIFF
--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -28,6 +28,14 @@ def test_status_card_escapes_fields_and_preserves_known_tone() -> None:
     assert "&#x27;quoted&#x27;" in html
 
 
+def test_status_card_omits_empty_detail_element() -> None:
+    html = render_status_card("Total", "0", detail="")
+
+    assert "<small>" not in html
+    assert "</small>" not in html
+    assert "<strong>0</strong></article>" in html
+
+
 def test_table_escapes_headers_rows_and_empty_message() -> None:
     empty = render_table(["A&B", "C"], [], empty_message="<none>")
     rows = render_table(["A"], [["<cell>"]])


### PR DESCRIPTION
## Summary
- Add focused coverage that `render_status_card()` omits the optional `<small>` detail element when `detail` is empty.

## Issue
Closes #2518

## Scope / overlap
- Base: `origin/main` `5de2d5612370632838b67096054ac2e74cc98332`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_html_report.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_html_report.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_html_report.py` only.

## Validation
- `python3 -m pytest -q tests/test_html_report.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only HTML helper coverage; no retrieval/answer/eval behavior changed.
