### PR TITLE
test(answer): pin metadata multi-topic fallback matching

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -152,6 +152,11 @@ def test_metadata_field_requested_matches_raw_key_when_no_label_map() -> None:
     assert metadata_field_requested("custom_field", "값", {"topics": ["custom field"]}) is True
 
 
+def test_metadata_field_requested_matches_later_topic_after_non_match() -> None:
+    # 여러 topic 중 앞 topic 이 빗나가도 뒤 topic 이 label/value 에 맞으면 True 다.
+    assert metadata_field_requested("agency", "행정안전부", {"topics": ["예산", "행정 안전부"]}) is True
+
+
 def test_metadata_field_requested_matches_compacted_value() -> None:
     # value 쪽 공백도 compact 되어 topic '행정안전부' 와 매칭된다.
     assert metadata_field_requested("agency", "행정 안전부", {"topics": ["행정안전부"]}) is True


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`metadata_field_requested`가 verification topic 목록을 순서대로 검사할 때, 앞 topic이 빗나가도 뒤 topic이 metadata label/value에 맞으면 True를 반환해야 하는 any-topic fallback 동작을 test-only로 고정했습니다.

Closes #2610

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — metadata field topic matching helper 단위 테스트 1건 추가

## 3. 리스크

- 리스크: helper의 topic 순회가 첫 non-match에서 조기 종료되는 회귀를 놓칠 수 있음.
- 배제 근거: 앞 topic `예산`은 `agency=행정안전부`에 맞지 않고, 뒤 topic `행정 안전부`만 compact matching되는 케이스를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` — 22 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `metadata_field_requested` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
