### PR TITLE
fix(metadata): coerce numeric string region page numbers

### DIFF
--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -78,6 +78,17 @@ def _is_integer_page_number(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+def _coerce_page_number(value: Any) -> int | None:
+    if _is_integer_page_number(value):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
 def metadata_tokens(text: str) -> list[str]:
     tokens = []
     for match in TOKEN_RE.finditer(unicodedata.normalize("NFC", text)):
@@ -96,8 +107,9 @@ def normalize_regions(value: Any) -> list[dict[str, Any]]:
             continue
         region: dict[str, Any] = {}
         page_number = item.get("page_number")
-        if _is_integer_page_number(page_number):
-            region["page_number"] = page_number
+        coerced_page_number = _coerce_page_number(page_number)
+        if coerced_page_number is not None:
+            region["page_number"] = coerced_page_number
         elif page_number is None:
             region["page_number"] = None
         bbox = item.get("bbox")
@@ -123,9 +135,9 @@ def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] 
         except (TypeError, ValueError):
             pass
     page_numbers = [
-        int(region["page_number"])
+        page_number
         for region in regions
-        if _is_integer_page_number(region.get("page_number"))
+        if (page_number := _coerce_page_number(region.get("page_number"))) is not None
     ]
     if not page_numbers:
         return None

--- a/tests/test_answer_format_helpers.py
+++ b/tests/test_answer_format_helpers.py
@@ -171,7 +171,7 @@ def test_make_citation_preserves_empty_region_dict_placeholder() -> None:
     assert "page_span" not in citation
 
 
-def test_make_citation_ignores_string_region_page_number_for_span() -> None:
+def test_make_citation_coerces_string_region_page_number_for_span() -> None:
     citation = make_citation({
         "doc_id": "rfp-001",
         "chunk_id": "chunk-7",
@@ -179,8 +179,11 @@ def test_make_citation_ignores_string_region_page_number_for_span() -> None:
         "metadata": {"citation_basis": "source_pdf"},
     })
 
-    assert citation["regions"] == [{"bbox": [0.1, 0.2, 0.3, 0.4]}]
-    assert "page_span" not in citation
+    assert citation["regions"] == [
+        {"page_number": 3, "bbox": [0.1, 0.2, 0.3, 0.4]}
+    ]
+    assert citation["page_span"] == [3, 3]
+    assert citation["citation_label"] == "원본 PDF p.3"
 
 
 def test_make_citation_preserves_canonical_pdf_metadata_and_label() -> None:

--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -83,6 +83,11 @@ def test_normalize_regions_rejects_boolean_page_number() -> None:
     assert "page_number" not in out[0]
 
 
+def test_normalize_regions_coerces_numeric_string_page_number() -> None:
+    out = normalize_regions([{"page_number": "3"}])
+    assert out == [{"page_number": 3, "bbox": None}]
+
+
 # --- normalize_page_span ---
 
 
@@ -129,6 +134,13 @@ def test_normalize_page_span_ignores_boolean_region_pages() -> None:
     assert normalize_page_span(None, [{"page_number": True}, {"page_number": 3}]) == [
         3,
         3,
+    ]
+
+
+def test_normalize_page_span_uses_numeric_string_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": "3"}, {"page_number": 5}]) == [
+        3,
+        5,
     ]
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_regions([{"page_number": "3"}])`가 숫자 문자열 page를 누락해 region-derived `page_span`이 축소되던 동작을 고쳤습니다. explicit `page_span` pair는 이미 numeric string을 허용하므로, region `page_number`도 bool은 거부하되 numeric string은 int로 정규화합니다.

Closes #2689

## 2. 영향 파일

- `rag_metadata_processing.py` — shared page-number coercion helper로 numeric string region pages 허용, bool rejection 유지
- `tests/test_metadata_normalization.py` — region normalization / fallback span regression coverage
- `tests/test_answer_format_helpers.py` — citation helper가 string region page를 page_span/citation_label로 반영하는 계약 갱신

## 3. 리스크

- 리스크: 기존에는 문자열 `page_number`가 omission되던 citation output에 `page_number`, `page_span`, `citation_label`이 추가될 수 있습니다.
- 배제 근거: numeric string page는 valid page number로 볼 수 있고, boolean page values는 #2688 guard로 계속 invalid 처리됩니다.

## 4. 테스트

- 변경 전 실패 확인: `pytest -q tests/test_metadata_normalization.py -q` → numeric string region page regression 2개 fails
- 변경 후 통과: `pytest -q tests/test_metadata_normalization.py tests/test_answer_format_helpers.py` → `67 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

RAG metadata/citation normalization behavior change이지만 load-bearing checkpoint 목록(`rag_core`, retrieval/verifier/answer/query, ingestion, eval, api, ADR, build_index)은 직접 수정하지 않았습니다. real100_v2 aggregate는 실행하지 않았고, focused unit regression과 adjacent answer helper surface로 검증했습니다.

## 6. 하위 호환

Answer schema/CLI/doc link 변경 없음. 기존 dict 계약은 유지하고, numeric string region page가 있던 경우 누락되던 optional citation fields가 정상 생성됩니다.

## 7. 범위 외

- 음수/0 page number policy는 별도 concern으로 남겼습니다.
- full suite / real100_v2 eval은 실행하지 않았습니다.
