### PR TITLE
test(embedding): pin vector rank guard

### DIFF
--- a/tests/test_embedding_provider_protocol.py
+++ b/tests/test_embedding_provider_protocol.py
@@ -43,6 +43,17 @@ def test_embedding_dimension_mismatch_raises_explicit_error() -> None:
         ensure_embedding_dimension(result, 4)
 
 
+def test_embedding_dimension_validation_rejects_non_matrix_vectors() -> None:
+    result = EmbeddingResult(
+        vectors=np.zeros(4, dtype=np.float32),
+        backend="fake",
+        model="fake-model",
+    )
+
+    with pytest.raises(ValueError, match="expected 4, got None"):
+        ensure_embedding_dimension(result, 4)
+
+
 def test_embedding_dimension_match_returns_original_result() -> None:
     result = EmbeddingResult(
         vectors=np.zeros((1, 4), dtype=np.float32),


### PR DESCRIPTION
## Summary
- Add focused coverage that `ensure_embedding_dimension()` rejects non-2D vectors when an expected dimension is configured.

## Issue
Closes #2520

## Scope / overlap
- Base: `origin/main` `f763844d83cd9789baccd72678cc7734cc063f15`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_embedding_provider_protocol.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_embedding_provider_protocol.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_embedding_provider_protocol.py` only.

## Validation
- `python3 -m pytest -q tests/test_embedding_provider_protocol.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only embedding protocol coverage; no retrieval/answer/eval behavior changed.
