### PR TITLE
test(answer): pin negative budget formatting

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -241,6 +241,10 @@ def test_format_budget_int_thousands_separator() -> None:
     assert format_metadata_claim_value("budget", 0) == "0원"
 
 
+def test_format_budget_negative_int_keeps_sign_and_separator() -> None:
+    assert format_metadata_claim_value("budget", -1000000) == "-1,000,000원"
+
+
 def test_format_budget_integer_float_drops_decimals() -> None:
     """정수값 float(예: 1000.0)은 int 로 변환되어 소수점 없이 표시."""
     assert format_metadata_claim_value("budget", 1000.0) == "1,000원"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`format_metadata_claim_value("budget", ...)`가 음수 예산도 부호와 천 단위 구분자, 원화 suffix를 유지해 렌더링한다는 기존 pure helper 계약을 regression test로 고정합니다.

Closes #2590

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer pure format helper 테스트 1건 추가

## 3. 리스크

- 리스크 낮음: production 코드 변경 없이 기존 helper 동작을 pin하는 test-only 변경입니다.
- 깨짐 경로: 음수 budget 포맷이 바뀌면 테스트가 실패합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 21 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py` only; no main drift/open PR/dirty worktree overlap)

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only pure helper contract pin이라 eval aggregate 영향 없음. Private real-eval 미실행(불필요).

## 6. 하위 호환

하위 호환 영향 없음. Answer schema/version 변경 없음; 기존 동작을 테스트로 고정합니다.

## 7. 범위 외

`format_metadata_claim_value` 구현 변경, answer schema 변경, full suite/private eval은 범위 외입니다.
