### PR TITLE
test(metadata): pin decimal string region fallback rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -185,6 +185,13 @@ def test_normalize_page_span_uses_numeric_string_region_pages() -> None:
     ]
 
 
+def test_normalize_page_span_ignores_decimal_string_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": "3.0"}, {"page_number": 5}]) == [
+        5,
+        5,
+    ]
+
+
 def test_normalize_page_span_ignores_nonpositive_region_pages() -> None:
     assert normalize_page_span(None, [{"page_number": 0}, {"page_number": -1}, {"page_number": 3}]) == [
         3,


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_page_span` ignores decimal-string region `page_number` values such as `"3.0"` during fallback derivation.
- Keep runtime behavior unchanged; integer-string-only coercion already covers this path.

## Issue
Closes #2711

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 37 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.