### PR TITLE
test(metrics): pin missing-count clamp

### DIFF
--- a/tests/test_naive_rag_metrics_helpers.py
+++ b/tests/test_naive_rag_metrics_helpers.py
@@ -30,6 +30,14 @@ def test_summarize_metric_reports_numeric_count_and_missing_values() -> None:
     }
 
 
+def test_summarize_metric_clamps_missing_when_total_is_smaller_than_values() -> None:
+    assert summarize_metric([1, 2, 3], total=1) == {
+        "mean": 2.0,
+        "n": 3,
+        "missing": 0,
+    }
+
+
 def test_summarize_case_metrics_and_latency_use_declared_totals() -> None:
     cases = [{"score": 1.0}, {"score": None}, {"other": 5}]
 


### PR DESCRIPTION
## Summary
- Add focused coverage that `summarize_metric()` clamps `missing` at zero when declared `total` is smaller than the numeric values provided.

## Issue
Closes #2522

## Scope / overlap
- Base: `origin/main` `4841d62ecc37b1502fe2f33b20ded48851567985`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_naive_rag_metrics_helpers.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_naive_rag_metrics_helpers.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_naive_rag_metrics_helpers.py` only.

## Validation
- `python3 -m pytest -q tests/test_naive_rag_metrics_helpers.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only naive metrics helper coverage; no retrieval/answer/eval behavior changed.
