### PR TITLE
test(claude): pin stderr tool-use symptom

### DIFF
--- a/tests/test_reproduce_claude_edit_tool.py
+++ b/tests/test_reproduce_claude_edit_tool.py
@@ -24,6 +24,17 @@ def test_classify_preserves_reproducer_symptom_order():
         assert repro.classify(**kwargs, timeout=30) == expected
 
 
+def test_classify_detects_tool_use_unique_error_from_stderr():
+    assert repro.classify(
+        exit_code=1,
+        stdout="",
+        stderr="API error: tool_use ids must be unique",
+        edited=False,
+        duration=1,
+        timeout=30,
+    ) == "S2_tool_use_ids"
+
+
 def test_render_markdown_table_escapes_pipe_cells():
     result = repro.CellResult(
         label="cell", cmd=["claude"], exit_code=None, duration_s=3.5,


### PR DESCRIPTION
## Summary
- Add focused coverage that `classify()` recognizes `tool_use ids must be unique` when the message is emitted on stderr.

## Issue
Closes #2526

## Scope / overlap
- Base: `origin/main` `a7688ae37dc27a47a29984eebc84e8c13e1145f7`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_reproduce_claude_edit_tool.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_reproduce_claude_edit_tool.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_reproduce_claude_edit_tool.py` only.

## Validation
- `python3 -m pytest -q tests/test_reproduce_claude_edit_tool.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only reproducer helper coverage; no retrieval/answer/eval behavior changed.
