### PR TITLE
test(audit): pin page metadata helper paths

### DIFF
--- a/tests/test_private_data_quality_audit_utils.py
+++ b/tests/test_private_data_quality_audit_utils.py
@@ -28,6 +28,12 @@ def test_percentile_interpolates_and_handles_empty_input():
     assert utils.percentile([10, 20, 30, 40], 0.5) == pytest.approx(25.0)
 
 
+def test_page_metadata_present_uses_metadata_and_region_fields():
+    assert utils.page_metadata_present({"page": "", "metadata": {"page_span": [2, 3]}})
+    assert utils.page_metadata_present({"regions": [{"page_number": ""}, {"page_number": 4}]})
+    assert not utils.page_metadata_present({"page": "", "metadata": {"pages": []}, "regions": []})
+
+
 def test_public_safety_flags_forbidden_keys_and_absolute_paths():
     hits = utils.forbidden_output_hits(
         {"safe": [{"doc_id": "PRIVATE-DOC"}], "note": "/Users/hskim/private/file.hwp"}


### PR DESCRIPTION
## Summary
- Add focused coverage that `page_metadata_present()` recognizes nested metadata page spans and OCR region page numbers while ignoring blank page fields.

## Issue
Closes #2524

## Scope / overlap
- Base: `origin/main` `d7dbf63e71cde1e916dbeba94d93abefc7f39c10`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_private_data_quality_audit_utils.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_private_data_quality_audit_utils.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_private_data_quality_audit_utils.py` only.

## Validation
- `python3 -m pytest -q tests/test_private_data_quality_audit_utils.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only private audit helper coverage; no retrieval/answer/eval behavior changed.
