### PR TITLE
test(answer): pin missing citation agency default

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -118,6 +118,12 @@ def test_make_citation_defaults_missing_section_to_empty() -> None:
     assert citation["section"] == ""
 
 
+def test_make_citation_defaults_missing_agency_to_empty() -> None:
+    citation = make_citation({"doc_id": "rfp-001", "chunk_id": "chunk-7"})
+
+    assert citation["agency"] == ""
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make_citation`에서 `agency` 필드가 없을 때 structured citation의 기본값이 empty string으로 유지되는 경계를 테스트로 고정했습니다. 소스 동작은 이미 의도와 맞아 test-only 변경입니다.

Closes #2667

## 2. 영향 파일

- `tests/test_answer_format_helpers.py` — missing `agency` 기본값 회귀 테스트 추가

## 3. 리스크

- 리스크: 테스트 전용 변경이라 런타임 동작 리스크는 낮습니다.
- 배제 근거: targeted helper 테스트 전체 통과, open PR 및 dirty Codex/Claude worktree와 대상 파일 overlap 없음.

## 4. 테스트

- `pytest -q tests/test_answer_format_helpers.py` → `36 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight:
  - branch files: `tests/test_answer_format_helpers.py`
  - open PR overlap: OK
  - dirty Codex/Claude worktree overlap: OK

## 5. Eval 영향

All `N/A` — test-only 변경이며 retrieval/indexing/answer runtime path를 변경하지 않았습니다. real-eval 미실행(사유: 런타임 동작 변경 없음, private eval aggregate 주장 없음).

## 6. 하위 호환

소스/스키마/CLI 변경 없음. Answer dict `schema_version` bump 불필요합니다.

## 7. 범위 외

- citation object validation 추가 없음
- retrieval, verifier, eval pipeline 변경 없음
