### PR TITLE
test(answer): pin missing citation regions omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -135,6 +135,18 @@ def test_make_citation_omits_missing_page_span_and_label() -> None:
     assert "citation_label" not in citation
 
 
+def test_make_citation_omits_non_list_regions() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "regions": {"page_number": 3},
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert "regions" not in citation
+    assert "page_span" not in citation
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `make_citation` when `regions` is not a list.
- Pin that optional `regions` and derived `page_span` fields remain omitted.

## 2. Issue
Closes #2671

## 3. Changes
- `tests/test_answer_format_helpers.py`: adds one regression test for non-list regions omission.

## 4. Validation
- [x] `pytest -q tests/test_answer_format_helpers.py` (38 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.