### PR TITLE
test(answer): pin invalid citation region item omission

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -147,6 +147,18 @@ def test_make_citation_omits_non_list_regions() -> None:
     assert "page_span" not in citation
 
 
+def test_make_citation_omits_non_dict_region_items() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "regions": ["not-a-region", 7],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert "regions" not in citation
+    assert "page_span" not in citation
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `make_citation` when `regions` contains non-dict items.
- Pin that invalid non-dict entries do not create `regions` or derived `page_span`.

## 2. Issue
Closes #2673

## 3. Changes
- `tests/test_answer_format_helpers.py`: adds one regression test for non-dict region item omission.

## 4. Validation
- [x] `pytest -q tests/test_answer_format_helpers.py` (39 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Empty region dicts are intentionally out of scope here because current normalization preserves them as placeholder regions.
- Fixture smoke may skip because this PR changes only tests.