### PR TITLE
docs: reconcile full pipeline queue namespace

### DIFF
--- a/docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md
+++ b/docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md
@@ -5,7 +5,7 @@
 - **Test spec:** `../../.omx/plans/test-spec-full-pipeline-experiment-roadmap-20260605.md` (local OMX artifact; not tracked in git)
 - **Ultragoal dedupe evidence:** `../../.omx/ultragoal/G002-full-pipeline-roadmap-dedupe-map.md` (local OMX artifact; not tracked in git)
 - **Related queue:** [`../../tasks/queue.md`](../../tasks/queue.md)
-- **Status:** handoff draft; queue IDs not assigned in this dirty worktree.
+- **Status:** namespace reconciled; `FP-*` drafts remain symbolic until PR #2710 resolves and the live queue state is re-read.
 
 ## Decision
 
@@ -30,6 +30,31 @@ queue-sync branch must verify:
 4. The branch/issue convention is satisfied before PR work starts.
 
 Until then, use the stable symbolic IDs below in plans and handoffs.
+
+## Queue Namespace Reconciliation — 2026-06-07
+
+Current tracked `origin/main` has **no canonical `T-2026-0080..0088` rows** in
+[`../../tasks/queue.md`](../../tasks/queue.md). The older
+`T-2026-0080-queue-backlog-roadmap-handoff.md` mentioned above was an untracked
+local draft, so it is not a canonical queue allocation.
+
+Open PR [#2710](https://github.com/hskim-solv/BidMate-DocAgent/pull/2710)
+currently owns the parser-roadmap namespace by adding `T-2026-0081` plus parser
+plans. Therefore:
+
+1. Do **not** create a competing `T-2026-0081` row from this full-pipeline
+   handoff.
+2. Do **not** backfill `T-2026-0080` merely to make numbering contiguous; gaps are
+   safer than changing ownership after an open PR has claimed `T-2026-0081`.
+3. Keep `FP-SYNC`, `FP-QE`, and `FP-GOV` symbolic until PR #2710 is either merged
+   or closed, then allocate the next canonical queue ID from the then-current
+   `tasks/queue.md` state.
+4. If PR #2710 changes the parser micro-eval ADR number or parser plan anchors,
+   update this handoff by rebase rather than creating a duplicate parser task.
+
+This resolves the namespace decision for this handoff: `T-2026-0080..0088` from
+the untracked local draft are explicitly non-canonical, while `T-2026-0081` is
+owned by PR #2710 until that PR resolves.
 
 ## Stage Matrix
 
@@ -147,12 +172,13 @@ Do not create default queue rows for these unless a later artifact changes the c
 
 ## Recommended Next Execution Order
 
-1. Resolve queue namespace (`T-2026-0081` parser append vs older `T-2026-0080..0088` handoff).
-2. Apply `FP-SYNC` on a clean issue/branch if queue mutation is desired.
-3. Promote `FP-QE` first, because it is the clearest uncovered P0 gap.
-4. Add or merge `FP-GOV` so later experiments cannot overclaim.
-5. Only then consider conditional lanes (`FP-INDEX-ELEMENT`, `FP-EVIDENCE-CONTRADICTION`) if existing tasks do not cover them.
-6. Use `FP-RESEARCH-PACKET` / `FP-RESEARCH-GOAL` per external-sensitive candidate family, not for the whole roadmap.
+1. Wait for PR #2710 to either merge or close, because it currently owns `T-2026-0081`.
+2. Re-read current `tasks/queue.md`; allocate the next `T-*` ID from live queue state without backfilling `T-2026-0080`.
+3. Apply `FP-SYNC` on a clean issue/branch if queue mutation is desired.
+4. Promote `FP-QE` first, because it is the clearest uncovered P0 gap.
+5. Add or merge `FP-GOV` so later experiments cannot overclaim.
+6. Only then consider conditional lanes (`FP-INDEX-ELEMENT`, `FP-EVIDENCE-CONTRADICTION`) if existing tasks do not cover them.
+7. Use `FP-RESEARCH-PACKET` / `FP-RESEARCH-GOAL` per external-sensitive candidate family, not for the whole roadmap.
 
 ## Verification for This Handoff
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Full-pipeline roadmap handoff의 queue namespace 결정을 최신 상태로 좁혔습니다. 현재 tracked `origin/main`에는 canonical `T-2026-0080..0088` queue row가 없고, open PR #2710이 `T-2026-0081` parser-roadmap namespace를 소유 중이므로 `FP-*` draft를 아직 `T-*`로 승격하지 않도록 명시했습니다.

Closes #2718

## 2. 영향 파일

- `docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md` — `T-2026-0080..0088` untracked draft를 non-canonical으로 정리하고, PR #2710이 끝날 때까지 `FP-SYNC`/`FP-QE`/`FP-GOV`를 symbolic 상태로 유지하도록 문서화.

No load-bearing runtime/eval/API/ADR files are changed.

## 3. 리스크

- Risk: PR #2710과 같은 handoff 파일을 동시에 수정하므로 rebase conflict가 생길 수 있음.
  - Mitigation: 이 PR은 PR #2710의 같은 라인을 건드리지 않고 namespace note / next-order section만 수정했습니다.
- Risk: 번호 gap(`T-2026-0080`)이 이상해 보일 수 있음.
  - Mitigation: 문서에 “contiguous numbering보다 ownership 안정성이 우선”이라고 명시했습니다.

## 4. 테스트

- `python3 scripts/agent_loop.py overlap-preflight --issue 2718 --branch docs/issue-2718-queue-namespace-reconcile --paths tasks/queue.md docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md docs/plans/T-2026-0080-queue-backlog-roadmap-handoff.md docs/plans/T-2026-0081-parser-ocr-vlm-routing-roadmap.md docs/plans/T-2026-0081-parser-output-merge-schema.md`
  - Evidence: `reports/agent_loop/overlap_preflight.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md`
- Python namespace marker assertion
- Legacy aggregate denylist grep against the handoff doc
- `git diff --check -- docs/plans/full-pipeline-roadmap-queue-sync-handoff-20260605.md`
- `make check-branch`

No runtime behavior changed, so no runtime regression test was added.

## 5. Eval 영향

Docs-only namespace reconciliation. No RAG behavior, parser behavior, eval script, index generation, API, or answer contract is changed. Real eval not run because there is no runtime/eval behavior change.

The handoff continues to preserve `real100_v2`-only private aggregate claim boundaries and introduces no legacy real100/v1/221/kordoc evidence.

## 6. 하위 호환

No CLI/API/schema/answer-contract behavior changes. No `schema_version` change required.

## 7. 범위 외

- Did not edit `tasks/queue.md`; PR #2710 currently owns the parser queue mutation.
- Did not implement `FP-QE` or `FP-GOV`; they remain symbolic until PR #2710 resolves and live queue state is re-read.
- Did not clean unrelated stale worktrees reported by the push hook.
