### PR TITLE
test(answer): pin string page span citation normalization

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -168,6 +168,19 @@ def test_make_citation_treats_citation_basis_as_canonical_pdf_path() -> None:
     assert "text_source" not in citation
 
 
+def test_make_citation_normalizes_string_page_span_for_canonical_pdf() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": ["2", "4"],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["page_span"] == [2, 4]
+    assert citation["citation_label"] == "원본 PDF pp.2-4"
+
+
 def test_make_citation_omits_empty_section_path_for_canonical_pdf() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 explicit string `page_span` 값을 integer page span으로 정규화하고 canonical PDF citation label에 반영하는 경로를 regression test로 고정했습니다.

Closes #2633

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — string `page_span` normalization + citation label regression 추가

## 3. 리스크

- 리스크: 테스트가 현재 구현의 정규화 경로와 어긋나면 citation helper 계약을 잘못 고정할 수 있음.
- 배제 근거: `make_citation`은 `normalize_page_span`을 통해 string page numbers를 int로 변환하며, targeted helper test로 현재 동작을 검증했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_format_helpers.py` — 28 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_format_helpers.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `make_citation` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
