### PR TITLE
test(taxonomy): pin partial multi-chunk label

### DIFF
--- a/tests/test_naive_rag_taxonomy.py
+++ b/tests/test_naive_rag_taxonomy.py
@@ -34,6 +34,20 @@ def test_classify_failure_labels_failed_abstention_for_unanswerable_case() -> No
     assert labels == ["answer_failure.failed_to_abstain"]
 
 
+def test_classify_failure_labels_partial_multi_chunk_retrieval() -> None:
+    primary, labels = classify_failure(
+        question={"answerable": True},
+        gold_chunk_ids=["gold-1", "gold-2"],
+        retrieved_chunk_ids=["gold-1"],
+        cited_chunk_ids=["gold-1"],
+        retrieval_metrics={"recall_at_10": 0.5, "recall_at_5": 0.5},
+        answer_metrics={"citation_accuracy": 1.0, "answer_relevancy": 1.0},
+    )
+
+    assert primary == "retrieval_failure.multi_chunk_evidence_missing"
+    assert labels == ["retrieval_failure.multi_chunk_evidence_missing"]
+
+
 def test_count_failures_ignores_unknown_and_none_labels() -> None:
     counts = count_failures([
         "retrieval_failure.query_wording_mismatch",


### PR DESCRIPTION
## Summary
- Add focused coverage that `classify_failure()` emits `retrieval_failure.multi_chunk_evidence_missing` for answerable multi-chunk gold cases with partial nonzero top-10 recall.

## Issue
Closes #2528

## Scope / overlap
- Base: `origin/main` `9449c42fb14464f7c05603368fb36d6eba400965`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_naive_rag_taxonomy.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_naive_rag_taxonomy.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_naive_rag_taxonomy.py` only.

## Validation
- `python3 -m pytest -q tests/test_naive_rag_taxonomy.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only naive taxonomy coverage; no retrieval/answer/eval behavior changed.
