### PR TITLE
test(answer): pin render citation id filtering

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -51,6 +51,24 @@ def test_render_claim_with_citation_ids() -> None:
     assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1, c2]"
 
 
+def test_render_claim_filters_blank_citation_ids() -> None:
+    answer = {
+        "summary": "요약",
+        "claims": [
+            {
+                "target": "행안부",
+                "claim": "예산 1조",
+                "citations": [
+                    {"chunk_id": ""},
+                    {"doc_id": "missing-chunk"},
+                    {"chunk_id": "c1"},
+                ],
+            }
+        ],
+    }
+    assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1]"
+
+
 def test_render_claim_without_citation_omits_suffix() -> None:
     # citation 이 비면 ' [..]' suffix 를 붙이지 않는다
     out = render_answer_text({"summary": "S", "claims": [{"target": "A", "claim": "C", "citations": []}]})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 claim citation suffix를 만들 때 빈 문자열 또는 누락된 `chunk_id`를 제외하고 실제 chunk id만 렌더링하는 계약을 테스트로 고정했습니다.

Closes #2548

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — answer render helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 렌더링 필터링 동작만 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, dirty worktree no-touch 목록과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` → 13 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 4 untracked no-touch, `/Users/hskim/issueF_recovery/wt` untracked data files only, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `render_answer_text` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
