### PR TITLE
test(answer): pin render summary whitespace trimming

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -31,6 +31,11 @@ def test_render_summary_only() -> None:
     assert render_answer_text({"summary": "요약문"}) == "요약문"
 
 
+def test_render_summary_strips_outer_whitespace() -> None:
+    # summary 는 strip 된 뒤 빈 줄 필터를 거쳐 출력된다.
+    assert render_answer_text({"summary": "  요약문 \n"}) == "요약문"
+
+
 def test_render_empty_summary_omits_blank_line() -> None:
     # summary 가 비면 빈 line 으로 필터되어 선행 빈 줄이 생기지 않는다
     # (빈 line 제외 필터가 없으면 '\n- A: C [c1]' 로 새어 KILL)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 summary의 바깥 공백을 제거한 뒤 빈 줄 필터를 거쳐 출력하는 formatting 동작을 test-only로 고정했습니다.

Closes #2614

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — render summary formatting 단위 테스트 1건 추가

## 3. 리스크

- 리스크: summary 앞뒤 공백/개행이 그대로 사용자 출력에 남는 formatting 회귀.
- 배제 근거: whitespace가 포함된 summary 입력이 `요약문`으로 렌더링되는 케이스를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` — 24 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `render_answer_text` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
