### PR TITLE
test(answer): pin metadata numeric value matching

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -142,6 +142,11 @@ def test_metadata_field_requested_matches_compacted_label_alias() -> None:
     assert metadata_field_requested("budget", 1000, {"topics": ["사업 금액"]}) is True
 
 
+def test_metadata_field_requested_matches_numeric_value() -> None:
+    # numeric metadata value 도 str(value) 기반 검색 대상으로 포함된다.
+    assert metadata_field_requested("budget", 1000, {"topics": ["1000"]}) is True
+
+
 def test_metadata_field_requested_matches_compacted_value() -> None:
     # value 쪽 공백도 compact 되어 topic '행정안전부' 와 매칭된다.
     assert metadata_field_requested("agency", "행정 안전부", {"topics": ["행정안전부"]}) is True


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`rag_answer.metadata_field_requested`가 numeric metadata value도 `str(value)` 기반 검색 대상으로 포함하는 계약을 test-only로 고정했습니다. 예산값 `1000`이 topic `1000`과 매칭되는 작은 regression signal입니다.

Closes #2606

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — `metadata_field_requested` numeric value matching 테스트 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없음, pure helper 단위 테스트만 추가했습니다.
- 깨짐 가능성: numeric value matching 계약이 바뀌면 이 테스트가 실패합니다. 이는 의도된 regression signal입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` → `20 passed`
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
  - branch file: `tests/test_answer_render_topic_match.py`
  - main drift overlap: none
  - open PR overlap: none
  - dirty worktree overlap: none
- Note: local disk is ~157Mi free, so this branch used an existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

RAG runtime/load-bearing path 변경 없음(test-only). Public/private eval metric 영향 없음. real-eval 미실행 사유: production behavior unchanged.

## 6. 하위 호환

하위 호환 영향 없음. Answer dict schema/CLI/API 변경 없음.

## 7. 범위 외

- production matching behavior 변경 없음.
- local stale worktree cleanup/prune는 지시상 수행하지 않았습니다.
