### PR TITLE
test(answer): pin canonical citation span hash coercion

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -117,6 +117,23 @@ def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     }
 
 
+def test_make_citation_coerces_canonical_pdf_text_span_hash_to_str() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": [3, 3],
+        "text_span_hash": 12345,
+        "metadata": {
+            "text_source": "pdf_pymupdf4llm",
+            "citation_basis": "source_pdf",
+        },
+    })
+
+    assert citation["text_span_hash"] == "12345"
+    assert citation["citation_label"] == "원본 PDF p.3"
+
+
 def test_make_citation_omits_empty_section_path_for_canonical_pdf() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`의 canonical PDF citation 경로에서 `text_span_hash`가 비문자 입력이어도 answer citation 계약상 문자열로 노출되는 기존 동작을 pure helper regression test로 고정합니다.

Closes #2586

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer pure format helper 테스트 1건 추가

## 3. 리스크

- 리스크 낮음: production 코드 변경 없이 기존 helper 동작을 pin하는 test-only 변경입니다.
- 깨짐 경로: `text_span_hash` coercion이 바뀌면 citation contract helper 테스트가 실패합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 19 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py` only; no main drift/open PR/dirty worktree overlap)

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only pure helper contract pin이라 eval aggregate 영향 없음. Private real-eval 미실행(불필요).

## 6. 하위 호환

하위 호환 영향 없음. Answer schema/version 변경 없음; 기존 동작을 테스트로 고정합니다.

## 7. 범위 외

`make_citation` 구현 변경, citation schema 변경, full suite/private eval은 범위 외입니다.
