### PR TITLE
test(answer): pin contract shape scalar classification

### DIFF
--- a/tests/test_answer_contract_snapshot.py
+++ b/tests/test_answer_contract_snapshot.py
@@ -116,6 +116,26 @@ class AnswerContractShapeTest(unittest.TestCase):
         cls.observed = _build_contract_shape()
         cls.golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
 
+    def test_shape_classifies_json_scalars_deterministically(self) -> None:
+        self.assertEqual(
+            _shape(
+                {
+                    "none": None,
+                    "truthy": True,
+                    "integer": 7,
+                    "decimal": 1.5,
+                    "text": "요약",
+                }
+            ),
+            {
+                "none": "null",
+                "truthy": "bool",
+                "integer": "int",
+                "decimal": "float",
+                "text": "str",
+            },
+        )
+
     def test_contract_subset_excludes_additive_observability_fields(self) -> None:
         subset = _extract_contract_subset({
             "answer": {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0003 answer contract snapshot helper가 JSON-like scalar를 결정적으로 분류한다는 전제를 작은 회귀 테스트로 고정합니다. 특히 Python에서 `bool`이 `int`의 subclass라서 순서가 바뀌면 shape signature가 조용히 `int`로 오염될 수 있는 경계를 명시합니다.

Closes #2572

## 2. 영향 파일

- `tests/test_answer_contract_snapshot.py` — contract snapshot helper scalar classification test 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 test-only assertion 추가입니다.
- 배제 근거: focused contract snapshot test 전체가 통과했고, branch/issue convention 및 diff whitespace check를 통과했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_contract_snapshot.py` → `4 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight: `DRIFT_OVERLAP_OK` (`tests/test_answer_contract_snapshot.py`; main drift/open PR/dirty worktree overlap 없음)

## 5. Eval 영향

RAG production path와 eval surface 변경 없음. Test-only 변경이라 public fixture/private real100_v2 eval 영향 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer contract 자체를 바꾸지 않고, snapshot helper의 기존 scalar classification 전제만 테스트로 고정합니다.

## 7. 범위 외

- golden snapshot 재생성 없음
- production answer schema/version 변경 없음
- full suite 실행은 CI에 위임
