### PR TITLE
test(answer): stringify numeric citation ids

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -346,9 +346,10 @@ def make_citation(item: dict[str, Any]) -> dict[str, Any]:
         metadata.get("text_source") == "pdf_pymupdf4llm"
         or bool(metadata.get("citation_basis"))
     )
+    chunk_id = item.get("chunk_id")
     citation = {
         "doc_id": item.get("doc_id", ""),
-        "chunk_id": item.get("chunk_id", ""),
+        "chunk_id": "" if chunk_id is None else str(chunk_id),
         "title": item.get("title", ""),
         "section": item.get("section", ""),
         "agency": item.get("agency", ""),
@@ -469,7 +470,7 @@ def render_answer_text(answer: dict[str, Any]) -> str:
     lines = ["" if summary is None else str(summary).strip()]
     for claim in answer.get("claims") or []:
         citations = claim.get("citations") or []
-        citation_ids = ", ".join(citation.get("chunk_id", "") for citation in citations if citation.get("chunk_id"))
+        citation_ids = ", ".join(str(citation.get("chunk_id", "")) for citation in citations if citation.get("chunk_id"))
         suffix = f" [{citation_ids}]" if citation_ids else ""
         lines.append(f"- {claim.get('target')}: {claim.get('claim')}{suffix}")
     insufficiency = answer.get("insufficiency")

--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -82,6 +82,12 @@ def test_citation_label_single_vs_range_page() -> None:
 # --- make_citation: canonical PDF metadata passthrough ---
 
 
+def test_make_citation_coerces_numeric_chunk_id_to_str() -> None:
+    citation = make_citation({"doc_id": "rfp-001", "chunk_id": 7})
+
+    assert citation["chunk_id"] == "7"
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",

--- a/tests/test_answer_render_topic_match.py
+++ b/tests/test_answer_render_topic_match.py
@@ -132,6 +132,20 @@ def test_render_claim_filters_falsy_citation_ids() -> None:
     assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [c1]"
 
 
+def test_render_claim_stringifies_numeric_citation_ids() -> None:
+    answer = {
+        "summary": "요약",
+        "claims": [
+            {
+                "target": "행안부",
+                "claim": "예산 1조",
+                "citations": [{"chunk_id": 7}, {"chunk_id": "c1"}],
+            }
+        ],
+    }
+    assert render_answer_text(answer) == "요약\n- 행안부: 예산 1조 [7, c1]"
+
+
 def test_render_claim_without_citation_omits_suffix() -> None:
     # citation 이 비면 ' [..]' suffix 를 붙이지 않는다
     out = render_answer_text({"summary": "S", "claims": [{"target": "A", "claim": "C", "citations": []}]})


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`render_answer_text`가 retained citation `chunk_id` 값을 `join()`에 직접 넘겨 truthy numeric ID에서 `TypeError`가 날 수 있던 경계를 고정했습니다. `make_citation` 경계에서도 numeric `chunk_id`를 문자열화해 structured answer citation과 rendered text가 같은 문자열 ID를 쓰도록 맞췄습니다.

Closes #2655

## 2. 영향 파일

- `rag_answer.py` — load-bearing: citation `chunk_id` 문자열 normalization 및 렌더링 방어
- `tests/test_answer_format_helpers.py` — `make_citation` numeric chunk_id normalization 회귀 테스트
- `tests/test_answer_render_topic_match.py` — rendered numeric citation ID 회귀 테스트

## 3. 리스크

- 리스크: citation ID normalization이 기존 raw falsy citation ID omission 동작과 충돌할 수 있습니다.
- 배제 근거: 기존 raw `chunk_id=0` omission 테스트는 유지했고, structured `make_citation`에서 numeric ID가 문자열화되는 새 경계만 추가 검증했습니다. pre-commit adversarial review의 blocker도 renderer-only normalization에서 construction-boundary normalization으로 해소했습니다.

## 4. 테스트

- `pytest -q tests/test_answer_render_topic_match.py tests/test_answer_format_helpers.py` → `66 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight:
  - branch files: `rag_answer.py`, `tests/test_answer_format_helpers.py`, `tests/test_answer_render_topic_match.py`
  - open PR overlap: OK
  - dirty Codex/Claude worktree overlap: OK
- load-bearing pre-commit adversarial review → passed after blocker fix

## 5. Eval 영향

Load-bearing `rag_answer.py` 변경입니다. 동작 변화는 citation `chunk_id` normalization/rendering 경계에 한정됩니다. Retrieval/indexing/private-data path는 건드리지 않았고, real-eval은 미실행했습니다(사유: answer citation formatting 단위 경계 수정이며 private eval aggregate 주장을 하지 않음).

## 6. 하위 호환

Answer dict schema/field는 변경하지 않았고 `schema_version` bump 불필요합니다. `chunk_id` 값의 표현은 citation contract에 맞게 문자열화되며, 기존 raw falsy rendered citation ID omission 테스트는 유지됩니다.

## 7. 범위 외

- citation object 전체 validation 추가 없음
- evidence/result boundary 전반의 ID normalization 변경 없음
- retrieval, verifier, eval pipeline 변경 없음
