### PR TITLE
test(answer): pin contract subset empty-result defaults

### DIFF
--- a/tests/test_answer_contract_snapshot.py
+++ b/tests/test_answer_contract_snapshot.py
@@ -179,6 +179,26 @@ class AnswerContractShapeTest(unittest.TestCase):
             },
         )
 
+    def test_contract_subset_keeps_keys_when_result_empty(self) -> None:
+        subset = _extract_contract_subset({})
+
+        self.assertEqual(
+            subset,
+            {
+                "answer": {
+                    "schema_version": None,
+                    "status": None,
+                    "status_reason": None,
+                    "query_type": None,
+                    "claims": None,
+                    "summary": None,
+                    "insufficiency": None,
+                },
+                "evidence": None,
+                "answer_text": None,
+            },
+        )
+
     def test_contract_subset_excludes_additive_observability_fields(self) -> None:
         subset = _extract_contract_subset({
             "answer": {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0003 answer contract snapshot helper가 완전히 빈 결과 입력에서도 안정적인 contract subset shape를 반환한다는 전제를 작은 회귀 테스트로 고정합니다. `answer` 내부 필드와 top-level `evidence`/`answer_text` 키가 모두 존재하되 값은 `None`이어야 합니다.

Closes #2578

## 2. 영향 파일

- `tests/test_answer_contract_snapshot.py` — empty-result contract subset default-shape test 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 test-only assertion 추가입니다.
- 배제 근거: focused contract snapshot test 전체가 통과했고, branch/issue convention 및 diff whitespace check를 통과했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_contract_snapshot.py` → `7 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight: `DRIFT_OVERLAP_OK` (`tests/test_answer_contract_snapshot.py`; main drift/open PR/dirty worktree overlap 없음)

## 5. Eval 영향

RAG production path와 eval surface 변경 없음. Test-only 변경이라 public fixture/private real100_v2 eval 영향 없음.

## 6. 하위 호환

하위 호환 영향 없음. ADR 0003 answer contract 자체를 바꾸지 않고, snapshot helper의 empty-result 기본 subset shape만 테스트로 고정합니다.

## 7. 범위 외

- golden snapshot 재생성 없음
- production answer schema/version 변경 없음
- full suite 실행은 CI에 위임
