### PR TITLE
test(metadata): pin false boolean page rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -83,6 +83,12 @@ def test_normalize_regions_rejects_boolean_page_number() -> None:
     assert "page_number" not in out[0]
 
 
+def test_normalize_regions_rejects_false_page_number() -> None:
+    out = normalize_regions([{"page_number": False}])
+    assert out == [{"bbox": None}]
+    assert "page_number" not in out[0]
+
+
 def test_normalize_regions_coerces_numeric_string_page_number() -> None:
     out = normalize_regions([{"page_number": "3"}])
     assert out == [{"page_number": 3, "bbox": None}]
@@ -105,6 +111,10 @@ def test_normalize_page_span_sorts_explicit_pair() -> None:
 
 def test_normalize_page_span_rejects_boolean_explicit_pair() -> None:
     assert normalize_page_span([True, 3], []) is None
+
+
+def test_normalize_page_span_rejects_false_explicit_pair() -> None:
+    assert normalize_page_span([False, 3], []) is None
 
 
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`False` page values가 Python `int` subclass 특성 때문에 page 0처럼 회귀하지 않도록 metadata normalization test coverage를 추가했습니다. #2688의 boolean rejection 계약을 `True`뿐 아니라 `False` endpoint/region page에도 명시적으로 고정합니다.

Closes #2691

## 2. 영향 파일

- `tests/test_metadata_normalization.py` — `False` explicit page span endpoint 및 region `page_number` rejection coverage 추가

## 3. 리스크

- 테스트 전용 PR이라 런타임 동작 변경 없음.
- 리스크: 없음. 기존 boolean rejection 동작을 더 좁게 고정합니다.

## 4. 테스트

- `pytest -q tests/test_metadata_normalization.py` → `28 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

테스트 전용 변경입니다. RAG 동작/answer schema/eval surface 변경 없음. real100_v2 aggregate는 실행하지 않았습니다.

## 6. 하위 호환

런타임 코드 변경 없음. 기존 계약/스키마/CLI flag/doc link 영향 없음.

## 7. 범위 외

- 양수/0/음수 page number policy는 별도 concern으로 남겼습니다.
- full suite / real100_v2 eval은 실행하지 않았습니다.
