### PR TITLE
test(metadata): pin float region page rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -89,6 +89,12 @@ def test_normalize_regions_rejects_false_page_number() -> None:
     assert "page_number" not in out[0]
 
 
+def test_normalize_regions_rejects_float_page_number() -> None:
+    out = normalize_regions([{"page_number": 1.9}])
+    assert out == [{"bbox": None}]
+    assert "page_number" not in out[0]
+
+
 def test_normalize_regions_coerces_numeric_string_page_number() -> None:
     out = normalize_regions([{"page_number": "3"}])
     assert out == [{"page_number": 3, "bbox": None}]


### PR DESCRIPTION
## 1. Summary
- Adds a focused regression test that pins `normalize_regions` rejecting float `page_number` values.
- Test-only guardrail; production behavior is unchanged.

## 2. Issue
Closes #2702

## 3. Changes
- Added `test_normalize_regions_rejects_float_page_number` in `tests/test_metadata_normalization.py`.

## 4. Validation
- `pytest -q tests/test_metadata_normalization.py` -> 33 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no overlap with open PRs or dirty Codex/Claude worktrees for changed file

## 5. Eval impact
- Test-only metadata normalization guardrail.
- No retrieval/answer/eval runtime behavior changed.
- Private eval not run; no `real100_v2` aggregate claim.

## 6. Risks / follow-ups
- Current repo CI has a known unrelated main doc-link failure in shard 2 until PR #2700 lands; this PR does not touch those files.
