### PR TITLE
test(answer): pin string citation region page numbers

### DIFF
--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -171,6 +171,18 @@ def test_make_citation_preserves_empty_region_dict_placeholder() -> None:
     assert "page_span" not in citation
 
 
+def test_make_citation_ignores_string_region_page_number_for_span() -> None:
+    citation = make_citation({
+        "doc_id": "rfp-001",
+        "chunk_id": "chunk-7",
+        "regions": [{"page_number": "3", "bbox": [0.1, 0.2, 0.3, 0.4]}],
+        "metadata": {"citation_basis": "source_pdf"},
+    })
+
+    assert citation["regions"] == [{"bbox": [0.1, 0.2, 0.3, 0.4]}]
+    assert "page_span" not in citation
+
+
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `make_citation` when a region has string `page_number`.
- Pin current behavior: string page numbers are not preserved as `page_number` and do not derive `page_span`; valid bbox remains.

## 2. Issue
Closes #2677

## 3. Changes
- `tests/test_answer_format_helpers.py`: adds one regression test for string region page numbers.

## 4. Validation
- [x] `pytest -q tests/test_answer_format_helpers.py` (41 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.