### PR TITLE
test(answer): pin render insufficiency single-detail branches

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -89,6 +89,18 @@ def test_render_insufficiency_block() -> None:
     assert out == "S\n- 근거 부족: 사유: r1, r2; 확인 필요 대상: 교육부"
 
 
+def test_render_insufficiency_reasons_only() -> None:
+    out = render_answer_text({"summary": "S", "insufficiency": {"reasons": ["r1"]}})
+
+    assert out == "S\n- 근거 부족: 사유: r1"
+
+
+def test_render_insufficiency_missing_targets_only() -> None:
+    out = render_answer_text({"summary": "S", "insufficiency": {"missing_targets": ["교육부"]}})
+
+    assert out == "S\n- 근거 부족: 확인 필요 대상: 교육부"
+
+
 def test_render_insufficiency_empty_details_omitted() -> None:
     # insufficiency 가 있어도 reasons/missing_targets 가 모두 비면 '근거 부족' 줄 생략
     out = render_answer_text({"summary": "S", "insufficiency": {"reasons": [], "missing_targets": []}})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_answer.render_answer_text`의 `insufficiency` 렌더링에서 reasons-only / missing-targets-only 단독 detail 분기를 직접 고정하는 test-only 회귀 커버리지를 추가했습니다. 기존 combined/empty 케이스만으로는 한쪽 detail만 있을 때 separator/label 출력이 흔들려도 `rag_answer` 단위 테스트에서 바로 드러나지 않습니다.

Closes #2598

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — `render_answer_text` 단독 insufficiency detail 분기 테스트 2개 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음, pure helper 단위 테스트만 추가했습니다.
- 깨짐 가능성: 현재 의도된 한국어 label/separator 계약이 바뀐 경우 테스트가 실패합니다. 이는 의도된 regression signal입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` → `16 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
  - branch file: `tests/test_answer_render_topic_match.py`
  - main drift overlap: none
  - open PR overlap: none
  - dirty worktree overlap: none

## 5. Eval 영향

RAG runtime/load-bearing path 변경 없음(test-only). Public/private eval metric 영향 없음. real-eval 미실행 사유: production behavior unchanged.

## 6. 하위 호환

하위 호환 영향 없음. Answer dict schema/CLI/API 변경 없음.

## 7. 범위 외

- `rag_synthesis._render_with_synthesis`는 이미 유사 단독 분기 테스트가 있어 변경하지 않았습니다.
- production rendering behavior 변경 없음.
