### PR TITLE
test(metadata): pin decimal string region page rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -100,6 +100,12 @@ def test_normalize_regions_coerces_numeric_string_page_number() -> None:
     assert out == [{"page_number": 3, "bbox": None}]
 
 
+def test_normalize_regions_rejects_decimal_string_page_number() -> None:
+    out = normalize_regions([{"page_number": "3.0"}])
+    assert out == [{"bbox": None}]
+    assert "page_number" not in out[0]
+
+
 def test_normalize_regions_rejects_nonpositive_page_numbers() -> None:
     out = normalize_regions([{"page_number": 0}, {"page_number": -2}])
     assert out == [{"bbox": None}, {"bbox": None}]


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_regions` rejects decimal-string `page_number` values such as `"3.0"`.
- Keep runtime behavior unchanged; integer-string-only coercion already covers this path.

## Issue
Closes #2708

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 36 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.