### PR TITLE
test(answer): pin metadata label alias compaction

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -137,6 +137,11 @@ def test_metadata_field_requested_matches_label() -> None:
     assert metadata_field_requested("budget", 1000, {"topics": ["예산"]}) is True
 
 
+def test_metadata_field_requested_matches_compacted_label_alias() -> None:
+    # label alias '사업금액' 은 topic '사업 금액' 과 compact 매칭된다.
+    assert metadata_field_requested("budget", 1000, {"topics": ["사업 금액"]}) is True
+
+
 def test_metadata_field_requested_matches_compacted_value() -> None:
     # value 쪽 공백도 compact 되어 topic '행정안전부' 와 매칭된다.
     assert metadata_field_requested("agency", "행정 안전부", {"topics": ["행정안전부"]}) is True


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_answer.metadata_field_requested`가 multi-word metadata label alias를 compact해서 topic과 매칭하는 계약을 test-only로 고정했습니다. 예산의 alias `사업금액`이 사용자 topic `사업 금액`과 동일하게 취급되는 regression signal입니다.

Closes #2604

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — `metadata_field_requested` compacted label alias matching 테스트 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음, pure helper 단위 테스트만 추가했습니다.
- 깨짐 가능성: label alias/compaction 계약이 바뀌면 이 테스트가 실패합니다. 이는 의도된 regression signal입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` → `19 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
  - branch file: `tests/test_answer_render_topic_match.py`
  - main drift overlap: none
  - open PR overlap: none
  - dirty worktree overlap: none
- Note: new checkout creation failed due local disk at ~132Mi free, so this branch used an existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

RAG runtime/load-bearing path 변경 없음(test-only). Public/private eval metric 영향 없음. real-eval 미실행 사유: production behavior unchanged.

## 6. 하위 호환

하위 호환 영향 없음. Answer dict schema/CLI/API 변경 없음.

## 7. 범위 외

- production matching behavior 변경 없음.
- local stale worktree cleanup/prune는 지시상 수행하지 않았습니다.
