### PR TITLE
test(answer): pin falsy rendered citation ids

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -86,6 +86,24 @@ def test_render_claim_filters_blank_citation_ids() -> None:
     assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1]"
 
 
+def test_render_claim_filters_falsy_citation_ids() -> None:
+    answer = {
+        "summary": "요약",
+        "claims": [
+            {
+                "target": "행안부",
+                "claim": "예산 1조",
+                "citations": [
+                    {"chunk_id": 0},
+                    {"chunk_id": None},
+                    {"chunk_id": "c1"},
+                ],
+            }
+        ],
+    }
+    assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1]"
+
+
 def test_render_claim_without_citation_omits_suffix() -> None:
     # citation 이 비면 ' [..]' suffix 를 붙이지 않는다
     out = render_answer_text({"summary": "S", "claims": [{"target": "A", "claim": "C", "citations": []}]})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 citation suffix를 만들 때 falsy `chunk_id` 값(`0`, `None`)을 제외하고 유효한 id만 렌더링하는 현재 계약을 단위 테스트로 고정합니다.

Closes #2639

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — render helper test-only coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 기존 렌더링 동작을 test-only로 고정합니다.
- 겹침 리스크: `OVERLAP_PREFLIGHT_OK` 확인 — 열린 PR/dirty worktree와 변경 파일 충돌 없음.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py` → 28 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK` (`tests/test_answer_render_topic_match.py` 단일 변경, open PR/dirty worktree overlap 없음)

## 5. Eval 영향

All `N/A` — test-only 변경이며 RAG pipeline/load-bearing runtime 동작 변경 없음. real-eval 미실행(동작 변경 없음).

## 6. 하위 호환

N/A — answer schema/CLI/API 계약 변경 없음.

## 7. 범위 외

- truthy non-string `chunk_id` 렌더링 정책 변경은 범위 외입니다.
- `render_answer_text` production 구현 변경은 범위 외입니다.
