### PR TITLE
test(answer): pin missing citation page span omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -124,6 +124,17 @@ def test_make_citation_defaults_missing_agency_to_empty() -> None:
     assert citation["agency"] == ""
 
 
+def test_make_citation_omits_missing_page_span_and_label() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert "page_span" not in citation
+    assert "citation_label" not in citation
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `make_citation` when PDF citation metadata exists without a page span.
- Pin that optional page-derived fields (`page_span`, `citation_label`) remain omitted.

## 2. Issue
Closes #2669

## 3. Changes
- `tests/test_answer_format_helpers.py`: adds one regression test for missing page span / label omission.

## 4. Validation
- [x] `pytest -q tests/test_answer_format_helpers.py` (37 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.