### PR TITLE
test(answer): pin null citation rendering

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -76,6 +76,12 @@ def test_render_claim_without_citation_omits_suffix() -> None:
     assert "[" not in out
 
 
+def test_render_claim_with_null_citations_omits_suffix() -> None:
+    out = render_answer_text({"summary": "S", "claims": [{"target": "A", "claim": "C", "citations": None}]})
+    assert out == "S\n- A: C"
+    assert "[" not in out
+
+
 def test_render_insufficiency_block() -> None:
     out = render_answer_text(
         {"summary": "S", "insufficiency": {"reasons": ["r1", "r2"], "missing_targets": ["교육부"]}}


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 claim의 `citations: None`을 citation 부재와 동일하게 처리하고 citation suffix를 붙이지 않는 기존 렌더링 계약을 test-only로 고정합니다.

Closes #2568

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — rendered answer citation suffix coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 `citations: None` 입력에서 불필요한 빈 suffix가 붙거나 렌더링이 깨지는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` — 14 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_render_topic_match.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 동작을 잠그는 test-only 변경입니다. Answer schema/CLI/doc 계약 변경 없음.

## 7. 범위 외

- `render_answer_text` production 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
