### PR TITLE
test(answer): pin duplicate comparison entity claim dedupe

### DIFF
--- a/tests/test_answer_claim_builders.py
+++ b/tests/test_answer_claim_builders.py
@@ -126,6 +126,13 @@ def test_build_comparison_claims_dedupes_shared_chunk() -> None:
     assert claims[0]["target"] == "행안부"
 
 
+def test_build_comparison_claims_dedupes_duplicate_entities() -> None:
+    ev = [_item("행안부", "c1")]
+    analysis = {"entities": ["행안부", "행안부"], "topics": [], "tokens": []}
+    claims = build_comparison_claims(analysis, ev)
+    assert [c["target"] for c in claims] == ["행안부"]
+
+
 def test_build_comparison_claims_skips_entity_without_evidence() -> None:
     # evidence 가 없는 entity 는 건너뛴다(빈 claim 생성 안 함)
     ev = [_item("행안부", "c1")]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`build_comparison_claims`가 duplicate comparison entity 입력에서 동일 evidence chunk를 두 번 claim으로 emit하지 않는 기존 dedupe 계약을 test-only로 고정합니다.

Closes #2564

## 2. 영향 파일

- `tests/test_answer_claim_builders.py` — comparison claim builder dedupe coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 중복 entity가 같은 chunk를 반복 claim으로 만들어 answer claim list를 부풀리는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_claim_builders.py` — 12 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_claim_builders.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `build_comparison_claims` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
