### PR TITLE
test(metadata): pin whitespace numeric page span coercion

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -123,6 +123,10 @@ def test_normalize_page_span_coerces_explicit_string_pair() -> None:
     assert normalize_page_span(["5", "9"], []) == [5, 9]
 
 
+def test_normalize_page_span_coerces_whitespace_string_pair() -> None:
+    assert normalize_page_span([" 5 ", "\t9\n"], []) == [5, 9]
+
+
 def test_normalize_page_span_rejects_decimal_string_explicit_pair() -> None:
     assert normalize_page_span(["3.0", "4"], []) is None
 


### PR DESCRIPTION
## Summary
- Add a regression test that `normalize_page_span` coerces explicit numeric-string endpoints with leading/trailing whitespace.
- Keep runtime behavior unchanged; Python `int()` coercion already covers this path.

## Issue
Closes #2715

## Validation
- `pytest -q tests/test_metadata_normalization.py` → 39 passed
- `git diff --check`
- `make check-branch`
- `OVERLAP_PREFLIGHT_OK`

## Eval impact
Test-only metadata normalization regression. No runtime behavior change, no private eval run, and no real100_v2 aggregate claim.

## Risk
Low; focused test-only assertion for existing helper behavior.