### PR TITLE
test(utils): pin stable_json formatting

### DIFF
--- a/tests/test_scripts_utils.py
+++ b/tests/test_scripts_utils.py
@@ -129,6 +129,11 @@ def test_stable_json_preserves_non_ascii_and_trailing_newline() -> None:
     assert json.loads(out) == {"기관": "행안부"}
 
 
+def test_stable_json_uses_two_space_nested_indent() -> None:
+    out = stable_json({"outer": {"inner": 1}})
+    assert out == '{\n  "outer": {\n    "inner": 1\n  }\n}\n'
+
+
 # --- repo_path / rel_path: ROOT_DIR 경계 ---
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`stable_json()`이 aggregate artifact writer들이 기대하는 사람이 읽기 쉬운 2-space nested JSON 레이아웃을 계속 유지하도록 회귀 테스트를 추가했습니다.

Closes #2536

## 2. 영향 파일

- `tests/test_scripts_utils.py` — scripts utility helper regression coverage only

## 3. 리스크

- 리스크 낮음: 구현 변경 없이 테스트 케이스만 추가합니다.
- 깨짐 경로: `stable_json()` 포맷이 compact JSON 또는 다른 indent 폭으로 바뀌어 artifact diff/readability 계약이 흔들리는 경우.
- 배제 근거: 새 테스트가 nested payload의 정확한 2-space pretty JSON 문자열을 고정합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_scripts_utils.py` — 21 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_scripts_utils.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. 기존 `stable_json()` 출력 포맷을 테스트로 고정합니다.

## 7. 범위 외

- `scripts/_utils.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
