### PR TITLE
test(eval): pin Korean ban-context guard

### DIFF
--- a/tests/test_check_real100_v2_only.py
+++ b/tests/test_check_real100_v2_only.py
@@ -33,6 +33,8 @@ make real-eval-v2-check
 
 def test_ban_context_and_stale_command_detection_are_separate():
     assert guard._is_ban_context("legacy reports/real100 is banned") is True
+    assert guard._is_ban_context("reports/real100 사용하지 말고 real100_v2를 사용") is True
+    assert guard._is_ban_context("legacy real100 집계는 금지") is True
     assert guard._is_ban_context("Use reports/real100 for a new claim") is False
     assert guard.STALE_COMMAND_RE.match("make real-eval")
     assert guard.STALE_COMMAND_RE.match("REAL_EVAL_ROOT=/x make real-eval --foo")


### PR DESCRIPTION
## Summary
- Add focused coverage that the real100_v2-only guard treats Korean prohibition wording (`사용하지`, `금지`) as ban context.

## Issue
Closes #2530

## Scope / overlap
- Base: `origin/main` `a126a2b3a2aaddd9fdc435e04e71e4b2d496ae02`.
- Open PR overlap preflight: scanned #2226, #2219, #2218, #2216; no overlap with `tests/test_check_real100_v2_only.py`.
- Codex/Claude/external dirty worktree preflight: selected `tests/test_check_real100_v2_only.py` was clear; root/main had unrelated `ingestion.py` and `tests/test_hwp_pdf_pymupdf4llm_loader.py` changes, plus untouched untracked docs/wiki.
- Changed path: `tests/test_check_real100_v2_only.py` only.

## Validation
- `python3 -m pytest -q tests/test_check_real100_v2_only.py`
- `git diff --check`
- `make check-branch`

## Eval impact
N/A — test-only real100_v2 guard coverage; no retrieval/answer/eval behavior changed.
