### PR TITLE
test(metadata): pin invalid string page span fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -103,6 +103,10 @@ def test_normalize_page_span_ignores_wrong_length_pair() -> None:
     assert normalize_page_span([1, 2, 3], [{"page_number": 4}]) == [4, 4]
 
 
+def test_normalize_page_span_invalid_string_pair_falls_back_to_regions() -> None:
+    assert normalize_page_span(["bad", "span"], [{"page_number": 4}]) == [4, 4]
+
+
 # --- normalize_document_sections ---
 
 


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `normalize_page_span` when an explicit string pair is invalid.
- Pin current behavior: invalid explicit pairs fall back to valid region page numbers.

## 2. Issue
Closes #2681

## 3. Changes
- `tests/test_metadata_normalization.py`: adds one regression test for invalid string page span fallback.

## 4. Validation
- [x] `pytest -q tests/test_metadata_normalization.py` (19 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.