### PR TITLE
test(answer): pin best sentence multiple topic hits scoring

### DIFF
--- a/tests/test_answer_sentence_metadata_claims.py
+++ b/tests/test_answer_sentence_metadata_claims.py
@@ -46,6 +46,16 @@ def test_best_sentence_topic_hit_is_case_insensitive() -> None:
     assert out == "Budget detail with additional context."
 
 
+def test_best_sentence_counts_multiple_topic_hits() -> None:
+    # topic hit 2개(2×3=6)가 token hit 5개를 이겨야 한다. topic 을 1개로 cap 하면 token 문장이 이김.
+    out = best_sentence(
+        "Budget schedule detail with additional context. contract review analysis evaluation item.",
+        ["budget", "schedule"],
+        ["contract", "review", "analysis", "evaluation", "item"],
+    )
+    assert out == "Budget schedule detail with additional context."
+
+
 def test_best_sentence_token_only_selection() -> None:
     # topic 없이 query token 매칭만으로 선택
     assert best_sentence("계약 내용. 예산 집행.", [], ["예산"]) == "예산 집행."


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`best_sentence`가 한 문장 안의 여러 matching topic을 모두 세고 `topic_hits * 3` scoring에 반영하는 동작을 test-only로 고정했습니다.

Closes #2620

## 2. 영향 파일

- `tests/test_answer_sentence_metadata_claims.py` — best_sentence multiple topic hit scoring 단위 테스트 1건 추가

## 3. 리스크

- 리스크: topic hit를 1개로 cap하거나 하나만 세는 회귀가 생기면 대표 문장 선택이 token-heavy 문장으로 바뀔 수 있음.
- 배제 근거: topic hit 2개(score 6)가 token hit 5개(score 5)를 이기는 fixture를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_sentence_metadata_claims.py` — 15 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- local disk space too low for a fresh checkout; reused existing clean separate `.codex` worktree without deleting/pruning stale worktrees.

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `best_sentence` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
