### PR TITLE
test(answer): pin multiple missing entity reasons

### DIFF
--- a/tests/test_answer_summary_insufficiency.py
+++ b/tests/test_answer_summary_insufficiency.py
@@ -54,6 +54,18 @@ def test_verification_reasons_comparison_appends_missing() -> None:
     assert out == ["r1", "missing_requested_entity:행안부"]
 
 
+def test_verification_reasons_comparison_appends_multiple_missing_in_order() -> None:
+    out = answer_verification_reasons(
+        {"query_type": "comparison", "missing_requested_entities": ["행안부", "교육부"]},
+        ["r1"],
+    )
+    assert out == [
+        "r1",
+        "missing_requested_entity:행안부",
+        "missing_requested_entity:교육부",
+    ]
+
+
 def test_verification_reasons_comparison_dedupes() -> None:
     # 이미 같은 reason 이 있으면 중복 추가하지 않는다
     out = answer_verification_reasons(


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`answer_verification_reasons`가 comparison의 `missing_requested_entities` 여러 개를 입력 순서대로 `missing_requested_entity:*` reason으로 append하는 계약을 테스트로 고정했습니다.

Closes #2556

## 2. 영향 파일

- `tests/test_answer_summary_insufficiency.py` — answer verification reason helper test-only coverage

## 3. 리스크

- 리스크 낮음: source 동작 변경 없이 기존 ordered append 동작만 고정합니다.
- overlap 리스크: 시작 전 open PR은 dependabot의 `requirements.txt`/`.github/workflows/*`뿐이고, root dirty/no-touch 및 새 parser candidate untracked 파일과 이 파일은 겹치지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_summary_insufficiency.py` → 14 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: root dirty 24 tracked + 7 untracked no-touch, open PR overlap 없음

## 5. Eval 영향

RAG source/eval/load-bearing 경로 변경 없음. Test-only coverage 추가라 public/private eval metric 변화 예상 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer dict schema/version 변경 없음.

## 7. 범위 외

- `answer_verification_reasons` source behavior 변경
- 전체 test suite 실행
- real100_v2 private eval 실행
