### PR TITLE
test(answer): pin status reason prefix matching

### DIFF
--- a/tests/test_answer_status_type_classification.py
+++ b/tests/test_answer_status_type_classification.py
@@ -50,6 +50,12 @@ def test_answer_status_insufficient_when_missing_requested_entity() -> None:
     assert out == ANSWER_STATUS_INSUFFICIENT
 
 
+def test_answer_status_missing_requested_reason_requires_prefix() -> None:
+    # reason 내부에 문자열이 들어있어도 prefix 가 아니면 supported 를 막지 않는다.
+    out = answer_status({}, _CLAIMS, True, ["not_missing_requested_entity:행안부"])
+    assert out == ANSWER_STATUS_SUPPORTED
+
+
 # --- answer_status: comparison partial 경로 ---
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`answer_status`가 `missing_requested_entity` reason을 prefix로만 해석하는 계약을 테스트로 고정했습니다. 문자열 내부에 해당 토큰이 들어있어도 prefix가 아니면 supported 상태를 막지 않습니다.

Closes #2554

## 2. 영향 파일

- `tests/test_answer_status_type_classification.py` — answer status helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 reason-prefix matching 동작만 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, dirty worktree no-touch 목록과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_status_type_classification.py` → 12 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 4 untracked no-touch, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `answer_status` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
