### PR TITLE
test(pr-eval): pin normalize leading-dot scope

### DIFF
--- a/tests/test_change_scope_path_predicates.py
+++ b/tests/test_change_scope_path_predicates.py
@@ -168,6 +168,7 @@ def test_is_pytest_path_adr0100_agent_evals_guard() -> None:
         ("a/b", "a/b"),             # 변화 없음
         ("./", ""),                 # 전부 ./ → 빈 문자열
         ("  x  ", "x"),             # 공백만 strip
+        ("a/./b.py", "a/./b.py"),    # 내부 ./ 세그먼트는 canonicalize 하지 않음
     ],
 )
 def test_normalize(raw: str, expected: str) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`pr_eval_change_scope._normalize()`가 선행 `./` prefix만 제거하고 내부 `./` path segment는 canonicalize하지 않는 현재 계약을 테스트로 고정했습니다. PR changed-file path 분류가 예기치 않게 더 공격적으로 정규화되는 회귀를 막기 위함입니다.

Closes #2538

## 2. 영향 파일

- `tests/test_change_scope_path_predicates.py` — PR eval path predicate regression coverage only

## 3. 리스크

- 리스크 낮음: 구현 변경 없이 테스트 케이스 1개만 추가합니다.
- 깨짐 경로: `_normalize()`가 내부 `./`까지 제거하도록 바뀌어 path-classifier 입력 계약이 조용히 달라지는 경우.
- 배제 근거: 새 parametrized case가 `a/./b.py`를 그대로 보존하는지 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_change_scope_path_predicates.py` — 50 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_change_scope_path_predicates.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. 기존 `_normalize()` 동작을 테스트로 고정합니다.

## 7. 범위 외

- `scripts/pr_eval_change_scope.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
