### PR TITLE
test(answer): pin summary metadata topic matching

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -164,6 +164,10 @@ def test_metadata_field_requested_matches_compacted_label_alias() -> None:
     assert metadata_field_requested("budget", 1000, {"topics": ["사업 금액"]}) is True
 
 
+def test_metadata_field_requested_matches_summary_alias() -> None:
+    assert metadata_field_requested("summary", "전자입찰", {"topics": ["사업요약"]}) is True
+
+
 def test_metadata_field_requested_matches_numeric_value() -> None:
     # numeric metadata value 도 str(value) 기반 검색 대상으로 포함된다.
     assert metadata_field_requested("budget", 1000, {"topics": ["1000"]}) is True
@@ -182,6 +186,10 @@ def test_metadata_field_requested_matches_later_topic_after_non_match() -> None:
 def test_metadata_field_requested_matches_compacted_value() -> None:
     # value 쪽 공백도 compact 되어 topic '행정안전부' 와 매칭된다.
     assert metadata_field_requested("agency", "행정 안전부", {"topics": ["행정안전부"]}) is True
+
+
+def test_metadata_field_requested_matches_compacted_summary_value() -> None:
+    assert metadata_field_requested("summary", "전자 입찰", {"topics": ["전자입찰"]}) is True
 
 
 def test_metadata_field_requested_matches_compacted_topic() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`metadata_field_requested`가 summary metadata의 `사업요약` alias와 compacted value(`전자 입찰` ↔ `전자입찰`)를 요청 topic으로 인식하는 경로를 regression test로 고정했습니다.

Closes #2635

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — summary metadata alias/value topic matching regression 추가

## 3. 리스크

- 리스크: 테스트가 `verification_topics`/metadata alias 계약과 어긋나면 topic helper behavior를 잘못 고정할 수 있음.
- 배제 근거: 기존 helper tests와 같은 직접 단위 import 방식으로, 현재 `metadata_field_requested`의 label+value compact matching 경로만 test-only로 검증했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py` — 27 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_render_topic_match.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `metadata_field_requested` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
