### PR TITLE
test(metadata): pin whitespace numeric region normalization

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -100,6 +100,11 @@ def test_normalize_regions_coerces_numeric_string_page_number() -> None:
     assert out == [{"page_number": 3, "bbox": None}]
 
 
+def test_normalize_regions_coerces_whitespace_numeric_string_page_number() -> None:
+    out = normalize_regions([{"page_number": " \t3\n"}])
+    assert out == [{"page_number": 3, "bbox": None}]
+
+
 def test_normalize_regions_rejects_decimal_string_page_number() -> None:
     out = normalize_regions([{"page_number": "3.0"}])
     assert out == [{"bbox": None}]


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for whitespace-padded numeric string `page_number` coercion in `normalize_regions`.
- Confirms region normalization keeps the integer page value and default `bbox: None` shape.

## 2. Issue
Closes #2723

## 3. Changes
- Added `test_normalize_regions_coerces_whitespace_numeric_string_page_number` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 41 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to reject whitespace-padded numeric strings.