### PR TITLE
test(metadata): pin whitespace decimal region page rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -111,6 +111,12 @@ def test_normalize_regions_rejects_decimal_string_page_number() -> None:
     assert "page_number" not in out[0]
 
 
+def test_normalize_regions_rejects_whitespace_decimal_string_page_number() -> None:
+    out = normalize_regions([{"page_number": " \t3.0\n"}])
+    assert out == [{"bbox": None}]
+    assert "page_number" not in out[0]
+
+
 def test_normalize_regions_rejects_nonpositive_page_numbers() -> None:
     out = normalize_regions([{"page_number": 0}, {"page_number": -2}])
     assert out == [{"bbox": None}, {"bbox": None}]


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for rejecting whitespace-padded decimal string `page_number` values in `normalize_regions`.
- Keeps the metadata page-number policy explicit: integer strings coerce, decimal strings do not.

## 2. Issue
Closes #2725

## 3. Changes
- Added `test_normalize_regions_rejects_whitespace_decimal_string_page_number` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 42 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to accept decimal string page numbers.