### PR TITLE
test(clarification): pin duplicate metadata label choice

### DIFF
--- a/tests/test_clarification_text.py
+++ b/tests/test_clarification_text.py
@@ -147,3 +147,18 @@ def test_metadata_clarification_strips_agency_project() -> None:
         ),
     )
     assert "행안부 · 사업A (doc1)" in out
+
+
+def test_metadata_clarification_duplicate_doc_id_keeps_first_label() -> None:
+    out = metadata_clarification_answer(
+        "예산은?",
+        _analysis(
+            ["doc1"],
+            [
+                {"doc_id": "doc1", "agency": "행안부", "project": "사업A"},
+                {"doc_id": "doc1", "agency": "교육부", "project": "사업B"},
+            ],
+        ),
+    )
+    assert "행안부 · 사업A (doc1)" in out
+    assert "교육부 · 사업B (doc1)" not in out


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`metadata_clarification_answer()`가 같은 `doc_id`에 대해 여러 metadata match를 받을 때 첫 번째 label을 유지하는 현재 렌더 계약을 테스트로 고정했습니다. metadata ambiguity 안내 문구가 동일 문서의 후속 중복 match에 흔들리지 않게 하기 위함입니다.

Closes #2542

## 2. 영향 파일

- `tests/test_clarification_text.py` — clarification text builder regression coverage only

## 3. 리스크

- 리스크 낮음: 구현 변경 없이 테스트 케이스만 추가합니다.
- 깨짐 경로: 같은 `doc_id`의 후속 metadata match가 먼저 수집된 `agency · project` label을 덮어써 사용자에게 다른 후보 라벨을 보여주는 경우.
- 배제 근거: 새 테스트가 첫 label 포함/두 번째 label 미포함을 직접 검증합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_clarification_text.py` — 12 passed
- `git diff --check`
- `make check-branch`
- Overlap preflight: branch file `tests/test_clarification_text.py`; open PR overlap 없음; dirty Codex/Claude worktree overlap 없음.

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. 테스트 전용 변경이라 real-data eval 미실행.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. 기존 clarification text 렌더 동작을 테스트로 고정합니다.

## 7. 범위 외

- `rag_clarification.py` 구현 변경 없음.
- 오래된 orphan worktree 정리 없음.
