### PR TITLE
test(answer): pin duplicate missing entity reason dedupe

### DIFF
--- a/tests/test_answer_summary_insufficiency.py
+++ b/tests/test_answer_summary_insufficiency.py
@@ -75,6 +75,14 @@ def test_verification_reasons_comparison_dedupes() -> None:
     assert out == ["missing_requested_entity:행안부"]
 
 
+def test_verification_reasons_comparison_dedupes_duplicate_missing_entities() -> None:
+    out = answer_verification_reasons(
+        {"query_type": "comparison", "missing_requested_entities": ["행안부", "행안부"]},
+        [],
+    )
+    assert out == ["missing_requested_entity:행안부"]
+
+
 # --- answer_summary ---
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`answer_verification_reasons`가 comparison 분석에서 `missing_requested_entities` 중복 입력을 받아도 `missing_requested_entity:*` reason을 중복 emit하지 않는 기존 계약을 test-only로 고정합니다.

Closes #2558

## 2. 영향 파일

- `tests/test_answer_summary_insufficiency.py` — answer insufficiency/reason unit coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 기존 dedupe 동작이 약화되어 중복 reason이 노출되는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_summary_insufficiency.py` — 15 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_summary_insufficiency.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `answer_verification_reasons` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
