### PR TITLE
test(answer): pin citation region fallback for invalid page span

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -279,6 +279,23 @@ def test_make_citation_derives_page_span_from_regions_for_canonical_pdf() -> Non
     assert citation["citation_label"] == "원본 PDF pp.5-7"
 
 
+def test_make_citation_uses_regions_when_explicit_page_span_is_invalid() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "title": "공고문",
+        "page_span": ["bad", "span"],
+        "regions": [
+            {"page_number": 9, "bbox": [0.1, 0.2, 0.3, 0.4]},
+            {"page_number": 8, "bbox": [0.5, 0.6, 0.7, 0.8]},
+        ],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["page_span"] == [8, 9]
+    assert citation["citation_label"] == "원본 PDF pp.8-9"
+
+
 def test_make_citation_omits_section_path_for_noncanonical_pdf() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`이 invalid explicit `page_span`을 받았을 때 `regions`의 page numbers로 fallback해서 canonical PDF `page_span`/label을 렌더링하는 경로를 regression test로 고정했습니다.

Closes #2637

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — invalid `page_span` → regions fallback citation regression 추가

## 3. 리스크

- 리스크: 테스트가 `normalize_page_span` fallback 계약과 어긋나면 citation helper behavior를 잘못 고정할 수 있음.
- 배제 근거: 기존 helper tests와 같은 직접 단위 import 방식으로, 현재 fallback behavior만 test-only로 검증했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_format_helpers.py` — 29 passed
- `git diff --check`
- `make check-branch`
- overlap preflight: branch files = `tests/test_answer_format_helpers.py`; `origin/main` drift 없음; open PR overlap 없음; dirty worktree overlap 없음; `OVERLAP_PREFLIGHT_OK`

## 5. Eval 영향

RAG/load-bearing production path 변경 없음. Test-only 변경이므로 public/private eval aggregate 영향 없음; real-eval 미실행.

## 6. 하위 호환

기존 answer dict/schema/CLI 계약 변경 없음. `schema_version` 변경 불필요.

## 7. 범위 외

- `make_citation`/`normalize_page_span` production logic 변경은 의도적으로 하지 않았습니다.
- 전체 test suite는 test-only helper regression 범위라 실행하지 않았습니다.
