### PR TITLE
test(answer): pin numeric summary rendering

### DIFF
--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -35,6 +35,10 @@ def test_render_null_summary_is_empty_string() -> None:
     assert render_answer_text({"summary": None}) == ""
 
 
+def test_render_numeric_summary_as_string() -> None:
+    assert render_answer_text({"summary": 2026}) == "2026"
+
+
 def test_render_summary_only() -> None:
     assert render_answer_text({"summary": "요약문"}) == "요약문"
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 numeric `summary` 값을 문자열로 변환해 렌더링하는 현재 경계 동작을 단위 테스트로 고정합니다.

Closes #2651

## 2. 영향 파일

- `tests/test_answer_render_topic_match.py` — render helper test-only coverage 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 기존 렌더링 동작을 test-only로 고정합니다.
- 겹침 리스크: `OVERLAP_PREFLIGHT_OK` 확인 — 열린 PR/dirty worktree와 변경 파일 충돌 없음.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py` → 34 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK` (`tests/test_answer_render_topic_match.py` 단일 변경, open PR/dirty worktree overlap 없음)

## 5. Eval 영향

All `N/A` — test-only 변경이며 RAG pipeline/load-bearing runtime 동작 변경 없음. real-eval 미실행(동작 변경 없음).

## 6. 하위 호환

N/A — answer schema/CLI/API 계약 변경 없음.

## 7. 범위 외

- `render_answer_text` production 구현 변경은 범위 외입니다.
- numeric `summary` 입력을 금지하거나 별도 schema validation으로 다루는 정책 변경은 범위 외입니다.
