### PR TITLE
fix(metadata): normalize explicit page span order

### DIFF
--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -112,7 +112,8 @@ def normalize_regions(value: Any) -> list[dict[str, Any]]:
 def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
     if isinstance(value, list) and len(value) == 2:
         try:
-            return [int(value[0]), int(value[1])]
+            start, end = int(value[0]), int(value[1])
+            return [min(start, end), max(start, end)]
         except (TypeError, ValueError):
             pass
     page_numbers = [

--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -88,6 +88,10 @@ def test_normalize_page_span_coerces_explicit_string_pair() -> None:
     assert normalize_page_span(["5", "9"], []) == [5, 9]
 
 
+def test_normalize_page_span_sorts_explicit_pair() -> None:
+    assert normalize_page_span([9, 5], []) == [5, 9]
+
+
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:
     regions = [{"page_number": 7}, {"page_number": 3}, {"page_number": 5}]
     assert normalize_page_span(None, regions) == [3, 7]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_page_span([9, 5], [])`가 역순 endpoint를 그대로 반환해 citation label이 `pp.9-5`처럼 렌더링될 수 있던 정규화 누락을 고쳤습니다. explicit page span pair는 int coercion 후 `[min, max]` 순서로 정규화합니다.

Closes #2685

## 2. 영향 파일

- `rag_metadata_processing.py` — explicit two-value `page_span` endpoint order normalization
- `tests/test_metadata_normalization.py` — reversed explicit span regression coverage

## 3. 리스크

- 리스크: 이미 역순 `page_span`을 의도적으로 보존하던 호출자가 있다면 출력 순서가 달라집니다.
- 배제 근거: region fallback은 이미 min/max를 반환하므로 explicit pair도 같은 정규화 계약으로 맞췄고, adjacent answer formatting helper tests를 함께 확인했습니다.

## 4. 테스트

- 변경 전 실패 확인: `pytest -q tests/test_metadata_normalization.py -q` → `test_normalize_page_span_sorts_explicit_pair` fails (`[9, 5] != [5, 9]`)
- 변경 후 통과: `pytest -q tests/test_metadata_normalization.py tests/test_answer_format_helpers.py` → `62 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

RAG metadata normalization behavior change이지만 load-bearing checkpoint 목록(`rag_core`, retrieval/verifier/answer/query, ingestion, eval, api, ADR, build_index)은 직접 수정하지 않았습니다. real100_v2 aggregate는 실행하지 않았고, public/unit surface의 focused regression으로 검증했습니다.

## 6. 하위 호환

Answer schema/CLI/doc link 변경 없음. `page_span` 값 형태는 기존 `list[int] | None` 계약을 유지하며 endpoint ordering만 정상화합니다.

## 7. 범위 외

- tuple 등 list가 아닌 explicit span 입력 허용 여부는 기존 계약을 보존하기 위해 변경하지 않았습니다.
- full suite / real100_v2 eval은 실행하지 않았습니다.
