### PR TITLE
test(doc-links): pin fragment adornment parsing

### DIFF
--- a/tests/test_check_doc_links.py
+++ b/tests/test_check_doc_links.py
@@ -150,6 +150,11 @@ def test_fragment_strips_path_line_suffix():
     assert split_fragment("foo.md:10#bar") == ("foo.md", "bar")
 
 
+def test_fragment_angle_brackets_and_title_stripped():
+    assert split_fragment("<foo.md#bar>") == ("foo.md", "bar")
+    assert split_fragment('foo.md#bar "Title"') == ("foo.md", "bar")
+
+
 # ---------------------------------------------------------------------------
 # normalize_target — href → filesystem-checkable path, or None to skip
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`split_fragment()`가 문서화한 href adornment 처리 계약을 고정하기 위해, angle-bracket으로 감싼 markdown fragment와 trailing link title이 붙은 fragment를 정상 파싱하는 회귀 테스트를 추가했습니다.

Closes #2534

## 2. 영향 파일

- `tests/test_check_doc_links.py` — doc-link parser regression coverage only

## 3. 리스크

- 리스크 낮음: 구현 변경 없이 테스트 케이스만 추가합니다.
- 깨짐 경로: `normalize_target()`와 달리 `split_fragment()`가 `<foo.md#bar>` 또는 `foo.md#bar "Title"` 형태를 더 이상 동일하게 정규화하지 못하는 회귀.
- 배제 근거: 새 테스트가 두 형태의 반환값을 직접 고정합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_check_doc_links.py` — 46 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_check_doc_links.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. 기존 `split_fragment()` 동작을 테스트로 고정합니다.

## 7. 범위 외

- `scripts/check_doc_links.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
