### PR TITLE
test(answer): pin citation page span from regions

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -246,6 +246,26 @@ def test_make_citation_treats_non_dict_metadata_as_empty() -> None:
     }
 
 
+def test_make_citation_derives_page_span_from_regions_for_canonical_pdf() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "regions": [
+            {"page_number": 7, "bbox": [0.1, 0.2, 0.3, 0.4], "source": "ocr"},
+            {"page_number": 5, "type": "table", "block_id": 9},
+        ],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["regions"] == [
+        {"page_number": 7, "bbox": [0.1, 0.2, 0.3, 0.4], "source": "ocr"},
+        {"page_number": 5, "bbox": None, "type": "table", "block_id": "9"},
+    ]
+    assert citation["page_span"] == [5, 7]
+    assert citation["citation_label"] == "원본 PDF pp.5-7"
+
+
 def test_make_citation_omits_section_path_for_noncanonical_pdf() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 explicit `page_span` 없이 `regions`의 page numbers에서 citation `page_span`과 label을 만들고, region metadata를 정규화해 보존하는 경로를 regression test로 고정했습니다.

Closes #2629

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — `make_citation`의 regions-derived `page_span`/`citation_label` helper regression 추가

## 3. 리스크

- 리스크: region 정규화 기대값이 실제 helper 계약과 어긋나면 잘못된 테스트를 고정할 수 있음.
- 배제 근거: 최초 실행에서 실제 `bbox: None` 보존 계약을 확인했고, 그 현재 동작에 맞춘 test-only 변경으로 재검증했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_format_helpers.py` — 27 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_format_helpers.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `make_citation` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
