### PR TITLE
test(answer): pin canonical PDF citation metadata

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -19,6 +19,7 @@ from rag_answer import (
     citation_label,
     claim_target,
     format_metadata_claim_value,
+    make_citation,
 )
 
 
@@ -72,6 +73,48 @@ def test_citation_label_basis_prefix() -> None:
 def test_citation_label_single_vs_range_page() -> None:
     assert citation_label("source_pdf", [7, 7]) == "원본 PDF p.7"  # single
     assert citation_label("source_pdf", [3, 5]) == "원본 PDF pp.3-5"  # range
+
+
+# --- make_citation: canonical PDF metadata passthrough ---
+
+
+def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "section": "입찰 개요",
+        "agency": "조달청",
+        "section_path": ["root", 2],
+        "page_span": [2, 4],
+        "text_span_hash": "span-sha",
+        "metadata": {
+            "text_source": "pdf_pymupdf4llm",
+            "citation_basis": "source_pdf",
+            "converted_pdf_sha256": "converted-sha",
+            "converted_pdf_page_count": 12,
+            "citation_pdf_sha256": "citation-sha",
+            "citation_pdf_page_count": 8,
+        },
+    })
+
+    assert citation == {
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "section": "입찰 개요",
+        "agency": "조달청",
+        "section_path": ["root", "2"],
+        "page_span": [2, 4],
+        "text_source": "pdf_pymupdf4llm",
+        "citation_basis": "source_pdf",
+        "converted_pdf_sha256": "converted-sha",
+        "converted_pdf_page_count": 12,
+        "citation_pdf_sha256": "citation-sha",
+        "citation_pdf_page_count": 8,
+        "text_span_hash": "span-sha",
+        "citation_label": "원본 PDF pp.2-4",
+    }
 
 
 # --- format_metadata_claim_value: budget 한국 통화 포맷 ---


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`의 canonical PDF citation metadata passthrough 계약을 테스트로 고정했습니다. PDF 기반 citation에서 `citation_pdf_sha256`, page count, `text_span_hash`, `section_path`, `citation_label`이 함께 보존되는지 확인합니다.

Closes #2546

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer formatting helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 `make_citation` 출력 계약만 테스트로 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, dirty worktree no-touch 목록과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 14 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 4 untracked no-touch, `/Users/hskim/issueF_recovery/wt` untracked data files only, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `make_citation` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
