### PR TITLE
test(metadata): pin whitespace nonpositive page span rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -165,6 +165,11 @@ def test_normalize_page_span_rejects_nonpositive_explicit_pair() -> None:
     assert normalize_page_span([-1, 3], []) is None
 
 
+def test_normalize_page_span_rejects_whitespace_nonpositive_string_pair() -> None:
+    assert normalize_page_span([" 0 ", "\t3\n"], []) is None
+    assert normalize_page_span(["\t-1\n", "3"], []) is None
+
+
 def test_normalize_page_span_rejects_float_explicit_pair() -> None:
     assert normalize_page_span([1.9, 3.1], []) is None
 


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for rejecting whitespace-padded nonpositive string explicit page span endpoints in `normalize_page_span`.
- Keeps the metadata page-span policy explicit: positive integer strings coerce, nonpositive endpoints do not.

## 2. Issue
Closes #2729

## 3. Changes
- Added `test_normalize_page_span_rejects_whitespace_nonpositive_string_pair` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 44 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to accept nonpositive string page span endpoints.