### PR TITLE
test(branch): pin parser exemptions

### DIFF
--- a/tests/test_branch_convention.py
+++ b/tests/test_branch_convention.py
@@ -82,6 +82,16 @@ def test_parse_branch_returns_issue_number(name, expected):
 
 
 @pytest.mark.parametrize("name", [
+    "revert-123-old-branch",
+    "dependabot/pip/requests-2.31.0",
+    "renovate/python-3.x",
+    "pre-commit-ci/update-config",
+])
+def test_parse_branch_returns_none_for_exempt_bot_branches(name):
+    assert cbi.parse_branch(name) is None
+
+
+@pytest.mark.parametrize("name", [
     "claude/issue-1-foo",
     "main",
     "feat/no-issue",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`parse_branch()`가 ADR 0007의 exempt branch prefix(`revert-`, `dependabot/`, `renovate/`, `pre-commit-ci/`)를 issue-linked branch로 오인하지 않고 계속 `None`으로 처리하는지 고정하는 테스트를 추가했습니다.

Closes #2532

## 2. 영향 파일

- `tests/test_branch_convention.py` — branch/issue convention regression coverage only

## 3. 리스크

- 리스크 낮음: 소스 변경 없이 테스트 케이스만 추가합니다.
- 깨짐 경로: exempt regex는 맞지만 `parse_branch()` 처리에서 일부 bot prefix가 issue-link 요구로 회귀하는 경우를 놓칠 수 있음.
- 배제 근거: 새 parametrized test가 모든 exempt prefix를 `parse_branch(...) is None`으로 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_branch_convention.py` — 54 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_branch_convention.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. `parse_branch()` 동작 변경 없이 기존 exempt 계약을 테스트로 고정합니다.

## 7. 범위 외

- `scripts/check_branch_and_issue.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
