### PR TITLE
test(answer): pin contract shape container classification

### DIFF
--- a/tests/test_answer_contract_snapshot.py
+++ b/tests/test_answer_contract_snapshot.py
@@ -136,6 +136,26 @@ class AnswerContractShapeTest(unittest.TestCase):
             },
         )
 
+    def test_shape_classifies_containers_recursively(self) -> None:
+        self.assertEqual(
+            _shape(
+                {
+                    "empty_items": [],
+                    "items": [{"status": "supported", "score": 1}],
+                    "metadata": {
+                        "flags": [True],
+                    },
+                }
+            ),
+            {
+                "empty_items": [],
+                "items": [{"status": "str", "score": "int"}],
+                "metadata": {
+                    "flags": ["bool"],
+                },
+            },
+        )
+
     def test_contract_subset_excludes_additive_observability_fields(self) -> None:
         subset = _extract_contract_subset({
             "answer": {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0003 answer contract snapshot helper가 container 값을 재귀적으로 구조화한다는 전제를 작은 회귀 테스트로 고정합니다. 빈 list는 그대로 비어 있어야 하고, non-empty list는 첫 원소의 shape를 대표값으로 삼으며, nested dict/list도 재귀적으로 축약되어야 합니다.

Closes #2574

## 2. 영향 파일

- `tests/test_answer_contract_snapshot.py` — contract snapshot helper container classification test 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 test-only assertion 추가입니다.
- 배제 근거: focused contract snapshot test 전체가 통과했고, branch/issue convention 및 diff whitespace check를 통과했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_contract_snapshot.py` → `5 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight: `DRIFT_OVERLAP_OK` (`tests/test_answer_contract_snapshot.py`; main drift/open PR/dirty worktree overlap 없음)

## 5. Eval 영향

RAG production path와 eval surface 변경 없음. Test-only 변경이라 public fixture/private real100_v2 eval 영향 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer contract 자체를 바꾸지 않고, snapshot helper의 기존 container classification 전제만 테스트로 고정합니다.

## 7. 범위 외

- golden snapshot 재생성 없음
- production answer schema/version 변경 없음
- full suite 실행은 CI에 위임
