### PR TITLE
test(answer): pin negative integer float budget formatting

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -252,6 +252,7 @@ def test_format_budget_negative_int_keeps_sign_and_separator() -> None:
 def test_format_budget_integer_float_drops_decimals() -> None:
     """정수값 float(예: 1000.0)은 int 로 변환되어 소수점 없이 표시."""
     assert format_metadata_claim_value("budget", 1000.0) == "1,000원"
+    assert format_metadata_claim_value("budget", -1000.0) == "-1,000원"
 
 
 def test_format_budget_decimal_float_keeps_two_decimals() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`format_metadata_claim_value`가 budget의 integer-valued float를 정수 통화 문자열로 렌더링하는 동작 중 negative integer-float 경계를 test-only로 고정했습니다.

Closes #2622

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — budget formatting 단위 테스트 1건 추가

## 3. 리스크

- 리스크: `-1000.0` 같은 음수 정수값 float가 `-1,000.00원`처럼 소수점 포함 형식으로 회귀할 수 있음.
- 배제 근거: `format_metadata_claim_value("budget", -1000.0) == "-1,000원"`을 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` — 24 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- created fresh separate worktree: `.codex/worktrees/issue-2622-budget-negative-integer-float`

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `format_metadata_claim_value` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
