### PR TITLE
test(answer): pin query type abstention priority

### DIFF
--- a/tests/test_answer_status_type_classification.py
+++ b/tests/test_answer_status_type_classification.py
@@ -96,6 +96,10 @@ def test_answer_query_type_insufficient_status_wins() -> None:
         answer_query_type({"query_type": "comparison"}, ANSWER_STATUS_INSUFFICIENT)
         == "abstention"
     )
+    assert (
+        answer_query_type({"query_type": "follow_up"}, ANSWER_STATUS_INSUFFICIENT)
+        == "abstention"
+    )
 
 
 def test_answer_query_type_maps_known_types() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`answer_query_type`에서 `ANSWER_STATUS_INSUFFICIENT`가 analysis의 `query_type`보다 우선해 `abstention`으로 분류되는 계약을 follow-up 케이스까지 테스트로 고정했습니다.

Closes #2552

## 2. 영향 파일

- `tests/test_answer_status_type_classification.py` — answer query type helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 status-priority 동작만 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, dirty worktree no-touch 목록과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_status_type_classification.py` → 11 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 4 untracked no-touch, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `answer_query_type` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
