### PR TITLE
test(metadata): pin string page span normalization

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -84,6 +84,10 @@ def test_normalize_page_span_uses_explicit_pair() -> None:
     assert normalize_page_span([5, 9], []) == [5, 9]
 
 
+def test_normalize_page_span_coerces_explicit_string_pair() -> None:
+    assert normalize_page_span(["5", "9"], []) == [5, 9]
+
+
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:
     regions = [{"page_number": 7}, {"page_number": 3}, {"page_number": 5}]
     assert normalize_page_span(None, regions) == [3, 7]


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `normalize_page_span` with explicit string pairs.
- Pin current behavior: numeric strings are coerced to integer page spans.

## 2. Issue
Closes #2679

## 3. Changes
- `tests/test_metadata_normalization.py`: adds one regression test for string page span normalization.

## 4. Validation
- [x] `pytest -q tests/test_metadata_normalization.py` (18 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.