### PR TITLE
Harden self-ship manifest handoff and review gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,8 @@ ACTIVE_AUTO_LOOP_AUTO_MAX_ITERATIONS ?= 5
 ACTIVE_AUTO_LOOP_TARGET_COMPLETED_COUNT ?=
 ACTIVE_AUTO_LOOP_EXECUTE_RUNNER ?= 1
 ACTIVE_AUTO_LOOP_EXECUTE_SHIP ?= 0
+ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST ?= 0
+ACTIVE_AUTO_LOOP_SHIP_MANIFEST_DIR ?= $(ACTIVE_SHIP_STATE_DIR)
 ACTIVE_AUTO_LOOP_AUTO_REPAIR ?= 1
 START_TASK_LIMIT ?= 5
 START_TASK_ATTEMPT_LIMIT ?= 15
@@ -1113,6 +1115,9 @@ agent-loop-active-auto-loop:
 	  $(if $(ACTIVE_AUTO_LOOP_TARGET_COMPLETED_COUNT),--target-completed-count "$(ACTIVE_AUTO_LOOP_TARGET_COMPLETED_COUNT)",) \
 	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_EXECUTE_RUNNER)),--execute-runner,) \
 	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_EXECUTE_SHIP)),--execute-ship,) \
+	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST)),--emit-ship-manifest,) \
+	  --ship-manifest-dir "$(ACTIVE_AUTO_LOOP_SHIP_MANIFEST_DIR)" \
+	  $(if $(SHIP_DAY),--ship-day "$(SHIP_DAY)",) \
 	  $(if $(filter 1 true yes,$(ACTIVE_AUTO_LOOP_AUTO_REPAIR)),--auto-repair,--no-auto-repair) \
 	  $(if $(TASK),--task "$(TASK)",) \
 	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",) \
@@ -1151,21 +1156,15 @@ agent-loop-active-auto-loop:
 	  ACTIVE_AUTO_LOOP_EXECUTE_SHIP=0 \
 	  ACTIVE_AUTO_LOOP_AUTO_REPAIR=1
 
-# ADR 0088 (P1) / ADR 0090 (P2.0→D-minus): opt-in staging self-ship lane. Composes
-# the byte-identical `시작` loop (EXECUTE_SHIP=0, unchanged) with the ISOLATED
-# staging-ship module as a post step. D-minus scope: verify the env-isolation
-# enforcement model + live protection-verify + DEFINE the manifest CONTRACT only —
-# _staging_ship.py reads ship_manifest.json IF one exists (single-consumption), else
-# falls back to --source, else blocks on user. The manifest EMISSION (the loop
-# auto-dropping a manifest at local-gate-complete) is DEFERRED to P2.2, where it
-# belongs with the real ship: the D-minus loop runs EXECUTE_SHIP=0 so the gated
-# change is never committed, making an emitted source_sha=HEAD meaningless. The loop
-# sub-make therefore receives NO ship signal at all — a PREFIX-based strip unsets
-# EVERY inherited BIDMATE_SHIP_* var (not a fixed allowlist, so a future/unknown
-# BIDMATE_SHIP_* secret can never leak into the workspace-write loop process) as
-# defence-in-depth, EXCEPT the control signal BIDMATE_SHIP_KILL_SWITCH which is
-# pre-checked above and must stay honorable. The autonomous live MERGE orchestration
-# (merge token / cap store plumbing) is DEFERRED to P2.2.
+# ADR 0088 / 0090: opt-in staging self-ship lane. Composes the normal `시작`
+# loop (EXECUTE_SHIP=0; no legacy ship-run) with an opt-in manifest emission seam
+# and the isolated staging-ship module as a post step. The loop writes only
+# ship_manifest.json after a safe local-gate-complete handoff; _staging_ship.py is
+# the only component that may later create/check/merge the staging PR, and only
+# behind its own explicit live flag/token checks. A PREFIX-based strip unsets EVERY
+# inherited BIDMATE_SHIP_* var (not a fixed allowlist, so a future/unknown secret
+# can never leak into the workspace-write loop process) as defence-in-depth, EXCEPT
+# the control signal BIDMATE_SHIP_KILL_SWITCH which is pre-checked above.
 # Mutually exclusive with `make ship-arm` (fail-closed on .claude/.ship-armed).
 시작-ship:
 	@if [ -f .claude/.ship-armed ]; then \
@@ -1180,7 +1179,10 @@ agent-loop-active-auto-loop:
 	  [ "$$v" = "BIDMATE_SHIP_KILL_SWITCH" ] && continue; \
 	  unset "$$v"; \
 	done; \
-	$(MAKE) 시작
+	$(MAKE) 시작 \
+	  ACTIVE_TASK_POOL=1 \
+	  ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST=1 \
+	  ACTIVE_AUTO_LOOP_SHIP_MANIFEST_DIR="$(ACTIVE_SHIP_STATE_DIR)"
 	$(PYTHON) scripts/_staging_ship.py \
 	  --repo-root "." \
 	  --state-dir "$(ACTIVE_SHIP_STATE_DIR)" \

--- a/docs/operations/staging-self-ship.md
+++ b/docs/operations/staging-self-ship.md
@@ -1,10 +1,12 @@
-# Staging self-ship lane — 운영자 runbook (P2.0 D-minus, ADR 0088 + ADR 0090)
+# Staging self-ship lane — 운영자 runbook (P2.0 D-minus + self-ship v1 primitives)
 
-`make 시작-ship`은 byte-identical `make 시작` 루프(`EXECUTE_SHIP=0`, 불변)에 격리된
-`scripts/_staging_ship.py` 모듈을 post step으로 결합한 **opt-in** lane이다. 장기
+`make 시작-ship`은 일반 `make 시작`의 legacy ship-run은 계속 끄고(`EXECUTE_SHIP=0`),
+opt-in manifest emission seam과 격리된 `scripts/_staging_ship.py` post step을 결합한
+**opt-in** lane이다. 장기
 목표는 자율 루프가 자기 작업을 장수(long-lived) `autopilot/integration` 브랜치로
-직접 머지하게 하는 것이다. **P2.0 D-minus 시점에서 이 lane은 강제(enforcement)
-전제조건을 검증하고 머지를 거부한다 — 자율 머지는 P2.2다.**
+직접 머지하게 하는 것이다. 기본 `make 시작-ship` 경로는 여전히 강제(enforcement)
+전제조건을 검증하고 머지를 거부한다. 실제 staging merge는 manifest `source_sha`와
+`BIDMATE_SHIP_MERGE_TOKEN`이 있는 명시적 `--execute-live-staging`에서만 가능하다.
 
 **P2.0 D-minus 변경 (ADR 0090):** 이 PR은 강제 모델을 실제로 작동하게 만든다:
 
@@ -22,15 +24,42 @@
 - `_staging_ship.py`는 **manifest CONTRACT 함수**(`write_ship_manifest` /
   `read_ship_manifest` / `archive_ship_manifest`, 단위 테스트됨)를 정의한다. `main()`은
   manifest가 **있으면** 읽고(idempotent — 소비하지 않음), 수동 실행을 위해 `--source`를
-  받는다. **이 PR에서 `agent_loop.py`는 manifest를 자동 emit하지 않는다** — 루프가
-  `EXECUTE_SHIP=0`으로 돌아 아무 변경도 커밋되지 않으므로 `source_sha=HEAD`는
-  stale / 무의미하다. Manifest emission은 HEAD-binding이 실제가 되는 P2.2로 연기됐다.
-- `_staging_ship.py main()`은 **검증-후-거부(verify-and-refuse) pre-flight harness**다:
-  manifest를 읽고(있으면), constitutional 가드 + 실시간 protection 체크를 실행한 뒤
-  **항상 rc 2 (blocked-on-user)를 반환**한다. `open_pr`/`merge`는 호출 시 raise하는
-  명시적 P2.2-연기 stub이다.
+  받는다. `agent_loop.py active-auto-loop --emit-ship-manifest`는 정확히 한 개의
+  `local-gate-complete` cycle, serial task pool, issue-linked source branch, full HEAD SHA,
+  그리고 non-report dirty file 0개일 때만 schema v2 manifest를 쓴다.
+- `_staging_ship.py main()`은 **검증 우선 harness**다. 기본 모드는 manifest를
+  읽고(있으면), constitutional 가드 + 실시간 protection 체크를 실행한 뒤 rc 2
+  (blocked-on-user)를 반환한다. `--execute-live-staging`을 명시하면 staging PR
+  create/check/merge를 실행하되, `--match-head-commit <source_sha>`를 강제하고
+  `--admin` / `--delete-branch`는 사용하지 않는다.
 
 이 lane이 항상 머지를 거부하는 것은 **올바른 D-minus 동작**이다 — 버그가 아니다.
+
+**Self-ship v1 primitive (2026-06-05):** staging GitHub PR 생성/merge wiring은
+명시 플래그 뒤에 구현됐다. main promotion은 여전히 simulation/contract 단계이며
+live merge는 deferred다. 다만 main review gate의 GitHub GraphQL 필드 판정
+(`reviewDecision` + `reviewThreads.nodes[].isResolved/isOutdated`)은 read-only resolver로
+구현됐다.
+
+- `ship_manifest.json` schema v2가 유일한 v1 계약이다. schema v1 + sidecar/supplemental
+  manifest는 거부된다.
+- manifest는 `target`, `base_branch`, `gate_evidence_path`,
+  `gate_evidence_digest`, `protected_paths_changed`, `ci_evidence_ref`,
+  `review_gate_ref`를 포함한다. CI/review ref는 포인터일 뿐이며 merge 권한이 아니다.
+- manifest emission seam은 merge가 아니다. loop는 `ship_manifest.json`만 작성하고,
+  staging PR 생성/체크/머지는 `_staging_ship.py --execute-live-staging`의 별도 명시
+  플래그와 merge token 경로가 담당한다.
+- main promotion simulation은 promoter-resolved facts만 사용한다:
+  CI green, `reviewDecision == APPROVED`, unresolved non-outdated thread 0,
+  branch protection, non-admin token, PR head SHA binding.
+- review gate resolver는 `gh api graphql`로 PR의 `reviewDecision`과 review thread 페이지를
+  읽고, `isResolved=false && isOutdated=false`인 thread 수를 센다. API/스키마/페이지 한도
+  실패는 모두 `api_error=True`로 fail-closed 처리된다.
+- guard/ship/protection path 변경은 external ack가 없으면 `main-blocked-guard-ack`다.
+  runner/bot/merge-token/agent-authored evidence는 ack가 될 수 없다.
+- cap store v1 전에는 main promotion이 finite bounded invocation에서만 허용된다.
+  infinite/retry/multiple-main-manifest/multiple-source-SHA mode는
+  `main-blocked-cap-deferred`다.
 
 ## 강제 모델 (enforcement model — 먼저 읽을 것)
 
@@ -41,8 +70,9 @@ workspace-write runner는 이를 우회할 수 있다. **권한(authority)**은 
 
 1. `autopilot/integration`에 대한 GitHub **branch protection** — `staging-self-ship-guard`
    워크플로를 **required status check**로 지정.
-2. (P2.2) branch protection을 우회할 수 없는 **권한 분리된 merge 토큰**
-   (`BIDMATE_SHIP_MERGE_TOKEN`) — **runner write 도메인 밖**에 저장.
+2. branch protection을 우회할 수 없는 **권한 분리된 merge 토큰**
+   (`BIDMATE_SHIP_MERGE_TOKEN`) — **runner write 도메인 밖**에 저장하고,
+   explicit live staging mutation에만 주입.
 
 `protection_verified`는 `repos/:owner/:repo/branches/autopilot%2Fintegration/protection`에
 대해 **실시간 `gh api` 쿼리**를 수행한다. `staging-self-ship-guard` required check가
