### PR TITLE
test(answer): pin empty citation region placeholders

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -159,6 +159,18 @@ def test_make_citation_omits_non_dict_region_items() -> None:
     assert "page_span" not in citation
 
 
+def test_make_citation_preserves_empty_region_dict_placeholder() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "regions": [{}],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["regions"] == [{"page_number": None, "bbox": None}]
+    assert "page_span" not in citation
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `make_citation` when `regions` contains an empty dict.
- Pin current placeholder behavior: empty region dicts normalize to `{page_number: None, bbox: None}` without deriving `page_span`.

## 2. Issue
Closes #2675

## 3. Changes
- `tests/test_answer_format_helpers.py`: adds one regression test for empty region placeholder preservation.

## 4. Validation
- [x] `pytest -q tests/test_answer_format_helpers.py` (40 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.