### PR TITLE
test(metadata): pin decimal string page span rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -117,6 +117,10 @@ def test_normalize_page_span_coerces_explicit_string_pair() -> None:
     assert normalize_page_span(["5", "9"], []) == [5, 9]
 
 
+def test_normalize_page_span_rejects_decimal_string_explicit_pair() -> None:
+    assert normalize_page_span(["3.0", "4"], []) is None
+
+
 def test_normalize_page_span_sorts_explicit_pair() -> None:
     assert normalize_page_span([9, 5], []) == [5, 9]
 


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_page_span` rejects decimal-string explicit endpoints such as `"3.0"`.
- Keep runtime behavior unchanged; integer-string-only coercion already covers this path.

## Issue
Closes #2706

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 35 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.