### PR TITLE
test(answer): pin citation helper non-dict metadata fallback

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -142,6 +142,26 @@ def test_make_citation_omits_empty_canonical_pdf_metadata() -> None:
     assert "citation_pdf_page_count" not in citation
 
 
+def test_make_citation_treats_non_dict_metadata_as_empty() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": [4, 4],
+        "metadata": ["not", "a", "dict"],
+        "text_span_hash": "span-sha",
+    })
+
+    assert citation == {
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "section": "",
+        "agency": "",
+        "page_span": [4, 4],
+    }
+
+
 # --- format_metadata_claim_value: budget 한국 통화 포맷 ---
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 `metadata`가 dict가 아닐 때 이를 빈 metadata처럼 취급한다는 순수 helper 계약을 작은 회귀 테스트로 고정합니다. 핵심 citation/page 필드는 보존하되 canonical PDF metadata/label/text_span_hash는 metadata가 유효할 때만 붙어야 합니다.

Closes #2580

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — non-dict metadata fallback test 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 test-only assertion 추가입니다.
- 배제 근거: focused format helper test 전체가 통과했고, branch/issue convention 및 diff whitespace check를 통과했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → `16 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py`; main drift/open PR/dirty worktree overlap 없음)

## 5. Eval 영향

RAG production path와 eval surface 변경 없음. Test-only 변경이라 public fixture/private real100_v2 eval 영향 없음.

## 6. 하위 호환

하위 호환 영향 없음. `make_citation` 구현/answer contract를 바꾸지 않고, 기존 fallback 동작만 테스트로 고정합니다.

## 7. 범위 외

- production answer formatting 변경 없음
- full suite 실행은 CI에 위임
