### PR TITLE
test(metadata): pin whitespace numeric region page coercion

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -193,6 +193,13 @@ def test_normalize_page_span_uses_numeric_string_region_pages() -> None:
     ]
 
 
+def test_normalize_page_span_coerces_whitespace_string_region_pages() -> None:
+    assert normalize_page_span(None, [{"page_number": " 3 "}, {"page_number": "\t5\n"}]) == [
+        3,
+        5,
+    ]
+
+
 def test_normalize_page_span_ignores_decimal_string_region_pages() -> None:
     assert normalize_page_span(None, [{"page_number": "3.0"}, {"page_number": 5}]) == [
         5,


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for whitespace-padded numeric string `region.page_number` coercion in `normalize_page_span`.
- Confirms fallback region pages remain normalized to integer min/max spans.

## 2. Issue
Closes #2719

## 3. Changes
- Added `test_normalize_page_span_coerces_whitespace_string_region_pages` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 40 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to reject whitespace-padded numeric strings.