### PR TITLE
test(answer): pin falsy text span hash omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -138,6 +138,20 @@ def test_make_citation_coerces_canonical_pdf_text_span_hash_to_str() -> None:
     assert citation["citation_label"] == "원본 PDF p.3"
 
 
+def test_make_citation_omits_falsy_text_span_hash_for_canonical_pdf() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": [3, 3],
+        "text_span_hash": 0,
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["citation_label"] == "원본 PDF p.3"
+    assert "text_span_hash" not in citation
+
+
 def test_make_citation_treats_citation_basis_as_canonical_pdf_path() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`의 canonical PDF citation에서 falsy `text_span_hash` 값이 생겼을 때 기존 truthy-only omission 동작을 회귀 테스트로 고정했습니다.

Closes #2627

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — `make_citation` helper의 falsy `text_span_hash` omission regression 추가

## 3. 리스크

- 리스크: 테스트 기대값이 실제 계약과 다르면 citation metadata 동작을 잘못 고정할 수 있음.
- 배제 근거: 구현은 `if span_hash:` 조건으로 truthy 값만 passthrough하므로, 이번 테스트는 현재 동작을 그대로 핀하는 test-only 변경입니다.

## 4. 테스트

- `pytest -q tests/test_answer_format_helpers.py` — 26 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_format_helpers.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `make_citation` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
