### PR TITLE
test(answer): pin zero metadata claim rendering

### DIFF
--- a/tests/test_answer_sentence_metadata_claims.py
+++ b/tests/test_answer_sentence_metadata_claims.py
@@ -86,6 +86,11 @@ def test_metadata_claims_requested_field_rendered() -> None:
     assert out == ["사업예산: 1,000,000원"]
 
 
+def test_metadata_claims_zero_value_is_rendered() -> None:
+    out = metadata_claim_sentences({"metadata": {"budget": 0}}, {"topics": ["예산"]})
+    assert out == ["사업예산: 0원"]
+
+
 def test_metadata_claims_unrequested_field_filtered_out() -> None:
     # 같은 값이라도 topic 이 매칭 안 되면 metadata_field_requested 필터로 제외 → []
     out = metadata_claim_sentences({"metadata": {"budget": 1000000}}, {"topics": ["일정"]})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`metadata_claim_sentences`가 numeric zero metadata value를 빈 값으로 오인하지 않고 명시적인 claim value로 렌더링하는 기존 계약을 test-only로 고정합니다.

Closes #2566

## 2. 영향 파일

- `tests/test_answer_sentence_metadata_claims.py` — metadata claim value guard coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 `0` 예산/수치가 빈 metadata처럼 drop되어 답변 claim에서 사라지는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_sentence_metadata_claims.py` — 13 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_sentence_metadata_claims.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `metadata_claim_sentences` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
