### PR TITLE
test(answer): pin claim target falsy numeric fallback

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -48,6 +48,10 @@ def test_claim_target_skips_falsy_fields_in_chain() -> None:
     assert claim_target({"agency": None, "title": None, "doc_id": "d"}) == "d"
 
 
+def test_claim_target_skips_falsy_numeric_fields_in_chain() -> None:
+    assert claim_target({"agency": 0, "title": "사업명"}) == "사업명"
+
+
 def test_claim_target_coerces_to_str() -> None:
     assert claim_target({"agency": 123}) == "123"
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`claim_target`이 falsy numeric `agency` 값을 최종 target으로 쓰지 않고 다음 identifier(`title`)로 fallback하는 기존 pure helper 계약을 regression test로 고정합니다.

Closes #2596

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — answer pure format helper 테스트 1건 추가

## 3. 리스크

- 리스크 낮음: production 코드 변경 없이 기존 helper 동작을 pin하는 test-only 변경입니다.
- 깨짐 경로: `claim_target` fallback chain의 falsy numeric 처리 방식이 바뀌면 테스트가 실패합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` → 24 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK` (`tests/test_answer_format_helpers.py` only; no main drift/open PR/dirty worktree overlap)

## 5. Eval 영향

RAG production/load-bearing path 변경 없음. Test-only pure helper contract pin이라 eval aggregate 영향 없음. Private real-eval 미실행(불필요).

## 6. 하위 호환

하위 호환 영향 없음. Answer schema/version 변경 없음; 기존 동작을 테스트로 고정합니다.

## 7. 범위 외

`claim_target` 구현 변경, answer schema 변경, full suite/private eval은 범위 외입니다.
