### PR TITLE
test(answer): pin null claims rendering

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -31,6 +31,10 @@ def test_render_summary_only() -> None:
     assert render_answer_text({"summary": "요약문"}) == "요약문"
 
 
+def test_render_null_claims_keeps_summary_only() -> None:
+    assert render_answer_text({"summary": "요약문", "claims": None}) == "요약문"
+
+
 def test_render_summary_strips_outer_whitespace() -> None:
     # summary 는 strip 된 뒤 빈 줄 필터를 거쳐 출력된다.
     assert render_answer_text({"summary": "  요약문 \n"}) == "요약문"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 `claims=None`을 빈 claims와 동일하게 취급해 summary만 렌더링하는 현재 경계 동작을 단위 테스트로 고정합니다.

Closes #2641

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — render helper test-only coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 기존 렌더링 동작을 test-only로 고정합니다.
- 겹침 리스크: `OVERLAP_PREFLIGHT_OK` 확인 — 열린 PR/dirty worktree와 변경 파일 충돌 없음.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py` → 29 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK` (`tests/test_answer_render_topic_match.py` 단일 변경, open PR/dirty worktree overlap 없음)

## 5. Eval 영향

All `N/A` — test-only 변경이며 RAG pipeline/load-bearing runtime 동작 변경 없음. real-eval 미실행(동작 변경 없음).

## 6. 하위 호환

N/A — answer schema/CLI/API 계약 변경 없음.

## 7. 범위 외

- `render_answer_text` production 구현 변경은 범위 외입니다.
- non-list truthy `claims` 입력 방어 정책 변경은 범위 외입니다.
