### PR TITLE
test(metadata): pin whitespace nonpositive region page rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -123,6 +123,12 @@ def test_normalize_regions_rejects_nonpositive_page_numbers() -> None:
     assert all("page_number" not in region for region in out)
 
 
+def test_normalize_regions_rejects_whitespace_nonpositive_string_page_numbers() -> None:
+    out = normalize_regions([{"page_number": " 0 "}, {"page_number": "\t-2\n"}])
+    assert out == [{"bbox": None}, {"bbox": None}]
+    assert all("page_number" not in region for region in out)
+
+
 # --- normalize_page_span ---
 
 


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for rejecting whitespace-padded nonpositive string `page_number` values in `normalize_regions`.
- Keeps the metadata page-number policy explicit: positive integer strings coerce, nonpositive strings do not.

## 2. Issue
Closes #2727

## 3. Changes
- Added `test_normalize_regions_rejects_whitespace_nonpositive_string_page_numbers` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 43 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to accept nonpositive string page numbers.