### PR TITLE
test(answer): pin partial topic reason precedence

### DIFF
--- a/tests/test_answer_status_reason_enum.py
+++ b/tests/test_answer_status_reason_enum.py
@@ -77,6 +77,19 @@ class TestAnswerStatusReasonEnum(unittest.TestCase):
         )
         self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
 
+    def test_partial_topic_grounding_reason_takes_precedence(self) -> None:
+        result = answer_status_reason(
+            status=ANSWER_STATUS_PARTIAL,
+            verified=True,
+            verification_reasons=[
+                "missing_requested_entity:행안부",
+                PARTIAL_TOPIC_GROUNDING_REASON,
+            ],
+        )
+        self.assertEqual(
+            result["code"], ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING
+        )
+
     def test_partial_without_topic_grounding_yields_comparison_code(self) -> None:
         # The "other" partial path: comparison-coverage gaps, no
         # PARTIAL_TOPIC_GROUNDING_REASON in the reason list.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`answer_status_reason`의 partial 상태에서 `PARTIAL_TOPIC_GROUNDING_REASON`이 comparison missing-entity reason과 함께 있어도 topic-grounding code가 우선되는 기존 의미를 test-only로 고정합니다.

Closes #2560

## 2. 영향 파일

- `tests/test_answer_status_reason_enum.py` — status_reason enum/우선순위 단위 coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 partial reason 우선순위가 약화되어 topic-grounding partial이 comparison partial로 잘못 분류되는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_status_reason_enum.py` — 12 passed, 10 subtests passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_status_reason_enum.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `answer_status_reason` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
