### PR TITLE
test(answer): pin citation-basis-only canonical citation path

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -134,6 +134,22 @@ def test_make_citation_coerces_canonical_pdf_text_span_hash_to_str() -> None:
     assert citation["citation_label"] == "원본 PDF p.3"
 
 
+def test_make_citation_treats_citation_basis_as_canonical_pdf_path() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "section_path": ["root", "attachments"],
+        "page_span": [6, 8],
+        "metadata": {"citation_basis": "libreoffice_converted_pdf"},
+    })
+
+    assert citation["section_path"] == ["root", "attachments"]
+    assert citation["citation_basis"] == "libreoffice_converted_pdf"
+    assert citation["citation_label"] == "LibreOffice 변환 PDF pp.6-8"
+    assert "text_source" not in citation
+
+
 def test_make_citation_omits_empty_section_path_for_canonical_pdf() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 `text_source` 없이도 non-empty `citation_basis`만으로 canonical PDF citation 경로를 사용한다는 기존 계약을 pure helper regression test로 고정합니다.

Closes #2588

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer pure format helper 테스트 1건 추가

## 3. 리스크

- 리스크 낮음: production 코드 변경 없이 기존 helper 동작을 pin하는 test-only 변경입니다.
- 깨짐 경로: `citation_basis` 단독 canonical path, `section_path`, `citation_label` 동작이 바뀌면 테스트가 실패합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 20 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py` only; no main drift/open PR/dirty worktree overlap)

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only pure helper contract pin이라 eval aggregate 영향 없음. Private real-eval 미실행(불필요).

## 6. 하위 호환

하위 호환 영향 없음. Answer schema/version 변경 없음; 기존 동작을 테스트로 고정합니다.

## 7. 범위 외

`make_citation` 구현 변경, citation schema 변경, full suite/private eval은 범위 외입니다.
