### PR TITLE
test(answer): preserve zero summary rendering

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -465,7 +465,8 @@ def build_insufficiency(
 
 
 def render_answer_text(answer: dict[str, Any]) -> str:
-    lines = [str(answer.get("summary") or "").strip()]
+    summary = answer.get("summary")
+    lines = ["" if summary is None else str(summary).strip()]
     for claim in answer.get("claims") or []:
         citations = claim.get("citations") or []
         citation_ids = ", ".join(citation.get("chunk_id", "") for citation in citations if citation.get("chunk_id"))

--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -39,6 +39,10 @@ def test_render_numeric_summary_as_string() -> None:
     assert render_answer_text({"summary": 2026}) == "2026"
 
 
+def test_render_zero_summary_as_string() -> None:
+    assert render_answer_text({"summary": 0}) == "0"
+
+
 def test_render_summary_only() -> None:
     assert render_answer_text({"summary": "요약문"}) == "요약문"
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 numeric summary `2026`은 문자열로 렌더링하면서 falsy numeric summary `0`은 `or ""` fallback 때문에 누락하던 경계를 고정했습니다. `None`은 계속 빈 summary로 취급하되, non-None summary 값은 문자열화 후 trim 하도록 최소 수정했습니다.

Closes #2653

## 2. 영향 파일

- `rag_answer.py` — load-bearing: summary 렌더링 normalization 최소 수정
- `tests/test_answer_render_topic_match.py` — `summary=0` 회귀 테스트 추가

## 3. 리스크

- 리스크: `summary`가 `None`이 아닌 falsy 값일 때 기존 빈 문자열 처리와 달라질 수 있습니다.
- 배제 근거: 기존 numeric summary 문자열화 동작(`2026`)과 일관되게 `0`도 문자열화하도록 targeted test로 고정했고, `None`/빈 dict/whitespace-only summary 기존 테스트도 같은 파일에서 함께 통과했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py` → `35 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight:
  - branch files: `rag_answer.py`, `tests/test_answer_render_topic_match.py`
  - open PR overlap: OK
  - dirty Codex/Claude worktree overlap: OK

## 5. Eval 영향

Load-bearing `rag_answer.py` 변경입니다. 동작 변화는 answer text 렌더링에서 `summary=0`을 빈 문자열 대신 `"0"`으로 보존하는 좁은 normalization 수정에 한정됩니다. Retrieval/indexing/private-data path는 건드리지 않았고, real-eval은 미실행했습니다(사유: scalar summary 렌더링 단위 경계 수정이며 private eval aggregate 주장을 하지 않음).

## 6. 하위 호환

Answer dict schema/contract field는 변경하지 않았고 `schema_version` bump 불필요합니다. `summary=None`은 기존처럼 빈 summary로 유지됩니다.

## 7. 범위 외

- claim/citation/insufficiency 렌더링 변경 없음
- retrieval, verifier, eval pipeline 변경 없음
