### PR TITLE
test(metadata): pin float region page fallback rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -182,6 +182,13 @@ def test_normalize_page_span_ignores_nonpositive_region_pages() -> None:
     ]
 
 
+def test_normalize_page_span_ignores_float_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": 1.9}, {"page_number": 3}]) == [
+        3,
+        3,
+    ]
+
+
 # --- normalize_document_sections ---
 
 


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_page_span` ignores float-valued region `page_number` entries during fallback span derivation.
- Keep runtime behavior unchanged; existing integer-only coercion already covers this path.

## Issue
Closes #2704

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 34 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.