### PR TITLE
test(answer): pin non-list section path omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -173,6 +173,20 @@ def test_make_citation_omits_empty_section_path_for_canonical_pdf() -> None:
     assert "section_path" not in citation
 
 
+def test_make_citation_omits_non_list_section_path_for_canonical_pdf() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "section_path": ("root", "attachments"),
+        "page_span": [2, 2],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["citation_basis"] == "source_pdf"
+    assert "section_path" not in citation
+
+
 def test_make_citation_omits_empty_canonical_pdf_metadata() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 canonical PDF citation에서도 `section_path`를 non-empty list일 때만 보존하고 tuple 같은 non-list 값은 citation 계약에 노출하지 않는 동작을 test-only로 고정했습니다.

Closes #2624

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — canonical PDF citation `section_path` type guard 테스트 1건 추가

## 3. 리스크

- 리스크: non-list `section_path`가 그대로 citation dict에 들어가 downstream 계약이 흔들릴 수 있음.
- 배제 근거: tuple `section_path` + `citation_basis=source_pdf` 입력에서 `section_path`가 생략되는 케이스를 직접 검증했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_answer_format_helpers.py` — 25 passed
- `git diff --check`
- `make check-branch`
- overlap-preflight before PR: `DRIFT_OVERLAP_OK`
- created fresh separate worktree: `.codex/worktrees/issue-2624-nonlist-section-path`

## 5. Eval 영향

All `N/A` — test-only 변경이며 load-bearing runtime/eval path 수정 없음. real-eval 미실행(동작 코드 변경 없음).

## 6. 하위 호환

N/A — answer dict 계약/스키마/CLI flag/doc link 변경 없음.

## 7. 범위 외

- `make_citation` production implementation 변경 없음.
- stale/orphan worktree 정리 없음(다른 세션과 겹칠 수 있어 금지 규칙 준수).
