### PR TITLE
test(answer): pin empty canonical citation metadata omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -117,6 +117,31 @@ def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     }
 
 
+def test_make_citation_omits_empty_canonical_pdf_metadata() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": [1, 1],
+        "metadata": {
+            "text_source": "pdf_pymupdf4llm",
+            "citation_basis": "",
+            "converted_pdf_sha256": "",
+            "converted_pdf_page_count": None,
+            "citation_pdf_sha256": "citation-sha",
+            "citation_pdf_page_count": "",
+        },
+    })
+
+    assert citation["text_source"] == "pdf_pymupdf4llm"
+    assert citation["citation_pdf_sha256"] == "citation-sha"
+    assert citation["citation_label"] == "PDF p.1"
+    assert "citation_basis" not in citation
+    assert "converted_pdf_sha256" not in citation
+    assert "converted_pdf_page_count" not in citation
+    assert "citation_pdf_page_count" not in citation
+
+
 # --- format_metadata_claim_value: budget 한국 통화 포맷 ---
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 canonical PDF citation metadata에서 빈 문자열/None optional field를 blank value로 내보내지 않고 생략하는 기존 계약을 test-only로 고정합니다.

Closes #2562

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — canonical citation metadata format helper coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 optional citation metadata가 빈 값으로 노출되어 downstream citation 소비자가 blank field를 실제 값으로 오인하는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` — 15 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_format_helpers.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `make_citation` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