@@ -115,45 +145,63 @@ gh api -X PUT repos/:owner/:repo/branches/autopilot%2Fintegration/protection \
   -F 'allow_deletions=false'
 ```
 
-### 2. P2.2: 권한 분리된 merge 토큰과 cap store (연기됨)
+### 2. 권한 분리된 merge 토큰과 cap store
 
-이들은 **D-minus에 불필요**하며 P2.2로 연기됨:
+staging live merge에는 merge token이 필요하다. durable cap store와 main live promotion은
+후속 단계다.
 
 - `BIDMATE_SHIP_MERGE_TOKEN` — 이 repo로 스코프된 fine-grained PAT (또는 GitHub App
   installation 토큰), **Contents: read/write + Pull requests: read/write** 권한은 갖되
-  Administration은 **갖지 않음**. branch protection을 편집할 수 없어야 한다.
-- `BIDMATE_SHIP_CAP_STORE` — cross-worktree 일일 cap 트랜잭션성을 위한 T4
+  Administration은 **갖지 않음**. branch protection을 편집할 수 없어야 한다. live
+  staging mutation subprocess는 ambient `GH_TOKEN`을 버리고 이 값을 `GH_TOKEN`으로만
+  주입한다.
+- `BIDMATE_SHIP_CAP_STORE` — main promotion의 cross-worktree 일일 cap 트랜잭션성을 위한 T4
   self-immutable cap store 파일 경로 (runner write 도메인 밖).
 
-## Ship manifest 흐름 (P2.0 D-minus)
+## Ship manifest 흐름 (schema v2)
 
-`make 시작-ship`은 byte-identical `make 시작` 루프를 실행하고(`env -u`로 시크릿 제거,
-kill-switch 사전 점검), 그 다음 `_staging_ship.py`를 post step으로 호출한다.
+`make 시작-ship`은 루프 sub-make 전에 시크릿을 제거하고 kill-switch를 사전 점검한 뒤,
+`ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST=1`로 `make 시작`을 실행한다. 일반 `make 시작`은
+여전히 manifest를 쓰지 않는다. emission seam은 아래 조건을 모두 만족할 때만
+`$(ACTIVE_SHIP_STATE_DIR)/ship_manifest.json`을 작성한다:
 
-**이 PR에는 manifest 자동 emission이 없다.** `agent_loop.py`는 `ship_manifest.json`을
-쓰지 않는다 — 루프가 `EXECUTE_SHIP=0`으로 돌아 게이팅된 변경이 절대 커밋되지 않으므로
-`source_sha=HEAD`는 stale하다. manifest emission seam(`_maybe_write_ship_manifest`)은
-실제 커밋이 존재하고 HEAD-binding이 유의미한 P2.2로 연기됐다.
+- `EXECUTE_SHIP=0` — legacy `make ship-run`과 동시 사용 금지.
+- serial task pool (`task_pool=1`) — 한 manifest가 여러 병렬 cycle의 gate evidence를
+  대표하지 않도록 한다.
+- 정확히 한 개의 cycle이 `local-gate-complete`.
+- source branch가 issue-linked feature branch.
+- `source_sha`가 full 40-char HEAD SHA.
+- non-report dirty file 0개 — `reports/agent_loop/**` 생성물은 허용하지만 코드/문서의
+  uncommitted edit은 manifest를 쓰지 않는다.
 
 manifest **contract 함수**는 `_staging_ship.py`에 정의·단위 테스트됨:
 - `write_ship_manifest(state_dir, ...)` — `<state-dir>/ship_manifest.json` 작성
+  (`schema_version=2`, `source_branch`, `source_sha`, `target`, `base_branch`,
+  `title`, `body`, `day`, `gate_evidence_path`, `gate_evidence_digest`,
+  `protected_paths_changed`, `ci_evidence_ref`, `review_gate_ref`)
 - `read_ship_manifest(state_dir)` — **idempotent 읽기** (소비/아카이브하지 않음)
-- `archive_ship_manifest(state_dir)` — `.consumed`로 이동 (P2.2 merge 성공 경로에서
-  호출)
+- `archive_ship_manifest(state_dir)` — `.consumed`로 이동 (successful live staging /
+  main promotion 경로에서 호출)
 
 `_staging_ship.py main()`은 manifest가 **이미 있으면** 읽고(idempotent), 운영자가
 `--source`를 제공하면 그것을 사용한 뒤, constitutional 가드 + 실시간 protection 체크를
-실행하고 rc 2로 종료한다.
+실행한다. 기본 모드는 rc 2로 종료한다. live staging은 아래 명시 플래그가 필요하다.
 
 ```bash
-# manifest 경로 (contract, P2.2 emission seam이 작성; 테스트용으로 운영자가 배치):
+# manifest 경로 (contract; 시작-ship opt-in seam이 조건 충족 시 작성):
 # $(ACTIVE_SHIP_STATE_DIR)/ship_manifest.json
 
 # 오늘 실시간 protection-verify harness를 수동 실행하려면:
 python scripts/_staging_ship.py --source <branch> --state-dir reports/agent_loop/active
+
+# staging live merge를 명시 실행하려면 (기본 make target은 이 flag를 넘기지 않음):
+BIDMATE_SHIP_MERGE_TOKEN=... python scripts/_staging_ship.py \
+  --manifest-dir reports/agent_loop/active \
+  --state-dir reports/agent_loop/active \
+  --execute-live-staging
 ```
 
-## Gate 3 — 실시간 e2e (D-minus: 외부 강제 검증; P2.2: merge 검증)
+## Gate 3 — 실시간 e2e (외부 강제 + explicit staging merge 검증)
 
 운영자 branch-protection 설정 후, 이 두 adversarial 체크가 외부 권한이 실제임을
 증명한다. mock할 수 없다 — 실제 GitHub 서버 상태를 동작시킨다.
@@ -162,7 +210,7 @@ python scripts/_staging_ship.py --source <branch> --state-dir reports/agent_loop
    리뷰 *없이* `scripts/_staging_ship.py`를 편집하는 PR을 `autopilot/integration`으로
    연다. 예상: `staging-self-ship-guard` required check가 **실패**하고 머지가 차단된다
    (아래 "Constitutional-change 강제" 참조 — ADR 0091).
-2. **merge 토큰은 protection을 비활성화할 수 없다.** (P2.2, 토큰 프로비저닝 후)
+2. **merge 토큰은 protection을 비활성화할 수 없다.**
    ```bash
    GH_TOKEN=$BIDMATE_SHIP_MERGE_TOKEN gh api -X PATCH \
      repos/:owner/:repo/branches/autopilot%2Fintegration/protection \
@@ -170,8 +218,8 @@ python scripts/_staging_ship.py --source <branch> --state-dir reports/agent_loop
    ```
    예상: **HTTP 403**.
 
-Gate 3 check 1은 protection이 실제임을 검증한다. Check 2는 P2.2로 연기됨 (권한 분리
-토큰이 존재해야 함).
+Gate 3 check 1은 protection이 실제임을 검증한다. Check 2는 권한 분리 토큰이
+프로비저닝된 뒤 실행한다.
 
 ## lane 실행
 
@@ -195,28 +243,29 @@ export BIDMATE_SHIP_KILL_SWITCH=1      # env 형태
 fail-close한다 — 두 ship 권한은 상호 배타적이다 (ADR 0088 §7).
 
 이 lane은 `protection_verified`가 실시간 `gh api` 쿼리를 통과할 때까지 머지를 거부한다.
-이는 올바른 동작이다 — 버그가 아니다. 자율 머지는 merge 토큰, cap store, 직렬화된
-promotion 로직이 구현되는 P2.2에서 풀린다.
+이는 올바른 동작이다 — 버그가 아니다. 기본 `make 시작-ship`도 계속 검증-후-거부이며,
+staging live merge는 manifest와 `--execute-live-staging`을 명시해야 한다.
 
-## P2.0 D-minus가 구축한 것 vs blocked-on-user / 연기
+## 현재 구축된 것 vs blocked-on-user / 연기
 
-| 구축됨 (P2.0 D-minus) | Blocked-on-user (당신) | P2.2로 연기 |
+| 구축됨 | Blocked-on-user (당신) | 후속으로 연기 |
 |---|---|---|
-| `ship_manifest.json` **contract 함수** (`_staging_ship.py`의 `write_ship_manifest` / `read_ship_manifest` / `archive_ship_manifest`, 단위 테스트됨) | `autopilot/integration` 생성 + `staging-self-ship-guard` required check를 가진 branch protection | **`agent_loop.py` manifest emission seam** (`_maybe_write_ship_manifest`) — `EXECUTE_SHIP=0`이 `source_sha=HEAD`를 stale하게 만들어 연기 |
-| 실시간 `protection_verified` — `staging-self-ship-guard` required check + `allow_force_pushes=false` + `enforce_admins=true`를 확인하는 실제 `gh api` 쿼리, URL 인코딩된 슬래시 브랜치, fail-closed; env-trust 플래그 제거 | Gate-3 실시간 e2e check 1 (가드 파일 PR → required check 실패) | 실시간 `gh pr create` / `gh pr merge` (open_pr/merge는 P2.2-연기 stub) |
-| `BIDMATE_SHIP_*` env 격리 — 단일 출처 `scripts/_ship_env.py`, 모든 6개 runner 서브프로세스 lane에 deny-by-prefix; `make 시작-ship`은 루프 sub-make 전에 시크릿 제거 | ADR 0090 Status `proposed → accepted` | 권한 분리 merge 토큰(`BIDMATE_SHIP_MERGE_TOKEN`) + `merge()`의 ambient-credential 제거 |
-| `main()` 검증-후-거부 pre-flight harness — manifest 있으면 읽고(idempotent), `--source` 수용; 항상 rc 2 | | T4 self-immutable cap store(`BIDMATE_SHIP_CAP_STORE`) + cross-worktree 공유 lock + 일일 cap 트랜잭션성 |
-| ADR 0090 + 이 갱신된 runbook | | `source_sha` → PR head binding(`--match-head-commit`) + 직렬화된 promotion |
+| `ship_manifest.json` **schema v2 contract 함수** + `agent_loop.py` opt-in manifest emission seam (`--emit-ship-manifest`, 단위 테스트됨) | `autopilot/integration` 생성 + `staging-self-ship-guard` required check를 가진 branch protection | main live promotion wiring |
+| 실시간 `protection_verified` — `staging-self-ship-guard` required check + `allow_force_pushes=false` + `enforce_admins=true`를 확인하는 실제 `gh api` 쿼리, URL 인코딩된 슬래시 브랜치, fail-closed; env-trust 플래그 제거 | Gate-3 실시간 e2e check 1 (가드 파일 PR → required check 실패) | main live promotion wiring |
+| `BIDMATE_SHIP_*` env 격리 — 단일 출처 `scripts/_ship_env.py`, 모든 6개 runner 서브프로세스 lane에 deny-by-prefix; `make 시작-ship`은 루프 sub-make 전에 시크릿 제거 | ADR 0090 Status `proposed → accepted` | durable cap store(`BIDMATE_SHIP_CAP_STORE`) + cross-worktree 공유 lock + 일일 cap 트랜잭션성 |
+| `main()` 기본 검증-후-거부 + 명시 `--execute-live-staging` staging PR create/check/merge; `--match-head-commit` 강제; `--admin`/`--delete-branch` 금지 | 권한 분리 `BIDMATE_SHIP_MERGE_TOKEN` provisioning | main promotion의 source_sha live binding |
+| protected-path detector, external ack validator, review gate matrix, read-only GitHub GraphQL review-thread resolver, main gate simulation, no-cap bounded-mode blocker, promotion lock primitive | main live promotion evidence source/policy 확정 | main live promotion wiring |
+| ADR 0090 + 이 갱신된 runbook | | main promotion의 source_sha live binding |
 | | | Bounded check poll(`BIDMATE_SHIP_CHECK_ATTEMPTS`/`BIDMATE_SHIP_CHECK_INTERVAL_SECONDS`) |
 | | | Gate-3 실시간 e2e check 2 (merge 토큰 PUT protection → 403) |
 | | | P2.1: `_ship_env.py` + manifest emission seam을 `SELF_IMMUTABLE_PATHS`에 추가 |
 
 ## 범위 경계 (scope boundary)
 
-**P2.0 D-minus**는 강제 모델 + manifest contract 정의 레이어다. 루프 manifest emission
-seam과 자율 머지 오케스트레이션은 P2.2다. 그 이상의 능력(무제한 self-modify / option 3,
-main 자동 promotion, task 자동 생성)은 P2.1–P3이며 각각 자체 ADR과 명시적 승인이
-필요하다.
+**현재 v1 slice**는 강제 모델 + schema v2 manifest + opt-in loop emission seam +
+explicit staging live path + main promotion simulation이다. main 자율 머지
+오케스트레이션은 후속이다. 그 이상의 능력(무제한 self-modify / option 3, main 자동
+promotion, task 자동 생성)은 각각 자체 ADR과 명시적 승인이 필요하다.
 
 `_ship_env.py`와 manifest emission seam은 P2.1에서 `SELF_IMMUTABLE_PATHS`에 추가돼야
 한다 (현재 전체 `SELF_IMMUTABLE_PATHS` 구현과 함께 연기됨).

--- a/docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md
+++ b/docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md
@@ -1,9 +1,9 @@
 # Full Pipeline Roadmap Queue Sync Handoff
 
 - **Date:** 2026-06-05
-- **Source PRD:** [`../../.omx/plans/prd-full-pipeline-experiment-roadmap-20260605.md`](../../.omx/plans/prd-full-pipeline-experiment-roadmap-20260605.md)
-- **Test spec:** [`../../.omx/plans/test-spec-full-pipeline-experiment-roadmap-20260605.md`](../../.omx/plans/test-spec-full-pipeline-experiment-roadmap-20260605.md)
-- **Ultragoal dedupe evidence:** [`../../.omx/ultragoal/G002-full-pipeline-roadmap-dedupe-map.md`](../../.omx/ultragoal/G002-full-pipeline-roadmap-dedupe-map.md)
+- **Source PRD:** `../../.omx/plans/prd-full-pipeline-experiment-roadmap-20260605.md` (local OMX artifact; not tracked in git)
+- **Test spec:** `../../.omx/plans/test-spec-full-pipeline-experiment-roadmap-20260605.md` (local OMX artifact; not tracked in git)
+- **Ultragoal dedupe evidence:** `../../.omx/ultragoal/G002-full-pipeline-roadmap-dedupe-map.md` (local OMX artifact; not tracked in git)
 - **Related queue:** [`../../tasks/queue.md`](../../tasks/queue.md)
 - **Status:** handoff draft; queue IDs not assigned in this dirty worktree.
 
@@ -12,7 +12,7 @@
 Apply the full-pipeline roadmap as **symbolic task drafts** first. Do not add new
 canonical `T-*` rows in this handoff because the current worktree already has a
 relevant dirty `T-2026-0081` parser-roadmap append while
-[`T-2026-0080-queue-backlog-roadmap-handoff.md`](T-2026-0080-queue-backlog-roadmap-handoff.md)
+`T-2026-0080-queue-backlog-roadmap-handoff.md` (draft artifact not tracked in this tree)
 separately drafts `T-2026-0080..0088` for a different queue sync.
 
 This preserves the user's intent—"try every non-dominated lane and find the

--- a/scripts/_staging_ship.py
+++ b/scripts/_staging_ship.py
@@ -19,25 +19,31 @@ guards, and (b) **fails closed** (``EnforcementNotVerified``) unless the externa
 protection is read-verified, so it can never silently "pass" gate 3 without the real
 GitHub setup.
 
-D1 scope (this PR)
-------------------
-This PR ships exactly **D1 = enforcement-model activation + manifest contract**:
+D1 + v1 primitive scope
+-----------------------
+This module keeps main promotion live wiring deferred, but now carries the local
+contracts and explicit staging live path needed by self-ship v1:
   1. The ship-manifest contract (write/read/archive + schema) — the loop→lane hand-off.
   2. A *live* read-only ``protection_verified`` that actually queries GitHub branch
      protection (``gh repo view`` + ``gh api .../protection``) and returns True only
      when the specific ``staging-self-ship-guard`` required check is present AND
      force-push is denied.
-The **autonomous merge orchestration** (PR open/merge, daily-cap transactionality,
-serialized promotion via a single-instance lock, source-SHA binding) is deliberately
-DEFERRED to **P2.2** because it needs cross-worktree transactional hardening. The
-``_RealGitOps`` open_pr/merge methods are therefore honest stubs that raise
-``EnforcementNotVerified``, and ``main()`` is a verify-and-refuse pre-flight harness
-that NEVER merges.
+  3. An explicit ``--execute-live-staging`` path for staging PR create/check/merge
+     using ``BIDMATE_SHIP_MERGE_TOKEN`` and ``--match-head-commit``.
+  4. A read-only GraphQL resolver for main review-gate facts
+     (``reviewDecision`` + unresolved non-outdated review threads).
+  5. Fail-closed local primitives for main-gate simulation, guard-change external
+     ack, bounded no-cap mode, and promotion locking.
+The **main** autonomous merge orchestration (main source binding around live PRs,
+live main mutation, and durable cap-store semantics) is still deferred. The default
+CLI mode remains verify-and-refuse; staging mutation requires the explicit flag and
+never uses admin/delete-branch bypasses.
 """
 
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -82,6 +88,9 @@ _PROTECTED_TARGETS: frozenset[str] = frozenset(
 # Only branches under this namespace are acceptable staging targets.
 _STAGING_PREFIX = "autopilot/"
 _STAGING_EXACT = "autopilot/integration"
+_TARGET_STAGING = "staging"
+_TARGET_MAIN = "main"
+_MAIN_EXACT = "main"
 
 # ADR 0088 external-enforcement authority: this exact required status check must be
 # present in the branch protection, not merely *some* required check.
@@ -97,6 +106,34 @@ _GH_TIMEOUT_SEC = 30
 _GH_AMBIENT_DROP_KEYS: frozenset[str] = frozenset(
     {"GH_REPO", "GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"}
 )
+_SHIP_MERGE_TOKEN_ENV = "BIDMATE_SHIP_MERGE_TOKEN"
+_REVIEW_THREADS_PAGE_SIZE = 100
+_REVIEW_THREADS_MAX_PAGES = 10
+_REVIEW_GATE_QUERY = """
+query(
+  $owner: String!,
+  $name: String!,
+  $number: Int!,
+  $first: Int!,
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewDecision
+      reviewThreads(first: $first, after: $after) {
+        nodes {
+          isResolved
+          isOutdated
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+""".strip()
 
 _FORCE_PUSH_TOKENS: frozenset[str] = frozenset(
     {"--force", "-f", "--force-with-lease", "--mirror"}
@@ -165,10 +202,50 @@ def assert_ship_arm_not_active(repo_root: str | os.PathLike[str]) -> None:
 # --------------------------------------------------------------------------- #
 SHIP_MANIFEST_FILENAME = "ship_manifest.json"
 SHIP_MANIFEST_CONSUMED = "ship_manifest.consumed.json"
-SHIP_MANIFEST_SCHEMA_VERSION = 1
+SHIP_MANIFEST_SCHEMA_VERSION = 2
 
 _SHIP_MANIFEST_REQUIRED_KEYS = frozenset(
-    {"schema_version", "source_branch", "source_sha", "title", "body", "day"}
+    {
+        "schema_version",
+        "source_branch",
+        "source_sha",
+        "target",
+        "base_branch",
+        "title",
+        "body",
+        "day",
+        "gate_evidence_path",
+        "gate_evidence_digest",
+        "protected_paths_changed",
+        "ci_evidence_ref",
+        "review_gate_ref",
+    }
+)
+
+SELF_SHIP_PROTECTED_PATH_GLOBS: tuple[str, ...] = (
+    "Makefile",
+    "scripts/agent_loop.py",
+    "scripts/_staging_ship.py",
+    "scripts/_ship_env.py",
+    "scripts/claude-hooks/**",
+    ".githooks/**",
+    ".claude/settings.json",
+    ".github/CODEOWNERS",
+    ".github/workflows/staging-self-ship-guard.yml",
+    ".github/workflows/branch-and-issue-check.yml",
+    ".github/workflows/pr-eval.yml",
+    "docs/operations/staging-self-ship.md",
+    "docs/operations/auto-ship.md",
+    "docs/operations/active-agent-loop.md",
+    "docs/adr/0088-*",
+    "docs/adr/0090-*",
+    "docs/adr/*self-ship*",
+)
+
+_ALLOWED_MANIFEST_TARGETS = frozenset({_TARGET_STAGING, _TARGET_MAIN})
+_ACK_ALLOWED_PERMISSIONS = frozenset({"maintain", "admin"})
+_ACK_DENIED_ACTOR_KINDS = frozenset(
+    {"runner", "bot", "github-actions", "dependency-bot", "codex", "claude", "omx", "merge-token"}
 )
 
 
@@ -180,13 +257,20 @@ def write_ship_manifest(
     title: str,
     body: str,
     day: str,
+    target: str = _TARGET_STAGING,
+    base_branch: str = _STAGING_EXACT,
+    gate_evidence_path: str = "",
+    gate_evidence_digest: str = "",
+    protected_paths_changed: list[str] | tuple[str, ...] | None = None,
+    ci_evidence_ref: str = "",
+    review_gate_ref: str = "",
     now: datetime | None = None,
 ) -> Path:
-    """Write ``<manifest_dir>/ship_manifest.json`` with the P2.0 contract.
+    """Write ``<manifest_dir>/ship_manifest.json`` with the v2 contract.
 
     ``agent_loop.py`` imports and calls this with the keyword signature above;
     the signature is part of the contract — do not change it. ``source_sha`` binds
-    the merge to the exact gated commit (consumed by the deferred P2.2 merge
+    the merge to the exact gated commit (consumed by live staging / deferred main
     orchestration via ``--match-head-commit``).
     """
     generated_at = (now or datetime.now(timezone.utc)).isoformat()
@@ -194,9 +278,16 @@ def write_ship_manifest(
         "schema_version": SHIP_MANIFEST_SCHEMA_VERSION,
         "source_branch": source_branch,
         "source_sha": source_sha,
+        "target": target,
+        "base_branch": base_branch,
         "title": title,
         "body": body,
         "day": day,
+        "gate_evidence_path": gate_evidence_path,
+        "gate_evidence_digest": gate_evidence_digest,
+        "protected_paths_changed": sorted(set(protected_paths_changed or [])),
+        "ci_evidence_ref": ci_evidence_ref,
+        "review_gate_ref": review_gate_ref,
         "generated_at": generated_at,
     }
     directory = Path(manifest_dir)
@@ -209,15 +300,15 @@ def write_ship_manifest(
     return path
 
 
-# A valid source_sha is a full 40-char lowercase hex git SHA (binds the deferred P2.2
-# merge to the exact gated commit). A malformed/empty SHA fails the manifest closed.
+# A valid source_sha is a full 40-char lowercase hex git SHA (binds live staging /
+# deferred main merge to the exact gated commit). A malformed/empty SHA fails closed.
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 def read_ship_manifest(manifest_dir: str | os.PathLike[str]) -> dict | None:
     """Read + validate ``<dir>/ship_manifest.json`` WITHOUT consuming it.
 
-    Parses the manifest and validates the P2.0 contract, then returns the dict.
+    Parses the manifest and validates the schema v2 contract, then returns the dict.
     This is intentionally **idempotent / re-readable**: it does NOT rename the file
     (codex #3 / G1). Consumption happens only on a successful ship via
     :func:`archive_ship_manifest`, so a blocked / interrupted run leaves the manifest
@@ -246,7 +337,266 @@ def read_ship_manifest(manifest_dir: str | os.PathLike[str]) -> dict | None:
         raise ValueError(
             f"ship manifest {src} source_sha {source_sha!r} is not a 40-char hex SHA"
         )
+    target = data.get("target")
+    if target not in _ALLOWED_MANIFEST_TARGETS:
+        raise ValueError(
+            f"ship manifest {src} target {target!r} must be one of {sorted(_ALLOWED_MANIFEST_TARGETS)}"
+        )
+    for key in (
+        "source_branch",
+        "base_branch",
+        "title",
+        "body",
+        "day",
+        "gate_evidence_path",
+        "gate_evidence_digest",
+        "ci_evidence_ref",
+        "review_gate_ref",
+    ):
+        if not isinstance(data.get(key), str):
+            raise ValueError(f"ship manifest {src} field {key!r} must be a string")
+    if target == _TARGET_STAGING and data["base_branch"] != _STAGING_EXACT:
+        raise ValueError(
+            f"ship manifest {src} staging target must bind base_branch to {_STAGING_EXACT!r}"
+        )
+    if target == _TARGET_MAIN:
+        if data["base_branch"] != _MAIN_EXACT:
+            raise ValueError(
+                f"ship manifest {src} main target must bind base_branch to {_MAIN_EXACT!r}"
+            )
+        for key in (
+            "gate_evidence_path",
+            "gate_evidence_digest",
+            "ci_evidence_ref",
+            "review_gate_ref",
+        ):
+            if not data[key].strip():
+                raise ValueError(f"ship manifest {src} main field {key!r} must be non-empty")
+    protected_paths = data.get("protected_paths_changed")
+    if not isinstance(protected_paths, list) or not all(
+        isinstance(path, str) for path in protected_paths
+    ):
+        raise ValueError(
+            f"ship manifest {src} protected_paths_changed must be a list of strings"
+        )
     return data
+
+
+def detect_self_ship_protected_paths(paths: list[str] | tuple[str, ...]) -> list[str]:
+    """Return changed paths that require external human ack for main self-ship.
+
+    This is an in-process detector only. The authoritative unblock decision still
+    comes from external ack evidence resolved by the promoter.
+    """
+    protected: set[str] = set()
+    for raw in paths:
+        path = str(raw).strip().lstrip("./")
+        if any(fnmatch.fnmatchcase(path, pattern) for pattern in SELF_SHIP_PROTECTED_PATH_GLOBS):
+            protected.add(path)
+    return sorted(protected)
+
+
+@dataclass(frozen=True)
+class GuardChangeAck:
+    """External ack evidence for guard/ship/protection path changes.
+
+    Runner-authored manifests/reports are never valid ack sources. The promoter
+    must bind this evidence to the exact source SHA and protected path set.
+    """
+
+    actor: str
+    actor_kind: str
+    source_sha: str
+    protected_paths: tuple[str, ...]
+    permission: str = ""
+    external: bool = True
+    codeowner_approval: bool = False
+
+
+def guard_change_ack_valid(
+    ack: GuardChangeAck | None,
+    *,
+    source_sha: str,
+    protected_paths: list[str] | tuple[str, ...],
+) -> bool:
+    """True only for external maintainer/admin/CODEOWNER ack bound to this diff."""
+    required_paths = tuple(sorted(set(protected_paths)))
+    if not required_paths:
+        return True
+    if ack is None or not ack.external:
+        return False
+    if ack.actor_kind.strip().lower() in _ACK_DENIED_ACTOR_KINDS:
+        return False
+    if ack.source_sha != source_sha:
+        return False
+    if tuple(sorted(set(ack.protected_paths))) != required_paths:
+        return False
+    if ack.codeowner_approval:
+        return True
+    return ack.permission.strip().lower() in _ACK_ALLOWED_PERMISSIONS
+
+
+def review_gate_clean(
+    review_decision: str | None,
+    unresolved_non_outdated_threads: int | None,
+    *,
+    api_error: bool = False,
+) -> bool:
+    """Main review gate: APPROVED and zero unresolved non-outdated threads only."""
+    if api_error:
+        return False
+    if review_decision != "APPROVED":
+        return False
+    return unresolved_non_outdated_threads == 0
+
+
+@dataclass(frozen=True)
+class ReviewGateResolution:
+    """Read-only GitHub review gate facts resolved by the promoter.
+
+    ``api_error=True`` means the result must be treated as not clean. The
+    unresolved count is only authoritative when every requested page was fetched
+    and parsed.
+    """
+
+    review_decision: str | None
+    unresolved_non_outdated_threads: int | None
+    fetched_thread_pages: int = 0
+    api_error: bool = False
+
+
+def _review_gate_api_error(
+    *,
+    review_decision: str | None = None,
+    fetched_thread_pages: int = 0,
+) -> ReviewGateResolution:
+    return ReviewGateResolution(
+        review_decision=review_decision,
+        unresolved_non_outdated_threads=None,
+        fetched_thread_pages=fetched_thread_pages,
+        api_error=True,
+    )
+
+
+@dataclass(frozen=True)
+class MainGateSnapshot:
+    """Promoter-resolved external facts for main promotion.
+
+    Manifest refs may point to evidence, but they do not authorize merge. This
+    snapshot is the value object used by tests/fake GitHub adapters to prove that
+    the promoter, not the runner, resolved CI/review/protection/source state.
+    """
+
+    ci_green: bool
+    review_decision: str | None
+    unresolved_non_outdated_threads: int | None
+    protection_verified: bool
+    token_verified: bool
+    pr_head_sha: str | None
+    api_error: bool = False
+
+
+def bounded_main_without_cap_blocker(
+    *,
+    target: str,
+    target_manifest_count: int,
+    distinct_main_source_sha_count: int,
+    start_infinite: bool = False,
+    active_auto_loop_max_iterations: int | None = None,
+    retry_loop_requested: bool = False,
+) -> ShipResult | None:
+    """Block unbounded main promotion until a self-immutable cap store exists."""
+    if target != _TARGET_MAIN:
+        return None
+    reasons: list[str] = []
+    if start_infinite:
+        reasons.append("START_INFINITE=1")
+    if active_auto_loop_max_iterations == 0:
+        reasons.append("ACTIVE_AUTO_LOOP_MAX_ITERATIONS=0")
+    if target_manifest_count > 1:
+        reasons.append("multiple main manifests in one invocation")
+    if retry_loop_requested:
+        reasons.append("automatic retry loop requested")
+    if distinct_main_source_sha_count > 1:
+        reasons.append("more than one distinct main source SHA")
+    if reasons:
+        return ShipResult("main-blocked-cap-deferred", reasons=reasons)
+    return None
+
+
+def evaluate_main_promotion(
+    manifest: dict,
+    gates: MainGateSnapshot,
+    *,
+    ack: GuardChangeAck | None = None,
+    target_manifest_count: int = 1,
+    distinct_main_source_sha_count: int = 1,
+    start_infinite: bool = False,
+    active_auto_loop_max_iterations: int | None = None,
+    retry_loop_requested: bool = False,
+) -> ShipResult:
+    """Simulate the fail-closed main promotion gate from promoter-resolved facts."""
+    if manifest.get("target") != _TARGET_MAIN:
+        return ShipResult("not-main", reasons=["manifest target is not main"])
+    cap_block = bounded_main_without_cap_blocker(
+        target=_TARGET_MAIN,
+        target_manifest_count=target_manifest_count,
+        distinct_main_source_sha_count=distinct_main_source_sha_count,
+        start_infinite=start_infinite,
+        active_auto_loop_max_iterations=active_auto_loop_max_iterations,
+        retry_loop_requested=retry_loop_requested,
+    )
+    if cap_block is not None:
+        return cap_block
+    if not gates.protection_verified:
+        return ShipResult("main-blocked-protection", reasons=["main branch protection not verified"])
+    if not gates.token_verified:
+        return ShipResult("main-blocked-token", reasons=["merge token not verified as non-admin"])
+    if not gates.ci_green:
+        return ShipResult("main-blocked-ci", reasons=["promoter-resolved CI is not green"])
+    if not review_gate_clean(
+        gates.review_decision,
+        gates.unresolved_non_outdated_threads,
+        api_error=gates.api_error,
+    ):
+        return ShipResult("main-blocked-review", reasons=["review gate is not clean"])
+    source_sha = manifest.get("source_sha")
+    if gates.pr_head_sha != source_sha:
+        return ShipResult("main-blocked-source-mismatch", reasons=["PR head SHA differs from manifest"])
+    protected_paths = manifest.get("protected_paths_changed") or []
+    if protected_paths and not guard_change_ack_valid(
+        ack,
+        source_sha=source_sha,
+        protected_paths=protected_paths,
+    ):
+        return ShipResult("main-blocked-guard-ack", reasons=["protected path change lacks external ack"])
+    return ShipResult("main-merge-allowed")
+
+
+class PromotionLock:
+    """Small cross-process lock primitive for promotion critical sections."""
+
+    def __init__(self, lock_path: str | os.PathLike[str]):
+        self.lock_path = Path(lock_path)
+        self._fd: int | None = None
+
+    def __enter__(self) -> "PromotionLock":
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._fd = os.open(str(self.lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as exc:
+            raise EnforcementNotVerified(f"promotion lock already held: {self.lock_path}") from exc
+        os.write(self._fd, str(os.getpid()).encode("ascii"))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+        try:
+            self.lock_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def archive_ship_manifest(manifest_dir: str | os.PathLike[str]) -> None:
@@ -255,7 +605,7 @@ def archive_ship_manifest(manifest_dir: str | os.PathLike[str]) -> None:
     Called ONLY after a successful ship so the manifest can never be re-consumed once
     its work landed. ``os.replace`` is atomic; a no-op when the source manifest is
     already gone (idempotent). NOTE: the D1 ``main()`` harness never ships, so it does
-    not archive — archiving belongs to the deferred P2.2 merge orchestration.
+    not archive — archiving belongs only to successful live staging / main promotion.
     """
     directory = Path(manifest_dir)
     src = directory / SHIP_MANIFEST_FILENAME
@@ -325,6 +675,26 @@ class DailyMergeCapCounter:
         self.store.increment(day)
 
 
+class SingleInvocationCounterStore:
+    """Bounded staging-only counter for one explicit CLI invocation.
+
+    This is not the deferred durable cap store for main promotion. It is intentionally
+    process-local and only supports the v1 rule "one live staging merge attempt per
+    explicit invocation".
+    """
+
+    loop_writable = False
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+
+    def get(self, day: str) -> int:
+        return self._counts.get(day, 0)
+
+    def increment(self, day: str) -> None:
+        self._counts[day] = self._counts.get(day, 0) + 1
+
+
 # --------------------------------------------------------------------------- #
 # Git/gh operations interface (injectable for tests)
 # --------------------------------------------------------------------------- #
@@ -343,7 +713,7 @@ class GitOps(Protocol):
         """True only when ALL required status checks reported SUCCESS (pending/absent -> False)."""
         ...
 
-    def merge(self, pr_id: str) -> None: ...
+    def merge(self, pr_id: str, *, match_head_commit: str | None = None) -> None: ...
 
 
 @dataclass
@@ -365,7 +735,15 @@ class StagingShipLane:
     target_branch: str = _STAGING_EXACT
     require_external_enforcement: bool = True
 
-    def ship(self, *, source: str, title: str, body: str, day: str) -> ShipResult:
+    def ship(
+        self,
+        *,
+        source: str,
+        title: str,
+        body: str,
+        day: str,
+        source_sha: str = "",
+    ) -> ShipResult:
         # 1) mutual exclusion with ship-arm (ADR 0088 §7)
         assert_ship_arm_not_active(self.repo_root)
         # 2) kill-switch (checked before any side effect)
@@ -396,7 +774,10 @@ class StagingShipLane:
         if not self.ops.required_checks_all_success(pr_id):
             self.failures.record_failure()
             return ShipResult("blocked-ci", pr_id=pr_id, reasons=["required checks not all SUCCESS"])
-        self.ops.merge(pr_id)
+        if source_sha:
+            self.ops.merge(pr_id, match_head_commit=source_sha)
+        else:
+            self.ops.merge(pr_id)
         self.merge_cap.record_merge(day)
         self.failures.record_success()
         return ShipResult("shipped", pr_id=pr_id)
@@ -406,19 +787,18 @@ class StagingShipLane:
 # Real git/gh ops (used by the CLI). Runner is injectable so the methods are
 # unit-testable without touching the network.
 #
-# D1 split: ``protection_verified`` is LIVE (read-only) — it actually queries the
-# GitHub branch protection. The side-effecting merge orchestration (open_pr / merge /
-# required_checks_all_success) is DEFERRED to P2.2 and kept as honest stubs that
-# refuse rather than fake.
+# Split: ``protection_verified`` is LIVE read-only. The side-effecting staging
+# methods are implemented but are only reachable from the CLI through the explicit
+# ``--execute-live-staging`` flag; the default CLI path remains verify-and-refuse.
 # --------------------------------------------------------------------------- #
 class _RealGitOps:
     """Shells out to git/gh via an injectable runner.
 
     ``protection_verified`` read-verifies the *actual* GitHub branch protection
     (the ``staging-self-ship-guard`` required check is present + force-push denied);
-    there is no env-trust bypass. The merge-orchestration methods are deferred to
-    P2.2 and raise/return so this lane can verify external enforcement read-only
-    without yet auto-merging.
+    there is no env-trust bypass. Mutation methods use only the permission-separated
+    ``BIDMATE_SHIP_MERGE_TOKEN`` mapped to ``GH_TOKEN`` and never pass ``--admin`` or
+    ``--delete-branch``.
     """
 
     def __init__(self, run=None, repo_root="."):
@@ -441,7 +821,7 @@ class _RealGitOps:
             env = {
                 k: v
                 for k, v in os.environ.items()
-                if k not in _GH_AMBIENT_DROP_KEYS
+                if k not in _GH_AMBIENT_DROP_KEYS and k != _SHIP_MERGE_TOKEN_ENV
             }
         return self._run(
             argv,
@@ -453,6 +833,51 @@ class _RealGitOps:
             timeout=_GH_TIMEOUT_SEC,
         )
 
+    def _repo_identity(self) -> tuple[str, str] | None:
+        """Return (owner, repo) resolved from this repo root, or None on failure."""
+        try:
+            view = self._gh(["gh", "repo", "view", "--json", "owner,name"])
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if view.returncode != 0:
+            return None
+        try:
+            repo = json.loads(view.stdout)
+            owner = repo["owner"]["login"]
+            name = repo["name"]
+        except (ValueError, KeyError, TypeError):
+            return None
+        if not isinstance(owner, str) or not isinstance(name, str) or not owner or not name:
+            return None
+        return owner, name
+
+    def _mutation_env(self) -> dict[str, str]:
+        token = os.environ.get(_SHIP_MERGE_TOKEN_ENV, "").strip()
+        if not token:
+            raise EnforcementNotVerified(
+                f"{_SHIP_MERGE_TOKEN_ENV} is required for live self-ship mutation"
+            )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in _GH_AMBIENT_DROP_KEYS and k != _SHIP_MERGE_TOKEN_ENV
+        }
+        env["GH_TOKEN"] = token
+        return env
+
+    def _pr_view(self, source: str) -> dict | None:
+        proc = self._gh(
+            ["gh", "pr", "view", source, "--json", "number,baseRefName,headRefOid,state"],
+            env=self._mutation_env(),
+        )
+        if proc.returncode != 0:
+            return None
+        try:
+            data = json.loads(proc.stdout)
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
+
     def protection_verified(self, branch: str) -> bool:
         # Fail CLOSED on ANY environmental failure of the gh subprocess (issue #1697
         # BLOCKING): gh missing (FileNotFoundError/OSError), a hung gh
@@ -461,18 +886,10 @@ class _RealGitOps:
         # of this verifier and crash main(). Nonzero rc + unparseable JSON + incomplete
         # protection state are handled below and likewise fail closed.
         # Derive owner/repo for the gh api path.
-        try:
-            view = self._gh(["gh", "repo", "view", "--json", "owner,name"])
-        except (OSError, subprocess.SubprocessError):
+        repo = self._repo_identity()
+        if repo is None:
             return False
-        if view.returncode != 0:
-            return False
-        try:
-            repo = json.loads(view.stdout)
-            owner = repo["owner"]["login"]
-            name = repo["name"]
-        except (ValueError, KeyError, TypeError):
-            return False
+        owner, name = repo
         # URL-encode the branch (staging branches contain a slash, e.g.
         # ``autopilot/integration`` -> ``autopilot%2Fintegration``) so the gh api
         # path is not malformed (informational #1 / G4).
@@ -529,38 +946,238 @@ class _RealGitOps:
             return False
         return True
 
-    def open_pr(self, *, source: str, base: str, title: str, body: str) -> str:
-        raise EnforcementNotVerified(
-            "live merge orchestration is deferred to P2.2; this lane verifies external "
-            "enforcement but does not yet auto-merge"
+    def resolve_review_gate(
+        self,
+        pr_id: str | int,
+        *,
+        page_size: int = _REVIEW_THREADS_PAGE_SIZE,
+        max_pages: int = _REVIEW_THREADS_MAX_PAGES,
+    ) -> ReviewGateResolution:
+        """Read-only GraphQL resolver for main review-gate facts.
+
+        The clean path is intentionally narrow: ``reviewDecision == APPROVED`` and
+        every non-outdated review thread is resolved. Any gh/API/schema/pagination
+        failure returns ``api_error=True`` so callers fail closed.
+        """
+        try:
+            pr_number = int(str(pr_id))
+        except (TypeError, ValueError):
+            return _review_gate_api_error()
+        if pr_number <= 0 or not (1 <= page_size <= 100) or max_pages <= 0:
+            return _review_gate_api_error()
+        repo = self._repo_identity()
+        if repo is None:
+            return _review_gate_api_error()
+        owner, name = repo
+        after: str | None = None
+        review_decision: str | None = None
+        unresolved_non_outdated = 0
+        for page_idx in range(max_pages):
+            argv = [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={_REVIEW_GATE_QUERY}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={pr_number}",
+                "-F",
+                f"first={page_size}",
+            ]
+            if after is not None:
+                argv.extend(["-F", f"after={after}"])
+            try:
+                proc = self._gh(argv)
+            except (OSError, subprocess.SubprocessError):
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            if proc.returncode != 0:
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            try:
+                payload = json.loads(proc.stdout)
+            except ValueError:
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            if not isinstance(payload, dict) or payload.get("errors"):
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            data = payload.get("data")
+            if not isinstance(data, dict):
+                return _review_gate_api_error(fetched_thread_pages=page_idx)
+            repository = data.get("repository")
+            if not isinstance(repository, dict):
+                return _review_gate_api_error(fetched_thread_pages=page_idx)
+            pull_request = repository.get("pullRequest")
+            if not isinstance(pull_request, dict):
+                return _review_gate_api_error(fetched_thread_pages=page_idx)
+            raw_decision = pull_request.get("reviewDecision")
+            if raw_decision is not None and not isinstance(raw_decision, str):
+                return _review_gate_api_error(fetched_thread_pages=page_idx)
+            review_decision = raw_decision
+            threads = pull_request.get("reviewThreads")
+            if not isinstance(threads, dict):
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            nodes = threads.get("nodes")
+            page_info = threads.get("pageInfo")
+            if not isinstance(nodes, list) or not isinstance(page_info, dict):
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=page_idx,
+                )
+            for node in nodes:
+                if not isinstance(node, dict):
+                    return _review_gate_api_error(
+                        review_decision=review_decision,
+                        fetched_thread_pages=page_idx,
+                    )
+                is_resolved = node.get("isResolved")
+                is_outdated = node.get("isOutdated")
+                if not isinstance(is_resolved, bool) or not isinstance(is_outdated, bool):
+                    return _review_gate_api_error(
+                        review_decision=review_decision,
+                        fetched_thread_pages=page_idx,
+                    )
+                if not is_resolved and not is_outdated:
+                    unresolved_non_outdated += 1
+            has_next = page_info.get("hasNextPage")
+            end_cursor = page_info.get("endCursor")
+            fetched_pages = page_idx + 1
+            if not isinstance(has_next, bool):
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=fetched_pages,
+                )
+            if not has_next:
+                return ReviewGateResolution(
+                    review_decision=review_decision,
+                    unresolved_non_outdated_threads=unresolved_non_outdated,
+                    fetched_thread_pages=fetched_pages,
+                    api_error=False,
+                )
+            if not isinstance(end_cursor, str) or not end_cursor:
+                return _review_gate_api_error(
+                    review_decision=review_decision,
+                    fetched_thread_pages=fetched_pages,
+                )
+            after = end_cursor
+        return _review_gate_api_error(
+            review_decision=review_decision,
+            fetched_thread_pages=max_pages,
         )
+
+    def open_pr(self, *, source: str, base: str, title: str, body: str) -> str:
+        existing = self._pr_view(source)
+        if existing is not None:
+            if existing.get("baseRefName") != base:
+                raise EnforcementNotVerified(
+                    f"existing PR for {source!r} targets {existing.get('baseRefName')!r}, "
+                    f"not expected base {base!r}"
+                )
+            if existing.get("state") != "OPEN":
+                raise EnforcementNotVerified(f"existing PR for {source!r} is not open")
+            return str(existing["number"])
+        proc = self._gh(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--head",
+                source,
+                "--base",
+                base,
+                "--title",
+                title,
+                "--body",
+                body,
+                "--no-maintainer-edit",
+            ],
+            env=self._mutation_env(),
+        )
+        if proc.returncode != 0:
+            raise EnforcementNotVerified("gh pr create failed")
+        created = self._pr_view(source)
+        if created is None or created.get("baseRefName") != base or created.get("state") != "OPEN":
+            raise EnforcementNotVerified("created PR could not be re-read/bound to expected base")
+        return str(created["number"])
 
     def required_checks_all_success(self, pr_id: str) -> bool:
-        return False
+        try:
+            proc = self._gh(
+                [
+                    "gh",
+                    "pr",
+                    "checks",
+                    str(pr_id),
+                    "--required",
+                    "--json",
+                    "name,state,bucket",
+                ],
+                env=self._mutation_env(),
+            )
+        except (OSError, subprocess.SubprocessError, EnforcementNotVerified):
+            return False
+        if proc.returncode != 0:
+            return False
+        try:
+            checks = json.loads(proc.stdout)
+        except ValueError:
+            return False
+        if not isinstance(checks, list) or not checks:
+            return False
+        return all(isinstance(item, dict) and item.get("bucket") == "pass" for item in checks)
 
-    def merge(self, pr_id: str) -> None:
-        raise EnforcementNotVerified(
-            "live merge orchestration is deferred to P2.2; this lane verifies external "
-            "enforcement but does not yet auto-merge"
+    def merge(self, pr_id: str, *, match_head_commit: str | None = None) -> None:
+        if not match_head_commit or not _SHA_RE.match(match_head_commit):
+            raise EnforcementNotVerified("merge requires a 40-char source_sha for --match-head-commit")
+        proc = self._gh(
+            [
+                "gh",
+                "pr",
+                "merge",
+                str(pr_id),
+                "--squash",
+                "--match-head-commit",
+                match_head_commit,
+            ],
+            env=self._mutation_env(),
         )
+        if proc.returncode != 0:
+            raise EnforcementNotVerified("gh pr merge failed")
 
 
 def main(argv: list[str] | None = None) -> int:
-    """D1 verify-and-refuse harness — NEVER merges.
+    """Verify-first harness; live staging requires an explicit flag.
 
     Reads the ship manifest (loop → lane hand-off), runs the cheap local guards, and
-    LIVE-verifies the external GitHub branch protection (read-only). It ALWAYS returns
-    2 (blocked-on-user) because the autonomous merge orchestration (PR open/merge,
-    daily-cap transactionality, serialized promotion, source-SHA binding) is deferred
-    to P2.2. This is an honest pre-flight; nothing is faked.
+    LIVE-verifies the external GitHub branch protection (read-only). By default it
+    returns 2 (blocked-on-user) after verification. Only ``--execute-live-staging``
+    may create/check/merge a staging PR, and even then it requires ``source_sha`` so
+    merge uses ``--match-head-commit``.
     """
     parser = argparse.ArgumentParser(
-        description="P2.0 D1 staging self-ship pre-flight harness (ADR 0088/0090); does NOT merge"
+        description="staging self-ship verify-first harness (ADR 0088/0090); live merge requires --execute-live-staging"
     )
     parser.add_argument("--source", default="", help="source branch to ship")
     parser.add_argument("--title", default="")
     parser.add_argument("--body", default="")
     parser.add_argument("--day", default="")
+    parser.add_argument("--source-sha", default="", help="40-char source SHA for --match-head-commit")
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--state-dir", default=".omc/state")
     parser.add_argument(
@@ -568,10 +1185,16 @@ def main(argv: list[str] | None = None) -> int:
         default="",
         help="dir holding ship_manifest.json (defaults to --state-dir)",
     )
+    parser.add_argument(
+        "--execute-live-staging",
+        action="store_true",
+        help="explicitly create/check/merge a staging PR; default remains verify-and-refuse",
+    )
     args = parser.parse_args(argv)
 
     # 1) Read the manifest (loop -> lane hand-off). The read is idempotent — D1 never
-    #    ships, so it never archives the manifest (consumption belongs to P2.2).
+    #    ships, so it never archives the manifest (consumption belongs to successful
+    #    live staging / main promotion).
     manifest_dir = args.manifest_dir or args.state_dir
     try:
         manifest = read_ship_manifest(manifest_dir)
@@ -583,13 +1206,17 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     if manifest is not None:
         source = manifest["source_branch"]
+        source_sha = manifest["source_sha"]
         title = manifest["title"]
         body = manifest["body"]
         day = manifest["day"]
+        target = manifest["target"]
     else:
-        source = title = body = day = ""
+        source = source_sha = title = body = day = ""
+        target = _TARGET_STAGING
     # CLI flags override manifest fields when non-empty.
     source = args.source or source
+    source_sha = args.source_sha or source_sha
     title = args.title or title
     body = args.body or body
     day = args.day or day
@@ -638,29 +1265,72 @@ def main(argv: list[str] | None = None) -> int:
     # 3b) No work to ship (no manifest AND no --source). The live protection pre-flight
     #     above has already run + reported (issue #1697 Fix 2), so the headline D-minus
     #     value is exercised even on the default path. Refuse rc 2 — there is nothing
-    #     to hand to the (deferred) P2.2 merge orchestration.
+    #     to hand to explicit live staging / deferred main promotion.
     if manifest is None and not args.source:
         sys.stderr.write("[staging-self-ship] blocked-on-user: no ship manifest\n")
         return 2
 
-    # 4) ALWAYS refuse to merge in D1, but the message must be HONEST about whether
+    if args.execute_live_staging:
+        if target != _TARGET_STAGING:
+            sys.stderr.write(
+                f"[staging-self-ship] blocked-on-user: live CLI only supports target={_TARGET_STAGING!r}\n"
+            )
+            return 2
+        if not source_sha or not _SHA_RE.match(source_sha):
+            sys.stderr.write(
+                "[staging-self-ship] blocked-on-user: --execute-live-staging requires "
+                "manifest source_sha or --source-sha for --match-head-commit\n"
+            )
+            return 2
+        if not enforcement_verified:
+            sys.stderr.write(
+                "[staging-self-ship] blocked-on-user: external enforcement must verify before live staging\n"
+            )
+            return 2
+        lane = StagingShipLane(
+            ops=ops,
+            repo_root=args.repo_root,
+            state_dir=args.state_dir,
+            merge_cap=DailyMergeCapCounter(store=SingleInvocationCounterStore(), cap=1),
+        )
+        try:
+            result = lane.ship(
+                source=source,
+                title=title,
+                body=body,
+                day=day,
+                source_sha=source_sha,
+            )
+        except (ShipArmConflict, StagingBoundaryViolation, ForcePushForbidden, EnforcementNotVerified) as exc:
+            sys.stderr.write(f"[staging-self-ship] blocked-on-user: live staging failed: {exc}\n")
+            return 2
+        if result.decision == "shipped":
+            archive_ship_manifest(manifest_dir)
+            sys.stderr.write(
+                f"[staging-self-ship] staging-merged: pr={result.pr_id} source_sha={source_sha}\n"
+            )
+            return 0
+        sys.stderr.write(
+            f"[staging-self-ship] {result.decision}: {'; '.join(result.reasons)}\n"
+        )
+        return 2
+
+    # 4) Default path refuses to merge, but the message must be HONEST about whether
     #    protection was actually verified (codex Fix 4): only claim "verified
     #    read-only" when the live check returned True; otherwise focus on the
-    #    unverified/unreachable enforcement. Either way autonomous merge orchestration
-    #    is deferred to P2.2.
+    #    unverified/unreachable enforcement. Live mutation requires the explicit
+    #    --execute-live-staging flag above.
     if enforcement_verified:
         sys.stderr.write(
             "[staging-self-ship] blocked-on-user: enforcement model verified read-only, but "
-            "autonomous merge orchestration (PR open/merge, daily-cap transactionality, "
-            "serialized promotion, source-SHA binding) is deferred to P2.2 — this lane does "
-            "not yet auto-merge.\n"
+            "default mode does not auto-merge. Re-run with --execute-live-staging only "
+            "when the manifest source_sha is the exact commit to merge.\n"
         )
     else:
         sys.stderr.write(
             "[staging-self-ship] blocked-on-user: external enforcement NOT verified / not "
             "reachable (required staging-self-ship-guard check, explicit force-push-deny, and "
-            "enforce_admins not confirmed). Autonomous merge orchestration is also deferred to "
-            "P2.2 — this lane does not yet auto-merge.\n"
+            "enforce_admins not confirmed). Default mode does not auto-merge.\n"
         )
     return 2
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -5967,6 +5967,20 @@ def _current_git_head(repo_root: Path) -> str | None:
     return result.stdout.strip() or None
 
 
+def _current_git_head_full(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    head = result.stdout.strip()
+    return head if re.fullmatch(r"[0-9a-f]{40}", head) else None
+
+
 def _open_pr_for_branch(branch: str | None, *, repo_root: Path) -> str | None:
     if not branch or branch in {"HEAD", "main", "master", "unknown"}:
         return None
@@ -7033,6 +7047,127 @@ def _changed_files_hash(changed_files: Sequence[str], *, repo_root: Path) -> str
         payload.append({"path": display, "content_hash": content_hash})
     raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _ship_manifest_ignorable_dirty_path(path: str) -> bool:
+    normalized = path.strip().lstrip("./")
+    return normalized == "reports/agent_loop" or normalized.startswith("reports/agent_loop/")
+
+
+def _maybe_emit_active_ship_manifest(
+    *,
+    enabled: bool,
+    execute_ship: bool,
+    task_pool_size: int,
+    cycles: Sequence[dict[str, object]],
+    source_branch: str | None,
+    manifest_dir: Path,
+    ship_day: str | None,
+    repo_root: Path,
+) -> dict[str, object] | None:
+    """Write the loop→ship-lane manifest when the opt-in seam is safely satisfied.
+
+    This is deliberately a *file hand-off*, not a merge. The source SHA is the
+    current full git HEAD, and the seam refuses to emit when local non-report edits
+    are uncommitted because the manifest's ``source_sha`` would not cover them.
+    """
+    if not enabled:
+        return None
+    result: dict[str, object] = {
+        "enabled": True,
+        "emitted": False,
+        "reason": "not evaluated",
+    }
+    if execute_ship:
+        result["reason"] = "execute_ship already uses the legacy ship-run lane"
+        return result
+    if task_pool_size != 1:
+        result["reason"] = "ship manifest emission requires serial task_pool=1"
+        return result
+    completed_cycles = [cycle for cycle in cycles if cycle.get("completed") is True]
+    if len(completed_cycles) != 1:
+        result["reason"] = f"expected exactly one completed cycle, found {len(completed_cycles)}"
+        return result
+    cycle = completed_cycles[0]
+    if cycle.get("completion_decision") != "local-gate-complete":
+        result["reason"] = "completed cycle was not a local-gate-complete handoff"
+        return result
+    if cycle.get("gate_ready") is not True or cycle.get("privacy_clean") is not True:
+        result["reason"] = "gate evidence is not ready and privacy-clean"
+        return result
+    if not source_branch or not _branch_is_issue_linked(source_branch):
+        result["reason"] = "source branch is not an issue-linked feature branch"
+        return result
+    source_sha = _current_git_head_full(repo_root)
+    if source_sha is None:
+        result["reason"] = "could not bind source_sha to full git HEAD"
+        return result
+    try:
+        dirty_paths = _changed_files_from_git(repo_root)
+    except ValueError as exc:
+        result["reason"] = f"could not verify git dirty state: {exc}"
+        return result
+    non_report_dirty = [
+        path for path in dirty_paths if not _ship_manifest_ignorable_dirty_path(path)
+    ]
+    if non_report_dirty:
+        result["reason"] = "non-report working tree edits are uncommitted: " + ", ".join(
+            non_report_dirty[:5]
+        )
+        return result
+    gate_evidence_raw = str(cycle.get("gate_evidence") or "").strip()
+    if not gate_evidence_raw:
+        result["reason"] = "completed cycle has no gate evidence path"
+        return result
+    gate_path = Path(gate_evidence_raw)
+    if not gate_path.is_absolute():
+        gate_path = repo_root / gate_evidence_raw
+    if not gate_path.is_file():
+        result["reason"] = f"gate evidence file is missing: {gate_evidence_raw}"
+        return result
+    gate_rel = _repo_path(gate_path, repo_root)
+    gate_digest = "sha256:" + hashlib.sha256(gate_path.read_bytes()).hexdigest()
+    changed_files = [
+        _normalize_changed_file(str(path), repo_root=repo_root)
+        for path in cycle.get("changed_files", [])
+        if path
+    ] if isinstance(cycle.get("changed_files"), list) else []
+    task_id = str(cycle.get("task_id") or "")
+    title_text = _sanitize_inline_text(str(cycle.get("title") or "Agent loop task"))
+    from scripts._staging_ship import (  # noqa: PLC0415
+        detect_self_ship_protected_paths,
+        write_ship_manifest,
+    )
+
+    manifest_path = write_ship_manifest(
+        _active_path(manifest_dir, repo_root=repo_root),
+        source_branch=source_branch,
+        source_sha=source_sha,
+        title=f"{task_id}: {title_text}" if task_id else title_text,
+        body=(
+            "Automated staging self-ship candidate.\n\n"
+            f"- Task: {task_id or 'N/A'}\n"
+            f"- Gate evidence: `{gate_rel}`\n"
+            "- Authority remains with staging branch protection and live required checks."
+        ),
+        day=ship_day or datetime.now(timezone.utc).date().isoformat(),
+        gate_evidence_path=gate_rel,
+        gate_evidence_digest=gate_digest,
+        protected_paths_changed=detect_self_ship_protected_paths(tuple(changed_files)),
+        ci_evidence_ref="staging-live-required-checks",
+        review_gate_ref="staging-live-pr-review",
+    )
+    return {
+        "enabled": True,
+        "emitted": True,
+        "reason": "local gate complete",
+        "path": _repo_path(manifest_path, repo_root),
+        "task_id": task_id,
+        "source_branch": source_branch,
+        "source_sha": source_sha,
+        "gate_evidence_path": gate_rel,
+        "gate_evidence_digest": gate_digest,
+    }
 
 
 def write_eval_run_manifest(
@@ -11285,6 +11420,9 @@ def write_active_auto_loop(
     target_completed_count: int | None = None,
     execute_runner: bool = False,
     execute_ship: bool = False,
+    emit_ship_manifest: bool = False,
+    ship_manifest_dir: Path = DEFAULT_ACTIVE_DIR,
+    ship_day: str | None = None,
     auto_repair: bool = False,
     record_gate_heartbeats: bool = True,
     task_id: str | None = None,
@@ -12533,6 +12671,28 @@ def write_active_auto_loop(
     else:
         decision = "planned"
 
+    ship_manifest_emission = _maybe_emit_active_ship_manifest(
+        enabled=emit_ship_manifest,
+        execute_ship=execute_ship,
+        task_pool_size=effective_task_pool_size,
+        cycles=cycles,
+        source_branch=parent_branch,
+        manifest_dir=ship_manifest_dir,
+        ship_day=ship_day,
+        repo_root=repo_root,
+    )
+    if ship_manifest_emission is not None:
+        if ship_manifest_emission.get("emitted") is True:
+            warnings.append(
+                "ship manifest emitted: "
+                + str(ship_manifest_emission.get("path", "unknown"))
+            )
+        else:
+            warnings.append(
+                "ship manifest not emitted: "
+                + str(ship_manifest_emission.get("reason", "unknown"))
+            )
+
     # T-X1 (agent-loop integration plan): advisory-only learning-capture pointer,
     # recorded only when the loop actually ran a cycle. Never writes to the
     # wiki/memory or invokes any agent (call-only); decision/control flow unchanged.
@@ -12574,6 +12734,8 @@ def write_active_auto_loop(
         # locked snapshot uniformly with the checkpoint reader. Uncontended at X==1 -> byte-identical.
         "warnings": _dedupe_preserve_order(warnings.snapshot()),
     }
+    if ship_manifest_emission is not None:
+        state_payload["ship_manifest_emission"] = ship_manifest_emission
     # ADR 0092 (AC8/AC13): emit recommendations + cooldown_state on the terminal state write
     # too (this block, not write_cycle_checkpoint, is the final state file). The persisted
     # cooldown_state is what _load_active_lane_stats reads on the NEXT run so a just-actuated
@@ -12619,6 +12781,11 @@ def write_active_auto_loop(
             "blockers": blockers,
             "learning_capture_advisory": bool(learning_advisory),
             "adr_lifecycle_advisory": bool(adr_lifecycle_advisory),
+            "ship_manifest_emitted": (
+                bool(ship_manifest_emission.get("emitted"))
+                if ship_manifest_emission is not None
+                else False
+            ),
         },
     )
     return ActiveAutoLoopResult(
@@ -21279,6 +21446,13 @@ def build_parser() -> argparse.ArgumentParser:
     auto_loop.add_argument("--target-completed-count", type=int)
     auto_loop.add_argument("--execute-runner", action="store_true")
     auto_loop.add_argument("--execute-ship", action="store_true")
+    auto_loop.add_argument(
+        "--emit-ship-manifest",
+        action="store_true",
+        help="Opt-in: write ship_manifest.json after exactly one local-gate-complete cycle.",
+    )
+    auto_loop.add_argument("--ship-manifest-dir", type=Path, default=DEFAULT_ACTIVE_DIR)
+    auto_loop.add_argument("--ship-day")
     auto_loop.add_argument("--auto-repair", action=argparse.BooleanOptionalAction, default=False)
     auto_loop.add_argument("--record-gate-heartbeats", action=argparse.BooleanOptionalAction, default=True)
     auto_loop.add_argument("--task")
@@ -22374,6 +22548,9 @@ def main(argv: list[str] | None = None) -> int:
                 target_completed_count=args.target_completed_count,
                 execute_runner=args.execute_runner,
                 execute_ship=args.execute_ship,
+                emit_ship_manifest=args.emit_ship_manifest,
+                ship_manifest_dir=args.ship_manifest_dir,
+                ship_day=args.ship_day,
                 auto_repair=args.auto_repair,
                 record_gate_heartbeats=args.record_gate_heartbeats,
                 task_id=args.task,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4644,6 +4644,23 @@ def test_make_active_start_can_disable_runner_and_has_korean_alias() -> None:
     assert '--auth-mode "chatgpt"' in alias.stdout
 
 
+def test_make_start_ship_enables_manifest_emission_without_legacy_ship_run() -> None:
+    result = subprocess.run(
+        ["make", "-n", "시작-ship"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "ACTIVE_TASK_POOL=1" in result.stdout
+    assert "ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST=1" in result.stdout
+    assert "--emit-ship-manifest" in result.stdout
+    assert '--ship-manifest-dir "reports/agent_loop/active"' in result.stdout
+    assert "--execute-ship" not in result.stdout
+
+
 def test_active_auto_loop_completes_task_and_picks_next_from_state(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path, task_id="T-2026-1001", title="First task")
     queue = repo / "tasks" / "queue.md"
@@ -4761,6 +4778,153 @@ def test_active_auto_loop_local_gate_completion_without_ship(monkeypatch, tmp_pa
     assert result.completed_task_ids == ("T-2026-1001",)
     assert result.cycles[0]["completion_decision"] == "local-gate-complete"
     assert any("recorded local gate completion" in warning for warning in result.warnings)
+
+
+def test_active_auto_loop_emits_ship_manifest_after_single_local_gate_completion(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Manifest seam task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"ready": true, "privacy_clean": true}\n', encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+    monkeypatch.setattr(agent_loop, "_current_git_head_full", lambda repo_root: source_sha)
+    monkeypatch.setattr(
+        agent_loop,
+        "_changed_files_from_git",
+        lambda repo_root: ["reports/agent_loop/active/auto_loop.md"],
+    )
+
+    result = agent_loop.write_active_auto_loop(
+        task_pool=1,
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=False,
+        emit_ship_manifest=True,
+        ship_manifest_dir=active_dir,
+        ship_day="2026-06-06",
+        repo_root=repo,
+    )
+
+    manifest_path = active_dir / "ship_manifest.json"
+    assert result.decision == "limit-reached"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 2
+    assert manifest["source_branch"] == "chore/issue-9999-active-loop"
+    assert manifest["source_sha"] == source_sha
+    assert manifest["target"] == "staging"
+    assert manifest["base_branch"] == "autopilot/integration"
+    assert manifest["day"] == "2026-06-06"
+    assert manifest["gate_evidence_path"] == "reports/agent_loop/active/gate_evidence/T-2026-1001/evidence.json"
+    assert manifest["gate_evidence_digest"].startswith("sha256:")
+    assert any("ship manifest emitted" in warning for warning in result.warnings)
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["ship_manifest_emission"]["emitted"] is True
+
+
+def test_active_auto_loop_does_not_emit_ship_manifest_by_default(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="No manifest by default")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+
+    result = agent_loop.write_active_auto_loop(
+        task_pool=1,
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "limit-reached"
+    assert not (active_dir / "ship_manifest.json").exists()
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert "ship_manifest_emission" not in state
+
+
+def test_active_auto_loop_blocks_ship_manifest_when_non_report_edits_are_uncommitted(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-1001", title="Dirty tree task")
+    _patch_active_loop_clear(monkeypatch)
+    active_dir = repo / "reports" / "agent_loop" / "active"
+
+    def fake_runner(**kwargs):  # type: ignore[no-untyped-def]
+        report = active_dir / "codex_runner.md"
+        state = active_dir / "codex_runner_state.json"
+        runs = active_dir / "codex_runs"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# runner\n", encoding="utf-8")
+        state.write_text("{}\n", encoding="utf-8")
+        return agent_loop.ActiveCodexRunnerResult(report, state, runs, "completed", (), (), ())
+
+    def fake_gate(*, task_id, **kwargs):  # type: ignore[no-untyped-def]
+        path = active_dir / "gate_evidence" / task_id / "evidence.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"ready": True, "privacy_clean": True}
+
+    monkeypatch.setattr(agent_loop, "write_active_codex_runner", fake_runner)
+    monkeypatch.setattr(agent_loop, "write_active_gate_evidence", fake_gate)
+    monkeypatch.setattr(
+        agent_loop,
+        "_current_git_head_full",
+        lambda repo_root: "0123456789abcdef0123456789abcdef01234567",
+    )
+    monkeypatch.setattr(agent_loop, "_changed_files_from_git", lambda repo_root: ["scripts/agent_loop.py"])
+
+    result = agent_loop.write_active_auto_loop(
+        task_pool=1,
+        max_iterations=1,
+        execute_runner=True,
+        execute_ship=False,
+        emit_ship_manifest=True,
+        ship_manifest_dir=active_dir,
+        repo_root=repo,
+    )
+
+    assert not (active_dir / "ship_manifest.json").exists()
+    assert any("ship manifest not emitted" in warning for warning in result.warnings)
+    state = json.loads((active_dir / "auto_loop_state.json").read_text(encoding="utf-8"))
+    assert state["ship_manifest_emission"]["emitted"] is False
+    assert "uncommitted" in state["ship_manifest_emission"]["reason"]
 
 
 def test_active_auto_loop_absolute_target_stops_when_already_reached(tmp_path: Path) -> None:
@@ -5599,6 +5763,8 @@ def test_active_auto_loop_parser_defaults_align_with_makefile() -> None:
     assert args.read_agent == "auto"
     assert args.write_agent == "auto"
     assert args.max_iterations == "1"
+    assert args.emit_ship_manifest is False
+    assert args.ship_manifest_dir == agent_loop.DEFAULT_ACTIVE_DIR
 
 
 def test_active_auto_loop_infinite_runs_until_ready_queue_drains(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_staging_ship_regression.py
+++ b/tests/test_staging_ship_regression.py
@@ -3,17 +3,18 @@
 Covers the constitutional-invariant guards (force-push / staging boundary /
 kill-switch / ship-arm exclusion), the breaker counters (T1 bounded, T4 cap with
 self-immutable store), the lane (CI-green gate, fail-closed external enforcement),
-the P2.0 ship-manifest contract, and the *live* read-only ``protection_verified``.
-git/gh is injected as a fake so no network/GitHub is touched.
+the schema v2 ship-manifest contract, local main-promotion guard primitives, and
+the *live* read-only ``protection_verified``. git/gh is injected as a fake so no
+network/GitHub is touched.
 
-D1 scope: the autonomous merge orchestration (open_pr/merge LIVE impls, daily-cap
-transactionality, single-instance lock, source-SHA binding, bounded-poll) is deferred
-to P2.2; ``_RealGitOps.open_pr``/``merge`` are honest stubs and ``main()`` is a
-verify-and-refuse harness that always returns rc 2. Those P2.2 behaviours are NOT
-tested here.
+Live mutation scope: staging PR create/check/merge is implemented but only reachable
+through ``--execute-live-staging``. Main promotion mutation is still deferred; the
+GitHub review-thread resolver is read-only. The default CLI path remains
+verify-and-refuse.
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -233,7 +234,7 @@ def test_lane_rejects_raw_payload_in_body(tmp_path):
         )
 
 
-# --- P2.0 ship-manifest contract (US-1) --------------------------------------
+# --- schema v2 ship-manifest contract ----------------------------------------
 
 def test_manifest_round_trips_all_schema_fields(tmp_path):
     ss.write_ship_manifest(
@@ -243,15 +244,30 @@ def test_manifest_round_trips_all_schema_fields(tmp_path):
         title="chore: staging self-ship",
         body="5 PRs merged, revert 0",
         day="2026-05-31",
+        target="main",
+        base_branch="main",
+        gate_evidence_path="reports/agent_loop/active/gate_evidence/T-1/evidence.json",
+        gate_evidence_digest="sha256:0123",
+        protected_paths_changed=["scripts/_staging_ship.py", "Makefile"],
+        ci_evidence_ref="github-checks://pr/1",
+        review_gate_ref="github-review://pr/1",
     )
     data = ss.read_ship_manifest(tmp_path)
     assert data is not None
     assert data["schema_version"] == ss.SHIP_MANIFEST_SCHEMA_VERSION
+    assert data["schema_version"] == 2
     assert data["source_branch"] == "autopilot/work"
     assert data["source_sha"] == "0123456789abcdef0123456789abcdef01234567"
+    assert data["target"] == "main"
+    assert data["base_branch"] == "main"
     assert data["title"] == "chore: staging self-ship"
     assert data["body"] == "5 PRs merged, revert 0"
     assert data["day"] == "2026-05-31"
+    assert data["gate_evidence_path"].endswith("/evidence.json")
+    assert data["gate_evidence_digest"] == "sha256:0123"
+    assert data["protected_paths_changed"] == ["Makefile", "scripts/_staging_ship.py"]
+    assert data["ci_evidence_ref"] == "github-checks://pr/1"
+    assert data["review_gate_ref"] == "github-review://pr/1"
 
 
 def test_manifest_read_is_idempotent_not_consumed(tmp_path):
@@ -323,7 +339,7 @@ def test_manifest_missing_required_key_raises(tmp_path):
 def test_manifest_missing_source_sha_key_raises(tmp_path):
     import json
 
-    # source_sha is part of the D1 required-keys contract (merge-binding for P2.2).
+    # source_sha is part of the required-keys contract (merge-binding).
     payload = {
         "schema_version": ss.SHIP_MANIFEST_SCHEMA_VERSION,
         "source_branch": "autopilot/work",
@@ -343,7 +359,7 @@ def test_manifest_malformed_source_sha_raises(tmp_path, bad_sha):
     import json
 
     # A present-but-malformed source_sha (empty / non-hex / too short / uppercase) must
-    # fail closed — the SHA binds the deferred P2.2 merge to the exact gated commit.
+    # fail closed — the SHA binds live/deferred merge to the exact gated commit.
     payload = {
         "schema_version": ss.SHIP_MANIFEST_SCHEMA_VERSION,
         "source_branch": "autopilot/work",
@@ -367,9 +383,16 @@ def test_manifest_valid_40_hex_source_sha_ok(tmp_path):
         "schema_version": ss.SHIP_MANIFEST_SCHEMA_VERSION,
         "source_branch": "autopilot/work",
         "source_sha": sha,
+        "target": "staging",
+        "base_branch": "autopilot/integration",
         "title": "t",
         "body": "ok 1",
         "day": "d1",
+        "gate_evidence_path": "reports/agent_loop/active/gate_evidence/T/evidence.json",
+        "gate_evidence_digest": "sha256:abc",
+        "protected_paths_changed": [],
+        "ci_evidence_ref": "ci://staging",
+        "review_gate_ref": "review://staging",
     }
     (tmp_path / ss.SHIP_MANIFEST_FILENAME).write_text(
         json.dumps(payload), encoding="utf-8"
@@ -383,18 +406,314 @@ def test_manifest_wrong_schema_version_raises(tmp_path):
     import json
 
     payload = {
-        "schema_version": 999,
+        "schema_version": 1,
         "source_branch": "autopilot/work",
         "source_sha": "0123456789abcdef0123456789abcdef01234567",
         "title": "t",
         "body": "ok 1",
         "day": "d1",
+        "target": "staging",
+        "base_branch": "autopilot/integration",
+        "gate_evidence_path": "evidence.json",
+        "gate_evidence_digest": "sha256:abc",
+        "protected_paths_changed": [],
+        "ci_evidence_ref": "ci://x",
+        "review_gate_ref": "review://x",
+        "supplemental_manifest": {"target": "main"},
     }
     (tmp_path / ss.SHIP_MANIFEST_FILENAME).write_text(
         json.dumps(payload), encoding="utf-8"
     )
     with pytest.raises(ValueError):
         ss.read_ship_manifest(tmp_path)
+
+
+def test_manifest_rejects_invalid_target(tmp_path):
+    import json
+
+    ss.write_ship_manifest(
+        tmp_path,
+        source_branch="autopilot/work",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        title="t",
+        body="ok 1",
+        day="d1",
+    )
+    path = tmp_path / ss.SHIP_MANIFEST_FILENAME
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["target"] = "production"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError):
+        ss.read_ship_manifest(tmp_path)
+
+
+def test_manifest_rejects_non_list_protected_paths(tmp_path):
+    import json
+
+    ss.write_ship_manifest(
+        tmp_path,
+        source_branch="autopilot/work",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        title="t",
+        body="ok 1",
+        day="d1",
+    )
+    path = tmp_path / ss.SHIP_MANIFEST_FILENAME
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["protected_paths_changed"] = "scripts/_staging_ship.py"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError):
+        ss.read_ship_manifest(tmp_path)
+
+
+def test_main_manifest_requires_main_base_and_external_refs(tmp_path):
+    import json
+
+    ss.write_ship_manifest(
+        tmp_path,
+        source_branch="autopilot/work",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        title="t",
+        body="ok 1",
+        day="d1",
+        target="main",
+        base_branch="main",
+        gate_evidence_path="reports/agent_loop/active/gate_evidence/T/evidence.json",
+        gate_evidence_digest="sha256:abc",
+        ci_evidence_ref="github-checks://pr/1",
+        review_gate_ref="github-review://pr/1",
+    )
+    assert ss.read_ship_manifest(tmp_path)["target"] == "main"
+
+    path = tmp_path / ss.SHIP_MANIFEST_FILENAME
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["base_branch"] = "autopilot/integration"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError):
+        ss.read_ship_manifest(tmp_path)
+
+    payload["base_branch"] = "main"
+    payload["review_gate_ref"] = ""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError):
+        ss.read_ship_manifest(tmp_path)
+
+
+def test_protected_path_globs_match_guard_surfaces_only():
+    changed = [
+        "Makefile",
+        "scripts/_staging_ship.py",
+        "scripts/claude-hooks/stop-ship.sh",
+        "docs/adr/0123-self-ship-main-gate.md",
+        "docs/readme.md",
+        "tests/test_unrelated.py",
+    ]
+    assert ss.detect_self_ship_protected_paths(changed) == [
+        "Makefile",
+        "docs/adr/0123-self-ship-main-gate.md",
+        "scripts/_staging_ship.py",
+        "scripts/claude-hooks/stop-ship.sh",
+    ]
+
+
+def test_guard_change_ack_accepts_codeowner_or_maintainer_bound_to_sha_and_paths():
+    paths = ["Makefile", "scripts/_staging_ship.py"]
+    codeowner_ack = ss.GuardChangeAck(
+        actor="alice",
+        actor_kind="human",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        protected_paths=tuple(paths),
+        codeowner_approval=True,
+    )
+    maintainer_ack = ss.GuardChangeAck(
+        actor="bob",
+        actor_kind="human",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        protected_paths=tuple(reversed(paths)),
+        permission="maintain",
+    )
+    assert ss.guard_change_ack_valid(
+        codeowner_ack,
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        protected_paths=paths,
+    )
+    assert ss.guard_change_ack_valid(
+        maintainer_ack,
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        protected_paths=paths,
+    )
+
+
+@pytest.mark.parametrize(
+    "ack",
+    [
+        None,
+        ss.GuardChangeAck(
+            actor="runner",
+            actor_kind="runner",
+            source_sha="0123456789abcdef0123456789abcdef01234567",
+            protected_paths=("Makefile",),
+            permission="admin",
+        ),
+        ss.GuardChangeAck(
+            actor="bot",
+            actor_kind="bot",
+            source_sha="0123456789abcdef0123456789abcdef01234567",
+            protected_paths=("Makefile",),
+            permission="admin",
+        ),
+        ss.GuardChangeAck(
+            actor="alice",
+            actor_kind="human",
+            source_sha="ffffffffffffffffffffffffffffffffffffffff",
+            protected_paths=("Makefile",),
+            permission="admin",
+        ),
+        ss.GuardChangeAck(
+            actor="alice",
+            actor_kind="human",
+            source_sha="0123456789abcdef0123456789abcdef01234567",
+            protected_paths=("scripts/_staging_ship.py",),
+            permission="admin",
+        ),
+        ss.GuardChangeAck(
+            actor="alice",
+            actor_kind="human",
+            source_sha="0123456789abcdef0123456789abcdef01234567",
+            protected_paths=("Makefile",),
+            permission="write",
+        ),
+        ss.GuardChangeAck(
+            actor="alice",
+            actor_kind="human",
+            source_sha="0123456789abcdef0123456789abcdef01234567",
+            protected_paths=("Makefile",),
+            permission="admin",
+            external=False,
+        ),
+    ],
+)
+def test_guard_change_ack_rejects_spoofed_or_unbound_evidence(ack):
+    assert not ss.guard_change_ack_valid(
+        ack,
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        protected_paths=["Makefile"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("decision", "threads", "api_error", "expected"),
+    [
+        ("APPROVED", 0, False, True),
+        ("REVIEW_REQUIRED", 0, False, False),
+        ("CHANGES_REQUESTED", 0, False, False),
+        ("COMMENTED", 0, False, False),
+        (None, 0, False, False),
+        ("APPROVED", 1, False, False),
+        ("APPROVED", 0, True, False),
+    ],
+)
+def test_review_gate_clean_matrix(decision, threads, api_error, expected):
+    assert ss.review_gate_clean(decision, threads, api_error=api_error) is expected
+
+
+def _main_manifest(**overrides):
+    manifest = {
+        "schema_version": ss.SHIP_MANIFEST_SCHEMA_VERSION,
+        "source_branch": "autopilot/work",
+        "source_sha": "0123456789abcdef0123456789abcdef01234567",
+        "target": "main",
+        "base_branch": "main",
+        "title": "t",
+        "body": "ok 1",
+        "day": "d1",
+        "gate_evidence_path": "reports/agent_loop/active/gate_evidence/T/evidence.json",
+        "gate_evidence_digest": "sha256:abc",
+        "protected_paths_changed": [],
+        "ci_evidence_ref": "runner-claims-ci-green",
+        "review_gate_ref": "runner-claims-review-approved",
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def _main_gates(**overrides):
+    gates = {
+        "ci_green": True,
+        "review_decision": "APPROVED",
+        "unresolved_non_outdated_threads": 0,
+        "protection_verified": True,
+        "token_verified": True,
+        "pr_head_sha": "0123456789abcdef0123456789abcdef01234567",
+    }
+    gates.update(overrides)
+    return ss.MainGateSnapshot(**gates)
+
+
+@pytest.mark.parametrize(
+    ("gate_overrides", "decision"),
+    [
+        ({"ci_green": False}, "main-blocked-ci"),
+        ({"review_decision": "CHANGES_REQUESTED"}, "main-blocked-review"),
+        ({"unresolved_non_outdated_threads": 1}, "main-blocked-review"),
+        ({"protection_verified": False}, "main-blocked-protection"),
+        ({"token_verified": False}, "main-blocked-token"),
+        ({"pr_head_sha": "ffffffffffffffffffffffffffffffffffffffff"}, "main-blocked-source-mismatch"),
+    ],
+)
+def test_main_gate_simulation_fails_closed_from_promoter_resolved_facts(gate_overrides, decision):
+    # Manifest refs can point to evidence but cannot authorize merge by themselves.
+    result = ss.evaluate_main_promotion(_main_manifest(), _main_gates(**gate_overrides))
+    assert result.decision == decision
+
+
+def test_main_gate_requires_external_ack_for_protected_paths():
+    manifest = _main_manifest(protected_paths_changed=["scripts/_staging_ship.py"])
+    gates = _main_gates()
+    assert ss.evaluate_main_promotion(manifest, gates).decision == "main-blocked-guard-ack"
+    ack = ss.GuardChangeAck(
+        actor="maintainer",
+        actor_kind="human",
+        source_sha=manifest["source_sha"],
+        protected_paths=("scripts/_staging_ship.py",),
+        permission="admin",
+    )
+    assert ss.evaluate_main_promotion(manifest, gates, ack=ack).decision == "main-merge-allowed"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"start_infinite": True},
+        {"active_auto_loop_max_iterations": 0},
+        {"target_manifest_count": 2},
+        {"retry_loop_requested": True},
+        {"distinct_main_source_sha_count": 2},
+    ],
+)
+def test_main_blocks_unbounded_no_cap_modes(kwargs):
+    result = ss.evaluate_main_promotion(_main_manifest(), _main_gates(), **kwargs)
+    assert result.decision == "main-blocked-cap-deferred"
+
+
+def test_bounded_single_main_manifest_can_pass_without_cap_store():
+    result = ss.evaluate_main_promotion(
+        _main_manifest(),
+        _main_gates(),
+        target_manifest_count=1,
+        distinct_main_source_sha_count=1,
+        active_auto_loop_max_iterations=5,
+    )
+    assert result.decision == "main-merge-allowed"
+
+
+def test_promotion_lock_blocks_parallel_holder(tmp_path):
+    lock_path = tmp_path / "promotion.lock"
+    with ss.PromotionLock(lock_path):
+        with pytest.raises(ss.EnforcementNotVerified):
+            with ss.PromotionLock(lock_path):
+                pass
+    assert not lock_path.exists()
 
 
 # --- P2.0 D1 _RealGitOps.protection_verified with injected fake runner (US-2) -
@@ -460,9 +779,40 @@ def _protection_proc(
         body["required_status_checks"]["contexts"] = contexts
     if checks is not None:
         body["required_status_checks"]["checks"] = checks
-    import json
-
     return (["gh", "api"], _FakeProc(rc, json.dumps(body)))
+
+
+def _review_threads_proc(
+    *,
+    decision="APPROVED",
+    nodes=None,
+    has_next=False,
+    cursor=None,
+    rc=0,
+    raw=None,
+    errors=None,
+):
+    if raw is not None:
+        return (["gh", "api", "graphql"], _FakeProc(rc, raw))
+    body = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewDecision": decision,
+                    "reviewThreads": {
+                        "nodes": [] if nodes is None else nodes,
+                        "pageInfo": {
+                            "hasNextPage": has_next,
+                            "endCursor": cursor,
+                        },
+                    },
+                }
+            }
+        }
+    }
+    if errors is not None:
+        body["errors"] = errors
+    return (["gh", "api", "graphql"], _FakeProc(rc, json.dumps(body)))
 
 
 def test_real_protection_verified_true_when_all_conditions_met():
@@ -751,27 +1101,288 @@ def test_real_protection_verified_url_encodes_slashed_branch():
     assert "autopilot/integration" not in api_call["argv"][2]
 
 
-# --- D1: merge orchestration is a deferred-to-P2.2 stub -----------------------
+# --- read-only GitHub GraphQL review gate resolver ---------------------------
 
-def test_real_open_pr_is_deferred_stub():
-    # D1 does not auto-merge: open_pr refuses rather than fakes.
+def test_real_review_gate_resolution_clean_reads_exact_graphql_fields():
+    runner = _FakeRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(
+            nodes=[
+                {"isResolved": True, "isOutdated": False},
+                {"isResolved": False, "isOutdated": True},
+            ],
+        ),
+    ])
+    result = ss._RealGitOps(run=runner).resolve_review_gate("7")
+    assert result == ss.ReviewGateResolution(
+        review_decision="APPROVED",
+        unresolved_non_outdated_threads=0,
+        fetched_thread_pages=1,
+        api_error=False,
+    )
+    assert ss.review_gate_clean(
+        result.review_decision,
+        result.unresolved_non_outdated_threads,
+        api_error=result.api_error,
+    )
+    graphql_call = next(c for c in runner.calls if c["argv"][:3] == ["gh", "api", "graphql"])
+    query_arg = next(arg for arg in graphql_call["argv"] if arg.startswith("query="))
+    assert "reviewDecision" in query_arg
+    assert "reviewThreads" in query_arg
+    assert "isResolved" in query_arg
+    assert "isOutdated" in query_arg
+    assert "pageInfo" in query_arg
+
+
+def test_real_review_gate_resolution_counts_active_unresolved_threads():
+    runner = _FakeRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(nodes=[{"isResolved": False, "isOutdated": False}]),
+    ])
+    result = ss._RealGitOps(run=runner).resolve_review_gate("7")
+    assert result.api_error is False
+    assert result.review_decision == "APPROVED"
+    assert result.unresolved_non_outdated_threads == 1
+    assert not ss.review_gate_clean(
+        result.review_decision,
+        result.unresolved_non_outdated_threads,
+        api_error=result.api_error,
+    )
+
+
+def test_real_review_gate_resolution_preserves_changes_requested_decision():
+    runner = _FakeRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(decision="CHANGES_REQUESTED", nodes=[]),
+    ])
+    result = ss._RealGitOps(run=runner).resolve_review_gate("7")
+    assert result.api_error is False
+    assert result.review_decision == "CHANGES_REQUESTED"
+    assert result.unresolved_non_outdated_threads == 0
+    assert not ss.review_gate_clean(
+        result.review_decision,
+        result.unresolved_non_outdated_threads,
+        api_error=result.api_error,
+    )
+
+
+def test_real_review_gate_resolution_paginates_threads():
+    runner = _SeqRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(
+            nodes=[{"isResolved": True, "isOutdated": False}],
+            has_next=True,
+            cursor="cursor-1",
+        ),
+        _review_threads_proc(nodes=[{"isResolved": False, "isOutdated": False}]),
+    ])
+    result = ss._RealGitOps(run=runner).resolve_review_gate("7", page_size=50, max_pages=2)
+    assert result == ss.ReviewGateResolution(
+        review_decision="APPROVED",
+        unresolved_non_outdated_threads=1,
+        fetched_thread_pages=2,
+        api_error=False,
+    )
+    graphql_calls = [c for c in runner.calls if c["argv"][:3] == ["gh", "api", "graphql"]]
+    assert len(graphql_calls) == 2
+    assert "-F" in graphql_calls[1]["argv"]
+    assert "after=cursor-1" in graphql_calls[1]["argv"]
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [(["gh", "repo", "view"], _FakeProc(returncode=1, stdout=""))],
+        [_REPO_VIEW_OK, _review_threads_proc(rc=1, raw="")],
+        [_REPO_VIEW_OK, _review_threads_proc(raw="not-json")],
+        [_REPO_VIEW_OK, _review_threads_proc(errors=[{"message": "boom"}])],
+        [
+            _REPO_VIEW_OK,
+            _review_threads_proc(
+                raw='{"data": {"repository": {"pullRequest": {"reviewDecision": "APPROVED", '
+                '"reviewThreads": {"nodes": []}}}}}'
+            ),
+        ],
+        [
+            _REPO_VIEW_OK,
+            _review_threads_proc(nodes=[{"isResolved": "false", "isOutdated": False}]),
+        ],
+    ],
+)
+def test_real_review_gate_resolution_fails_closed_on_api_or_schema_errors(responses):
+    result = ss._RealGitOps(run=_FakeRunner(responses)).resolve_review_gate("7")
+    assert result.api_error is True
+    assert result.unresolved_non_outdated_threads is None
+    assert not ss.review_gate_clean(
+        result.review_decision,
+        result.unresolved_non_outdated_threads,
+        api_error=result.api_error,
+    )
+
+
+def test_real_review_gate_resolution_fails_closed_when_page_cap_exceeded():
+    runner = _SeqRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(
+            nodes=[{"isResolved": True, "isOutdated": False}],
+            has_next=True,
+            cursor="cursor-1",
+        ),
+    ])
+    result = ss._RealGitOps(run=runner).resolve_review_gate("7", max_pages=1)
+    assert result.api_error is True
+    assert result.fetched_thread_pages == 1
+
+
+def test_real_review_gate_resolution_strips_ambient_gh_and_merge_token_env(monkeypatch):
+    monkeypatch.setenv("GH_REPO", "evil/other-repo")
+    monkeypatch.setenv("GH_TOKEN", "ambient-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "ambient-ghs")
+    monkeypatch.setenv("GH_ENTERPRISE_TOKEN", "ambient-ghe")
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    monkeypatch.setenv("PATH_KEEPME", "kept")
+    runner = _FakeRunner([
+        _REPO_VIEW_OK,
+        _review_threads_proc(nodes=[]),
+    ])
+    ss._RealGitOps(run=runner).resolve_review_gate("7")
+    assert runner.calls
+    for call in runner.calls:
+        env = call["kwargs"].get("env")
+        assert env is not None
+        assert "GH_REPO" not in env
+        assert "GH_TOKEN" not in env
+        assert "GITHUB_TOKEN" not in env
+        assert "GH_ENTERPRISE_TOKEN" not in env
+        assert "BIDMATE_SHIP_MERGE_TOKEN" not in env
+        assert env.get("PATH_KEEPME") == "kept"
+
+
+# --- explicit live staging wiring -------------------------------------------
+
+class _SeqRunner:
+    """Sequential runner for commands that repeat the same gh prefix."""
+
+    def __init__(self, responses: list[tuple[list[str], _FakeProc]]):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": list(argv), "kwargs": kwargs})
+        for idx, (prefix, proc) in enumerate(self._responses):
+            if list(argv)[: len(prefix)] == prefix:
+                self._responses.pop(idx)
+                return proc
+        return _FakeProc(returncode=1, stdout="")
+
+
+def test_real_open_pr_requires_separated_merge_token(monkeypatch):
+    monkeypatch.delenv("BIDMATE_SHIP_MERGE_TOKEN", raising=False)
     ops = ss._RealGitOps(run=_FakeRunner([]))
     with pytest.raises(ss.EnforcementNotVerified):
         ops.open_pr(source="autopilot/work", base="autopilot/integration", title="t", body="ok 1")
 
 
-def test_real_merge_is_deferred_stub():
-    ops = ss._RealGitOps(run=_FakeRunner([]))
+def test_real_open_pr_reuses_existing_open_pr_and_sanitizes_mutation_env(monkeypatch):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    monkeypatch.setenv("GH_TOKEN", "ambient-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "ambient-ghs")
+    monkeypatch.setenv("GH_REPO", "evil/repo")
+    runner = _FakeRunner([
+        (
+            ["gh", "pr", "view"],
+            _FakeProc(0, '{"number": 7, "baseRefName": "autopilot/integration", "state": "OPEN"}'),
+        )
+    ])
+    ops = ss._RealGitOps(run=runner)
+    assert ops.open_pr(
+        source="autopilot/work",
+        base="autopilot/integration",
+        title="t",
+        body="ok 1",
+    ) == "7"
+    call = runner.calls[0]
+    env = call["kwargs"]["env"]
+    assert env["GH_TOKEN"] == "ship-token"
+    assert "GITHUB_TOKEN" not in env
+    assert "GH_REPO" not in env
+    assert "BIDMATE_SHIP_MERGE_TOKEN" not in env
+
+
+def test_real_open_pr_creates_then_re_reads_bound_pr(monkeypatch):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _SeqRunner([
+        (["gh", "pr", "view"], _FakeProc(1, "")),
+        (["gh", "pr", "create"], _FakeProc(0, "https://github.example/pr/7\n")),
+        (
+            ["gh", "pr", "view"],
+            _FakeProc(0, '{"number": 7, "baseRefName": "autopilot/integration", "state": "OPEN"}'),
+        ),
+    ])
+    ops = ss._RealGitOps(run=runner)
+    assert ops.open_pr(
+        source="autopilot/work",
+        base="autopilot/integration",
+        title="t",
+        body="ok 1",
+    ) == "7"
+    create_call = next(c for c in runner.calls if c["argv"][:3] == ["gh", "pr", "create"])
+    assert "--head" in create_call["argv"]
+    assert "--base" in create_call["argv"]
+    assert "--no-maintainer-edit" in create_call["argv"]
+
+
+def test_real_open_pr_blocks_existing_wrong_base(monkeypatch):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _FakeRunner([
+        (
+            ["gh", "pr", "view"],
+            _FakeProc(0, '{"number": 7, "baseRefName": "main", "state": "OPEN"}'),
+        )
+    ])
+    ops = ss._RealGitOps(run=runner)
+    with pytest.raises(ss.EnforcementNotVerified):
+        ops.open_pr(source="autopilot/work", base="autopilot/integration", title="t", body="ok 1")
+
+
+def test_real_required_checks_all_success_requires_non_empty_required_pass(monkeypatch):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _FakeRunner([
+        (
+            ["gh", "pr", "checks"],
+            _FakeProc(0, '[{"name": "staging-self-ship-guard", "bucket": "pass", "state": "SUCCESS"}]'),
+        )
+    ])
+    assert ss._RealGitOps(run=runner).required_checks_all_success("7") is True
+    checks_call = runner.calls[0]["argv"]
+    assert "--required" in checks_call
+
+
+@pytest.mark.parametrize("stdout", ["[]", '[{"name": "ci", "bucket": "pending"}]', "not-json"])
+def test_real_required_checks_all_success_fails_closed(monkeypatch, stdout):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _FakeRunner([(["gh", "pr", "checks"], _FakeProc(0, stdout))])
+    assert ss._RealGitOps(run=runner).required_checks_all_success("7") is False
+
+
+def test_real_merge_requires_match_head_commit_and_never_uses_admin_or_delete(monkeypatch):
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _FakeRunner([(["gh", "pr", "merge"], _FakeProc(0, ""))])
+    ops = ss._RealGitOps(run=runner)
     with pytest.raises(ss.EnforcementNotVerified):
         ops.merge("7")
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    ops.merge("7", match_head_commit=sha)
+    argv = runner.calls[-1]["argv"]
+    assert argv[:4] == ["gh", "pr", "merge", "7"]
+    assert "--squash" in argv
+    assert "--match-head-commit" in argv
+    assert sha in argv
+    assert "--admin" not in argv
+    assert "--delete-branch" not in argv
 
 
-def test_real_required_checks_is_deferred_stub_returns_false():
-    ops = ss._RealGitOps(run=_FakeRunner([]))
-    assert ops.required_checks_all_success("7") is False
-
-
-# --- D1 main() verify-and-refuse harness (NEVER merges) -----------------------
+# --- default CLI verify-and-refuse plus explicit live staging -----------------
 
 def test_cli_blocks_on_user_with_no_manifest_and_no_source(monkeypatch, tmp_path, capsys):
     # No manifest AND no --source => still rc 2 with the "no ship manifest" message.
@@ -807,10 +1418,9 @@ def test_cli_no_manifest_no_source_still_runs_live_protection_check(monkeypatch,
     assert "blocked-on-user: no ship manifest" in err
 
 
-def test_cli_blocks_on_user_with_manifest_present_defers_to_p2_2(monkeypatch, tmp_path, capsys):
-    # With a manifest present (cap store / merge token NOT required in D1), main()
-    # LIVE-verifies protection (False via injected fake runner) then refuses, citing
-    # P2.2. It must NEVER merge.
+def test_cli_blocks_on_user_with_manifest_present_without_execute_flag(monkeypatch, tmp_path, capsys):
+    # With a manifest present, default mode LIVE-verifies protection then refuses.
+    # Without --execute-live-staging, the default path must NEVER merge.
     ss.write_ship_manifest(
         tmp_path,
         source_branch="autopilot/work",
@@ -844,13 +1454,12 @@ def test_cli_blocks_on_user_with_manifest_present_defers_to_p2_2(monkeypatch, tm
     assert rc == 2
     err = capsys.readouterr().err
     assert "blocked-on-user" in err
-    assert "P2.2" in err
-    assert "does not yet auto-merge" in err
+    assert "Default mode does not auto-merge" in err
 
 
 def test_cli_reports_enforcement_verified_then_still_refuses(monkeypatch, tmp_path, capsys):
-    # Even when protection IS verified live (True via injected fake runner), D1 STILL
-    # refuses to merge (rc 2) and cites P2.2 — it only verifies read-only.
+    # Even when protection IS verified live (True via injected fake runner), default mode STILL
+    # refuses to merge (rc 2) and points to the explicit live flag.
     ss.write_ship_manifest(
         tmp_path,
         source_branch="autopilot/work",
@@ -887,8 +1496,96 @@ def test_cli_reports_enforcement_verified_then_still_refuses(monkeypatch, tmp_pa
     assert rc == 2
     err = capsys.readouterr().err
     assert "is VERIFIED" in err
-    assert "P2.2" in err
-    assert "does not yet auto-merge" in err
+    assert "default mode does not auto-merge" in err
+    assert "--execute-live-staging" in err
+
+
+def test_cli_execute_live_staging_uses_explicit_flag_and_archives_manifest(monkeypatch, tmp_path, capsys):
+    ss.write_ship_manifest(
+        tmp_path,
+        source_branch="autopilot/work",
+        source_sha="0123456789abcdef0123456789abcdef01234567",
+        title="chore: t",
+        body="ok 1",
+        day="2026-05-31",
+    )
+    monkeypatch.setenv("BIDMATE_SHIP_MERGE_TOKEN", "ship-token")
+    runner = _SeqRunner([
+        _REPO_VIEW_OK,
+        _protection_proc(
+            contexts=[ss._REQUIRED_STAGING_CHECK],
+            force_enabled=False,
+            admins_enabled=True,
+            strict=True,
+        ),
+        _REPO_VIEW_OK,
+        _protection_proc(
+            contexts=[ss._REQUIRED_STAGING_CHECK],
+            force_enabled=False,
+            admins_enabled=True,
+            strict=True,
+        ),
+        (
+            ["gh", "pr", "view"],
+            _FakeProc(0, '{"number": 7, "baseRefName": "autopilot/integration", "state": "OPEN"}'),
+        ),
+        (
+            ["gh", "pr", "checks"],
+            _FakeProc(0, '[{"name": "staging-self-ship-guard", "bucket": "pass", "state": "SUCCESS"}]'),
+        ),
+        (["gh", "pr", "merge"], _FakeProc(0, "")),
+    ])
+    monkeypatch.setattr(ss.subprocess, "run", runner)
+
+    rc = ss.main([
+        "--manifest-dir",
+        str(tmp_path),
+        "--state-dir",
+        str(tmp_path),
+        "--execute-live-staging",
+    ])
+
+    assert rc == 0
+    assert not (tmp_path / ss.SHIP_MANIFEST_FILENAME).exists()
+    assert (tmp_path / ss.SHIP_MANIFEST_CONSUMED).exists()
+    err = capsys.readouterr().err
+    assert "staging-merged" in err
+    merge_call = next(c for c in runner.calls if c["argv"][:3] == ["gh", "pr", "merge"])
+    assert "--match-head-commit" in merge_call["argv"]
+    assert "0123456789abcdef0123456789abcdef01234567" in merge_call["argv"]
+    assert "--admin" not in merge_call["argv"]
+    assert "--delete-branch" not in merge_call["argv"]
+
+
+def test_cli_execute_live_staging_requires_source_sha(monkeypatch, tmp_path, capsys):
+    runner = _SeqRunner([
+        _REPO_VIEW_OK,
+        _protection_proc(
+            contexts=[ss._REQUIRED_STAGING_CHECK],
+            force_enabled=False,
+            admins_enabled=True,
+            strict=True,
+        ),
+    ])
+    monkeypatch.setattr(ss.subprocess, "run", runner)
+    rc = ss.main([
+        "--source",
+        "autopilot/work",
+        "--title",
+        "t",
+        "--body",
+        "ok 1",
+        "--day",
+        "2026-05-31",
+        "--manifest-dir",
+        str(tmp_path),
+        "--state-dir",
+        str(tmp_path),
+        "--execute-live-staging",
+    ])
+    assert rc == 2
+    assert "requires manifest source_sha or --source-sha" in capsys.readouterr().err
+    assert not any(c["argv"][:3] == ["gh", "pr", "merge"] for c in runner.calls)
 
 
 def test_cli_does_not_consume_manifest(monkeypatch, tmp_path, capsys):
@@ -934,7 +1631,7 @@ def test_cli_returns_2_no_traceback_when_gh_unavailable(monkeypatch, tmp_path, c
     assert rc == 2
     err = capsys.readouterr().err
     assert "NOT verified" in err
-    assert "P2.2" in err
+    assert "Default mode does not auto-merge" in err
 
 
 def test_cli_blocks_on_kill_switch(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Self-ship을 `agent_loop.py` 안의 직접 merge 실행으로 만들지 않고, 단일 local-gate completion 이후 조건을 만족할 때만 `ship_manifest.json`을 내보내는 파일 handoff로 분리했습니다. staging ship gate는 GitHub GraphQL의 `reviewDecision`과 unresolved/non-outdated review threads를 읽기 전용으로 확인해 과소/과대 차단을 줄이되, API/schema/환경 오류는 fail-closed로 둡니다. CI에서 드러난 기존 `docs/plans` dead link는 tracked 문서 링크가 아닌 local OMX artifact 경로였으므로 code span으로 낮춰 full-ci-green을 복구했습니다.

Closes #2699

## 2. 영향 파일

- `Makefile` — `시작-ship` opt-in manifest emission wiring.
- `scripts/agent_loop.py` — active-loop manifest emission seam and CLI flags; `_staging_ship` dependency is lazy so status-only hook paths keep minimal dependencies.
- `scripts/_staging_ship.py` — review-gate GraphQL resolver and manifest contract helpers.
- `tests/test_agent_loop.py` — active-loop manifest emission regression tests.
- `tests/test_staging_ship_regression.py` — GraphQL review-gate regression tests.
- `docs/operations/staging-self-ship.md` — operator/runbook contract update.
- `docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md` — pre-existing local-artifact links changed to non-link code spans so doc-link CI passes.

Load-bearing paths per `scripts/_governance.py`: N/A — no RAG/eval/API/ADR load-bearing path changed.

## 3. 리스크

- Review gate API shape drift could incorrectly block or allow staging promotion. Mitigation: GraphQL resolver tests cover clean gate, unresolved active thread block, outdated/resolved thread ignore, pagination, and fail-closed error paths.
- Active-loop manifest emission could accidentally become implicit ship authority. Mitigation: emission is opt-in only, disabled by default, blocked for `--execute-ship`, task pools, dirty non-report edits, missing gate evidence, non-issue branches, and non-local-gate completions.
- `agent_loop.py` depending on `_staging_ship` at module import time broke status-only hook fixtures. Mitigation: import is lazy inside manifest emission only and hook integration test is included in validation.
- Existing `docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md` linked to local `.omx` artifacts and an untracked draft file, causing CI doc-link failure. Mitigation: those references are no longer Markdown links.

## 4. 테스트

- `python3 -m pytest -q tests/test_agent_loop.py tests/test_staging_ship_regression.py tests/test_agent_loop_claude_integration.py tests/test_doc_links.py` → `637 passed`
- `python3 -m pytest -q tests/test_agent_loop.py` → `442 passed`
- `python3 -m pytest -q tests/test_agent_loop.py tests/test_staging_ship_regression.py -k 'ship or active_auto_loop'` → `185 passed, 388 deselected`
- `ruff check scripts/agent_loop.py scripts/_staging_ship.py tests/test_agent_loop.py tests/test_staging_ship_regression.py tests/test_agent_loop_claude_integration.py` → pass
- `python3 -m compileall -q scripts/agent_loop.py scripts/_staging_ship.py tests/test_agent_loop.py tests/test_staging_ship_regression.py tests/test_agent_loop_claude_integration.py` → pass
- `git diff --check` → pass
- `make check-branch` → pass for `chore/issue-2699-self-ship-manifest-handoff`

Overlap evidence: branch was created in a clean detached worktree from `origin/main` after isolating only the self-ship files from a dirty main checkout; the doc-link repair was added only after CI exposed it as deterministic full-ci-green blocker.

## 5. Eval 영향

All `N/A`: no RAG retrieval/answer/verifier/ingestion/eval behavior changed, and no load-bearing eval surface changed. real100_v2/private eval not run because this is automation/control-plane self-ship gating plus doc-link hygiene only.

## 6. 하위 호환

- Existing `active-auto-loop` defaults are preserved: manifest emission is disabled unless `--emit-ship-manifest` or `ACTIVE_AUTO_LOOP_EMIT_SHIP_MANIFEST=1` is set.
- New manifest schema is emitted only as opt-in file handoff; no answer contract or RAG schema changes.
- Review gate resolver remains fail-closed on missing GitHub/GraphQL data.
- Status-only stop-hook paths do not need `_staging_ship` until manifest emission is requested.

## 7. 범위 외

- No live main promotion from `agent_loop.py`.
- No durable capability store v1.
- No runner-writable merge token inside the active-loop process.
- No cleanup of unrelated orphan worktrees reported by the pre-push hook.
- No reconstruction or tracking of local `.omx` artifacts referenced by the roadmap handoff.
