### PR TITLE
test(answer): pin metadata claim ordering

### DIFF
--- a/tests/test_answer_sentence_metadata_claims.py
+++ b/tests/test_answer_sentence_metadata_claims.py
@@ -107,6 +107,26 @@ def test_metadata_claims_zero_value_is_rendered() -> None:
     assert out == ["사업예산: 0원"]
 
 
+def test_metadata_claims_multiple_fields_follow_contract_order() -> None:
+    out = metadata_claim_sentences(
+        {
+            "metadata": {
+                "summary": "전자입찰",
+                "bid_deadline_at": "2026-06-10",
+                "budget": 1000000,
+                "ignored_field": "무시",
+            }
+        },
+        {"topics": ["사업요약", "마감일", "예산"]},
+    )
+
+    assert out == [
+        "사업예산: 1,000,000원",
+        "입찰 마감일: 2026-06-10",
+        "사업 요약: 전자입찰",
+    ]
+
+
 def test_metadata_claims_unrequested_field_filtered_out() -> None:
     # 같은 값이라도 topic 이 매칭 안 되면 metadata_field_requested 필터로 제외 → []
     out = metadata_claim_sentences({"metadata": {"budget": 1000000}}, {"topics": ["일정"]})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`metadata_claim_sentences`가 여러 requested metadata field를 동시에 렌더링할 때 `METADATA_CLAIM_LABELS` 계약 순서를 따르고, label-map에 없는 metadata key는 렌더링하지 않는 경로를 regression test로 고정했습니다.

Closes #2631

## 2. 영향 파일

- `tests/test_answer_sentence_metadata_claims.py` — multi-field metadata claim ordering regression 추가

## 3. 리스크

- 리스크: topic 필터 기대값이 실제 `verification_topics` 계약과 어긋나면 잘못된 테스트를 고정할 수 있음.
- 배제 근거: 최초 실행에서 짧은 `요약` topic 제외 동작을 확인했고, 기존 topic 필터 계약에 맞춰 `사업요약` topic으로 재검증했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_sentence_metadata_claims.py` — 16 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_sentence_metadata_claims.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `metadata_claim_sentences` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
