### PR TITLE
fix(metadata): reject boolean page numbers in span normalization

### DIFF
--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -74,6 +74,10 @@ STRICT_METADATA_CONFIDENCE = 0.90
 REDUCED_METADATA_CONFIDENCE = 0.70
 
 
+def _is_integer_page_number(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def metadata_tokens(text: str) -> list[str]:
     tokens = []
     for match in TOKEN_RE.finditer(unicodedata.normalize("NFC", text)):
@@ -92,7 +96,7 @@ def normalize_regions(value: Any) -> list[dict[str, Any]]:
             continue
         region: dict[str, Any] = {}
         page_number = item.get("page_number")
-        if isinstance(page_number, int):
+        if _is_integer_page_number(page_number):
             region["page_number"] = page_number
         elif page_number is None:
             region["page_number"] = None
@@ -112,6 +116,8 @@ def normalize_regions(value: Any) -> list[dict[str, Any]]:
 def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
     if isinstance(value, list) and len(value) == 2:
         try:
+            if isinstance(value[0], bool) or isinstance(value[1], bool):
+                raise TypeError
             start, end = int(value[0]), int(value[1])
             return [min(start, end), max(start, end)]
         except (TypeError, ValueError):
@@ -119,7 +125,7 @@ def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] 
     page_numbers = [
         int(region["page_number"])
         for region in regions
-        if isinstance(region.get("page_number"), int)
+        if _is_integer_page_number(region.get("page_number"))
     ]
     if not page_numbers:
         return None

--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -77,6 +77,12 @@ def test_normalize_regions_preserves_explicit_none_page() -> None:
     assert out == [{"page_number": None, "bbox": None, "type": "fig"}]
 
 
+def test_normalize_regions_rejects_boolean_page_number() -> None:
+    out = normalize_regions([{"page_number": True}])
+    assert out == [{"bbox": None}]
+    assert "page_number" not in out[0]
+
+
 # --- normalize_page_span ---
 
 
@@ -90,6 +96,10 @@ def test_normalize_page_span_coerces_explicit_string_pair() -> None:
 
 def test_normalize_page_span_sorts_explicit_pair() -> None:
     assert normalize_page_span([9, 5], []) == [5, 9]
+
+
+def test_normalize_page_span_rejects_boolean_explicit_pair() -> None:
+    assert normalize_page_span([True, 3], []) is None
 
 
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:
@@ -113,6 +123,13 @@ def test_normalize_page_span_invalid_string_pair_falls_back_to_regions() -> None
 
 def test_normalize_page_span_invalid_pair_without_region_pages_is_none() -> None:
     assert normalize_page_span(["bad", "span"], [{"bbox": [1, 2, 3, 4]}]) is None
+
+
+def test_normalize_page_span_ignores_boolean_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": True}, {"page_number": 3}]) == [
+        3,
+        3,
+    ]
 
 
 # --- normalize_document_sections ---


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Python에서 `bool`이 `int`의 subclass라서 `normalize_regions([{"page_number": True}])` 및 `normalize_page_span([True, 3], [])`가 `True -> 1` page number로 정규화되던 버그를 고쳤습니다. page number 판정은 bool을 제외한 int만 허용하고, explicit span pair도 boolean endpoint를 fallback/none 경로로 보냅니다.

Closes #2687

## 2. 영향 파일

- `rag_metadata_processing.py` — bool을 제외한 integer page-number helper 추가 및 region/span normalization에 적용
- `tests/test_metadata_normalization.py` — boolean page_number / explicit span / region fallback regression coverage

## 3. 리스크

- 리스크: boolean page values가 실수로라도 page 1/0처럼 쓰이던 기존 출력이 사라집니다.
- 배제 근거: JSON boolean은 유효한 page number가 아니며, numeric strings (`"5"`)와 valid integer page numbers는 기존 테스트로 계속 보존됩니다.

## 4. 테스트

- 변경 전 실패 확인: `pytest -q tests/test_metadata_normalization.py -q` → boolean page-number regression 3개 fails
- 변경 후 통과: `pytest -q tests/test_metadata_normalization.py tests/test_answer_format_helpers.py` → `65 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

RAG metadata normalization behavior change이지만 load-bearing checkpoint 목록(`rag_core`, retrieval/verifier/answer/query, ingestion, eval, api, ADR, build_index)은 직접 수정하지 않았습니다. real100_v2 aggregate는 실행하지 않았고, focused unit regression과 adjacent answer helper surface로 검증했습니다.

## 6. 하위 호환

Answer schema/CLI/doc link 변경 없음. `page_span` 값 형태는 기존 `list[int] | None` 계약을 유지하며 boolean input만 invalid로 처리합니다.

## 7. 범위 외

- 음수/0 page number policy는 별도 concern으로 남겼습니다.
- full suite / real100_v2 eval은 실행하지 않았습니다.
