### PR TITLE
test(answer): pin negative decimal budget formatting

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -255,6 +255,10 @@ def test_format_budget_decimal_float_keeps_two_decimals() -> None:
     assert format_metadata_claim_value("budget", 1234.56) == "1,234.56원"
 
 
+def test_format_budget_negative_decimal_float_keeps_two_decimals() -> None:
+    assert format_metadata_claim_value("budget", -1234.5) == "-1,234.50원"
+
+
 def test_format_budget_non_numeric_passthrough() -> None:
     """budget 이라도 비-숫자값은 str() passthrough (예: '비공개')."""
     assert format_metadata_claim_value("budget", "비공개") == "비공개"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`format_metadata_claim_value("budget", ...)`가 음수 소수 예산도 부호, 천 단위 구분자, 소수점 2자리, 원화 suffix를 유지해 렌더링한다는 기존 pure helper 계약을 regression test로 고정합니다.

Closes #2592

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer pure format helper 테스트 1건 추가

## 3. 리스크

- 리스크 낮음: production 코드 변경 없이 기존 helper 동작을 pin하는 test-only 변경입니다.
- 깨짐 경로: 음수 decimal budget 포맷이 바뀌면 테스트가 실패합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 22 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py` only; no main drift/open PR/dirty worktree overlap)

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only pure helper contract pin이라 eval aggregate 영향 없음. Private real-eval 미실행(불필요).

## 6. 하위 호환

하위 호환 영향 없음. Answer schema/version 변경 없음; 기존 동작을 테스트로 고정합니다.

## 7. 범위 외

`format_metadata_claim_value` 구현 변경, answer schema 변경, full suite/private eval은 범위 외입니다.
