### PR TITLE
fix(metadata): reject nonpositive page numbers in spans

### DIFF
--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -80,12 +80,13 @@ def _is_integer_page_number(value: Any) -> bool:
 
 def _coerce_page_number(value: Any) -> int | None:
     if _is_integer_page_number(value):
-        return value
+        return value if value > 0 else None
     if isinstance(value, str):
         try:
-            return int(value)
+            page_number = int(value)
         except ValueError:
             return None
+        return page_number if page_number > 0 else None
     return None
 
 
@@ -131,6 +132,8 @@ def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] 
             if isinstance(value[0], bool) or isinstance(value[1], bool):
                 raise TypeError
             start, end = int(value[0]), int(value[1])
+            if start <= 0 or end <= 0:
+                raise ValueError
             return [min(start, end), max(start, end)]
         except (TypeError, ValueError):
             pass

--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -94,6 +94,12 @@ def test_normalize_regions_coerces_numeric_string_page_number() -> None:
     assert out == [{"page_number": 3, "bbox": None}]
 
 
+def test_normalize_regions_rejects_nonpositive_page_numbers() -> None:
+    out = normalize_regions([{"page_number": 0}, {"page_number": -2}])
+    assert out == [{"bbox": None}, {"bbox": None}]
+    assert all("page_number" not in region for region in out)
+
+
 # --- normalize_page_span ---
 
 
@@ -115,6 +121,11 @@ def test_normalize_page_span_rejects_boolean_explicit_pair() -> None:
 
 def test_normalize_page_span_rejects_false_explicit_pair() -> None:
     assert normalize_page_span([False, 3], []) is None
+
+
+def test_normalize_page_span_rejects_nonpositive_explicit_pair() -> None:
+    assert normalize_page_span([0, 3], []) is None
+    assert normalize_page_span([-1, 3], []) is None
 
 
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:
@@ -151,6 +162,13 @@ def test_normalize_page_span_uses_numeric_string_region_pages() -> None:
     assert normalize_page_span(None, [{"page_number": "3"}, {"page_number": 5}]) == [
         3,
         5,
+    ]
+
+
+def test_normalize_page_span_ignores_nonpositive_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": 0}, {"page_number": -1}, {"page_number": 3}]) == [
+        3,
+        3,
     ]
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_regions` / `normalize_page_span`이 `0`과 음수 page 값을 유효 page처럼 받아 citation span에 넣던 동작을 고쳤습니다. ingestion의 pymupdf4llm page helper는 이미 bool·≤0 page를 거부하므로, metadata normalization도 같은 positive page-number 계약으로 맞춥니다.

Closes #2694

## 2. 영향 파일

- `rag_metadata_processing.py` — page-number coercion을 positive-only로 제한하고 explicit span endpoint ≤0을 invalid 처리
- `tests/test_metadata_normalization.py` — region/explicit/fallback nonpositive page regression coverage

## 3. 리스크

- 리스크: 기존에 page 0/음수 값이 citation output에 남던 경우 해당 optional `page_number`/`page_span`이 사라질 수 있습니다.
- 배제 근거: citation label은 사용자-facing page number이고, 인접 ingestion helper tests가 `bool·≤0` rejection 계약을 이미 고정합니다.

## 4. 테스트

- 변경 전 실패 확인: `pytest -q tests/test_metadata_normalization.py -q` → nonpositive page regression 3개 fails
- 변경 후 통과: `pytest -q tests/test_metadata_normalization.py tests/test_answer_format_helpers.py tests/test_pymupdf4llm_postprocess_helpers.py` → `88 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

RAG metadata/citation normalization behavior change이지만 load-bearing checkpoint 목록(`rag_core`, retrieval/verifier/answer/query, ingestion, eval, api, ADR, build_index)은 직접 수정하지 않았습니다. real100_v2 aggregate는 실행하지 않았고, focused unit regression과 adjacent answer/ingestion helper surfaces로 검증했습니다.

## 6. 하위 호환

Answer schema/CLI/doc link 변경 없음. 기존 dict 계약은 유지하고, invalid nonpositive page values만 optional citation page fields에서 제외합니다.

## 7. 범위 외

- full suite / real100_v2 eval은 실행하지 않았습니다.
