### PR TITLE
test(metadata): pin wrong length page span without fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -163,6 +163,10 @@ def test_normalize_page_span_ignores_wrong_length_pair() -> None:
     assert normalize_page_span([1, 2, 3], [{"page_number": 4}]) == [4, 4]
 
 
+def test_normalize_page_span_wrong_length_pair_without_region_pages_is_none() -> None:
+    assert normalize_page_span([1, 2, 3], []) is None
+
+
 def test_normalize_page_span_invalid_string_pair_falls_back_to_regions() -> None:
     assert normalize_page_span(["bad", "span"], [{"page_number": 4}]) == [4, 4]
 


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_page_span` returns `None` for wrong-length explicit `page_span` values when no region pages are available.
- Keep runtime behavior unchanged; len != 2 values already fall through to region fallback.

## Issue
Closes #2713

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 38 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.