### PR TITLE
test(answer): pin render multiple claim lines

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -56,6 +56,18 @@ def test_render_claim_with_citation_ids() -> None:
     assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1, c2]"
 
 
+def test_render_multiple_claims_preserves_ordered_lines() -> None:
+    answer = {
+        "summary": "요약",
+        "claims": [
+            {"target": "행안부", "claim": "예산 1조", "citations": []},
+            {"target": "교육부", "claim": "마감 6월", "citations": []},
+        ],
+    }
+
+    assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조\n- 교육부: 마감 6월"
+
+
 def test_render_claim_filters_blank_citation_ids() -> None:
     answer = {
         "summary": "요약",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 summary 뒤에 claim을 입력 순서대로 한 줄씩 렌더링하는 formatting 동작을 test-only로 고정했습니다.

Closes #2616

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — render multiple claims formatting 단위 테스트 1건 추가

## 3. 리스크

- 리스크: 여러 claim이 있을 때 순서가 바뀌거나 줄바꿈 없이 합쳐지는 rendering 회귀.
- 배제 근거: 두 claim이 입력 순서대로 각각 별도 `- target: claim` 줄로 렌더링되는 케이스를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_render_topic_match.py` — 25 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `render_answer_text` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
