### PR TITLE
test(answer): pin contract snapshot observability exclusion

### DIFF
--- a/tests/test_answer_contract_snapshot.py
+++ b/tests/test_answer_contract_snapshot.py
@@ -116,6 +116,43 @@ class AnswerContractShapeTest(unittest.TestCase):
         cls.observed = _build_contract_shape()
         cls.golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
 
+    def test_contract_subset_excludes_additive_observability_fields(self) -> None:
+        subset = _extract_contract_subset({
+            "answer": {
+                "schema_version": 2,
+                "status": "supported",
+                "status_reason": {"code": "verified"},
+                "query_type": "single_doc",
+                "claims": [],
+                "summary": "요약",
+                "insufficiency": None,
+                "analysis": {"debug": "answer-local"},
+            },
+            "evidence": [],
+            "answer_text": "요약",
+            "analysis": {"debug": "top-level"},
+            "plan": {"steps": []},
+            "diagnostics": {"latency_ms": 1},
+            "trace": ["event"],
+            "conversation_state": {"turn": 1},
+            "mode": "agentic_full",
+        })
+
+        self.assertEqual(
+            set(subset),
+            {"answer", "evidence", "answer_text"},
+        )
+        self.assertNotIn("analysis", subset["answer"])
+        for observability_key in (
+            "analysis",
+            "plan",
+            "diagnostics",
+            "trace",
+            "conversation_state",
+            "mode",
+        ):
+            self.assertNotIn(observability_key, subset)
+
     def test_schema_version_is_pinned_to_two(self) -> None:
         # The literal value is not in the shape signature (shape only
         # captures the type "int"), so we re-read the answer dict


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0003 answer contract snapshot helper가 `analysis`/`plan`/`diagnostics`/`trace`/`conversation_state`/`mode` 같은 additive observability 필드를 contract subset에서 제외하는 경계를 test-only로 고정합니다.

Closes #2570

## 2. 영향 파일

- `tests/test_answer_contract_snapshot.py` — contract subset extraction boundary coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음.
- 깨짐 가능 경로는 observability 필드가 ADR 0003 contract snapshot에 섞여 불필요한 schema bump/golden drift를 유발하는 경우이며, 신규 targeted test로 배제했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_contract_snapshot.py` — 3 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: open PR은 dependabot only, dirty worktree 파일과 변경 파일(`tests/test_answer_contract_snapshot.py`) 겹침 없음

## 5. Eval 영향

RAG production/load-bearing 파일 변경 없음. Test-only 변경이라 eval delta 없음.

## 6. 하위 호환

기존 snapshot helper 경계를 잠그는 test-only 변경입니다. Answer schema/golden/CLI/doc 계약 변경 없음.

## 7. 범위 외

- answer contract golden regeneration 없음.
- production contract extraction/answer generation 구현 변경 없음.
- full suite/private eval 미실행: 단위 test-only PR이며 load-bearing production 변경이 없습니다.
