### PR TITLE
test(answer): pin best sentence topic case-insensitive hit

### DIFF
--- a/tests/test_answer_sentence_metadata_claims.py
+++ b/tests/test_answer_sentence_metadata_claims.py
@@ -40,6 +40,12 @@ def test_best_sentence_topic_weight_is_strictly_three() -> None:
     assert out == "예산 관련 항목 상세 검토."
 
 
+def test_best_sentence_topic_hit_is_case_insensitive() -> None:
+    # case-sensitive 로 회귀하면 두 문장 score=0 동점이 되어 더 짧은 fallback 문장이 이긴다.
+    out = best_sentence("Budget detail with additional context. x.", ["budget"], [])
+    assert out == "Budget detail with additional context."
+
+
 def test_best_sentence_token_only_selection() -> None:
     # topic 없이 query token 매칭만으로 선택
     assert best_sentence("계약 내용. 예산 집행.", [], ["예산"]) == "예산 집행."


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`best_sentence`가 sentence를 lowercase 처리한 뒤 topic hit를 계산해 영문 대소문자 차이에도 topic score를 반영하는 동작을 test-only로 고정했습니다.

Closes #2618

## 2. 영향 파일

- `tests/test_answer_sentence_metadata_claims.py` — best_sentence topic scoring 단위 테스트 1건 추가

## 3. 리스크

- 리스크: 영문 topic 대소문자 차이로 topic hit가 누락되어 대표 문장 선택이 바뀌는 scoring 회귀.
- 배제 근거: `Budget detail.` 문장이 `budget` topic hit로 선택되는 케이스를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_sentence_metadata_claims.py` — 14 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `best_sentence` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
