### PR TITLE
test(answer): pin insufficiency context fallback

### DIFF
--- a/tests/test_answer_summary_insufficiency.py
+++ b/tests/test_answer_summary_insufficiency.py
@@ -109,6 +109,19 @@ def test_build_insufficiency_missing_targets_is_unsupported_entities() -> None:
     assert out["checked_entities"] == ["행안부", "교육부"]
 
 
+def test_build_insufficiency_uses_context_entities_and_matched_doc_ids() -> None:
+    out = build_insufficiency(
+        "q",
+        {"context_entities": ["이전기관"], "matched_doc_ids": ["doc-1", "doc-2"]},
+        [],
+        True,
+        [],
+    )
+    assert out["missing_targets"] == ["이전기관"]
+    assert out["checked_entities"] == ["이전기관"]
+    assert out["checked_doc_ids"] == ["doc-1", "doc-2"]
+
+
 def test_build_insufficiency_not_verified_no_missing_falls_back_to_all_checked() -> None:
     # not verified 인데 missing_targets 가 비고 checked_entities 가 있으면 전체를 missing 으로
     out = build_insufficiency("q", {"entities": ["행안부"]}, [{"target": "행안부"}], False, [])


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`build_insufficiency`가 `entities`가 없을 때 `context_entities`를 checked/missing target으로 사용하고, `matched_doc_ids`를 `checked_doc_ids`로 보존하는 계약을 테스트로 고정했습니다.

Closes #2550

## 2. 영향 파일

- `tests/test_answer_summary_insufficiency.py` — answer insufficiency helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 insufficiency payload fallback 동작만 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, dirty worktree no-touch 목록과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_summary_insufficiency.py` → 13 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 4 untracked no-touch, `/Users/hskim/issueF_recovery/wt` untracked data files only, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `build_insufficiency` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
