### PR TITLE
test(doc-links): pin one-line comment heading skip

### DIFF
--- a/tests/test_check_doc_links_headings.py
+++ b/tests/test_check_doc_links_headings.py
@@ -82,6 +82,11 @@ def test_html_comment_block_headings_skipped() -> None:
     assert _headings(text) == ["# Keep", "# After"]
 
 
+def test_single_line_html_comment_heading_skipped() -> None:
+    text = "# Keep\n<!-- # In Comment -->\n# After\n"
+    assert _headings(text) == ["# Keep", "# After"]
+
+
 # ----------------------------------------------------------------------
 # ATX 인정 경계
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`_iter_heading_lines()`가 single-line HTML comment 안의 heading-shaped 텍스트를 GitHub anchor 후보로 만들지 않도록 회귀 테스트를 추가했습니다. 기존 block comment skip과 같은 anchor 무결성 경계를 더 좁게 고정합니다.

Closes #2540

## 2. 영향 파일

- `tests/test_check_doc_links_headings.py` — doc-link heading parser regression coverage only

## 3. 리스크

- 리스크 낮음: 구현 변경 없이 테스트 케이스만 추가합니다.
- 깨짐 경로: `<!-- # heading -->` 같은 single-line comment가 heading으로 수집되어 fragment-link 검사가 가짜 anchor를 허용하는 경우.
- 배제 근거: 새 테스트가 comment 내부 heading은 제외하고 전후 실제 heading만 반환하는지 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_check_doc_links_headings.py` — 12 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_check_doc_links_headings.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. 기존 heading parser 동작을 테스트로 고정합니다.

## 7. 범위 외

- `scripts/check_doc_links.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
