### PR TITLE
fix(metadata): reject float page span endpoints

### DIFF
--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -129,11 +129,10 @@ def normalize_regions(value: Any) -> list[dict[str, Any]]:
 def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
     if isinstance(value, list) and len(value) == 2:
         try:
-            if isinstance(value[0], bool) or isinstance(value[1], bool):
+            start = _coerce_page_number(value[0])
+            end = _coerce_page_number(value[1])
+            if start is None or end is None:
                 raise TypeError
-            start, end = int(value[0]), int(value[1])
-            if start <= 0 or end <= 0:
-                raise ValueError
             return [min(start, end), max(start, end)]
         except (TypeError, ValueError):
             pass

--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -128,6 +128,10 @@ def test_normalize_page_span_rejects_nonpositive_explicit_pair() -> None:
     assert normalize_page_span([-1, 3], []) is None
 
 
+def test_normalize_page_span_rejects_float_explicit_pair() -> None:
+    assert normalize_page_span([1.9, 3.1], []) is None
+
+
 def test_normalize_page_span_falls_back_to_region_min_max() -> None:
     regions = [{"page_number": 7}, {"page_number": 3}, {"page_number": 5}]
     assert normalize_page_span(None, regions) == [3, 7]


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_page_span([1.9, 3.1], [])`가 `int(...)` coercion으로 `[1, 3]`처럼 소수 page endpoint를 잘라내던 동작을 고쳤습니다. region page normalization은 이미 float page를 거부하므로, explicit `page_span` pair도 shared positive integer page-number coercion을 사용하게 맞췄습니다.

Closes #2698

## 2. 영향 파일

- `rag_metadata_processing.py` — explicit `page_span` endpoints를 `_coerce_page_number`로 정규화해 float truncation 방지
- `tests/test_metadata_normalization.py` — float explicit page span regression coverage

## 3. 리스크

- 리스크: 기존에 float page_span endpoint가 truncation되어 citation output에 남던 경우 해당 optional span이 사라질 수 있습니다.
- 배제 근거: page number는 positive integer 계약이며, region page normalization 및 ingestion helper tests와 일치시켰습니다.

## 4. 테스트

- 변경 전 실패 확인: `pytest -q tests/test_metadata_normalization.py -q` → float explicit span regression fails (`[1, 3] != None`)
- 변경 후 통과: `pytest -q tests/test_metadata_normalization.py tests/test_answer_format_helpers.py tests/test_pymupdf4llm_postprocess_helpers.py` → `89 passed`
- `git diff --check` → pass
- `make check-branch` → pass
- overlap preflight → `OVERLAP_PREFLIGHT_OK` (open PR/main drift/dirty worktree overlap 없음)

## 5. Eval 영향

RAG metadata/citation normalization behavior change이지만 load-bearing checkpoint 목록(`rag_core`, retrieval/verifier/answer/query, ingestion, eval, api, ADR, build_index)은 직접 수정하지 않았습니다. real100_v2 aggregate는 실행하지 않았고, focused unit regression과 adjacent answer/ingestion helper surfaces로 검증했습니다.

## 6. 하위 호환

Answer schema/CLI/doc link 변경 없음. 기존 dict 계약은 유지하고, invalid float page_span endpoint만 optional citation page fields에서 제외합니다.

## 7. 범위 외

- full suite / real100_v2 eval은 실행하지 않았습니다.
