### PR TITLE
test(metadata): pin invalid page span without fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -107,6 +107,10 @@ def test_normalize_page_span_invalid_string_pair_falls_back_to_regions() -> None
     assert normalize_page_span(["bad", "span"], [{"page_number": 4}]) == [4, 4]
 
 
+def test_normalize_page_span_invalid_pair_without_region_pages_is_none() -> None:
+    assert normalize_page_span(["bad", "span"], [{"bbox": [1, 2, 3, 4]}]) is None
+
+
 # --- normalize_document_sections ---
 
 


### PR DESCRIPTION
## 1. Summary
- Add a focused unit test for `normalize_page_span` when an explicit page span is invalid and regions have no page numbers.
- Pin current behavior: no fallback pages means the normalized page span is `None`.

## 2. Issue
Closes #2683

## 3. Changes
- `tests/test_metadata_normalization.py`: adds one regression test for invalid page span without fallback pages.

## 4. Validation
- [x] `pytest -q tests/test_metadata_normalization.py` (20 passed)
- [x] `git diff --check`
- [x] `make check-branch`
- [x] overlap preflight vs open PRs, origin/main drift, and dirty worktrees

## 5. Eval impact
- Test-only change; no runtime retrieval/answer behavior changed.
- real100_v2 not run.

## 6. Risk / rollback
- Low risk: test-only contract pin.
- Rollback: remove the added test.

## 7. Notes
- Fixture smoke may skip because this PR changes only tests.