### PR TITLE
test(answer): pin metadata field value matching

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -137,6 +137,11 @@ def test_metadata_field_requested_matches_label() -> None:
     assert metadata_field_requested("budget", 1000, {"topics": ["예산"]}) is True
 
 
+def test_metadata_field_requested_matches_compacted_value() -> None:
+    # value 쪽 공백도 compact 되어 topic '행정안전부' 와 매칭된다.
+    assert metadata_field_requested("agency", "행정 안전부", {"topics": ["행정안전부"]}) is True
+
+
 def test_metadata_field_requested_no_match_is_false() -> None:
     # topic '예산' 이 agency label/value 에 없으면 False
     assert metadata_field_requested("agency", "행안부", {"topics": ["예산"]}) is False


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_answer.metadata_field_requested`가 metadata label뿐 아니라 compacted metadata value 쪽도 `verification_topics`와 매칭하는 계약을 test-only로 고정했습니다. 공백이 들어간 기관명 값(`행정 안전부`)이 compact topic(`행정안전부`)과 매칭되는 실제 RFP metadata 흐름을 작은 단위 테스트로 보호합니다.

Closes #2600

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — `metadata_field_requested` compacted value matching 테스트 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음, pure helper 단위 테스트만 추가했습니다.
- 깨짐 가능성: metadata value compact matching 계약이 바뀌면 이 테스트가 실패합니다. 이는 의도된 regression signal입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` → `17 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
  - branch file: `tests/test_answer_render_topic_match.py`
  - main drift overlap: none
  - open PR overlap: none
  - dirty worktree overlap: none

## 5. Eval 영향

RAG runtime/load-bearing path 변경 없음(test-only). Public/private eval metric 영향 없음. real-eval 미실행 사유: production behavior unchanged.

## 6. 하위 호환

하위 호환 영향 없음. Answer dict schema/CLI/API 변경 없음.

## 7. 범위 외

- production matching behavior 변경 없음.
- broader metadata extraction/retrieval paths는 건드리지 않았습니다.
