### PR TITLE
test(answer): pin sentence topic case-insensitive matching

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -120,6 +120,11 @@ def test_sentence_topic_matches() -> None:
     assert sentence_has_verification_topic("예산 집행 내용", {"topics": ["예산"]}) is True
 
 
+def test_sentence_topic_matches_case_insensitively() -> None:
+    # sentence/topic 모두 lower 처리되어 영문 topic 대소문자 차이는 매칭을 막지 않는다.
+    assert sentence_has_verification_topic("Budget execution detail", {"topics": ["budget"]}) is True
+
+
 def test_sentence_topic_no_match_is_false() -> None:
     assert sentence_has_verification_topic("계약 내용", {"topics": ["예산"]}) is False
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`sentence_has_verification_topic`이 sentence와 topic을 모두 lowercase 처리해 영문 대소문자 차이를 매칭 실패로 보지 않는 동작을 test-only로 고정했습니다.

Closes #2612

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — sentence topic matching helper 단위 테스트 1건 추가

## 3. 리스크

- 리스크: 영문 verification topic 대소문자 차이 때문에 근거 문장이 과도하게 필터링되는 회귀.
- 배제 근거: `Budget execution detail` 문장과 `budget` topic의 case-insensitive 매칭을 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` — 23 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `sentence_has_verification_topic` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
