### PR TITLE
test(metadata): pin whitespace decimal page span rejection

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -148,6 +148,10 @@ def test_normalize_page_span_rejects_decimal_string_explicit_pair() -> None:
     assert normalize_page_span(["3.0", "4"], []) is None
 
 
+def test_normalize_page_span_rejects_whitespace_decimal_string_pair() -> None:
+    assert normalize_page_span([" \t3.0\n", "4"], []) is None
+
+
 def test_normalize_page_span_sorts_explicit_pair() -> None:
     assert normalize_page_span([9, 5], []) == [5, 9]
 


### PR DESCRIPTION
## 1. Summary
- Adds a test-only regression pin for rejecting whitespace-padded decimal string explicit page span endpoints in `normalize_page_span`.
- Keeps the metadata page-span policy explicit: integer strings coerce, decimal strings do not.

## 2. Issue
Closes #2731

## 3. Changes
- Added `test_normalize_page_span_rejects_whitespace_decimal_string_pair` in `tests/test_metadata_normalization.py`.

## 4. Verification
- `pytest -q tests/test_metadata_normalization.py` -> 45 passed
- `git diff --check` -> pass
- `make check-branch` -> pass
- `OVERLAP_PREFLIGHT_OK` -> no same-file main drift/open PR/dirty worktree overlap

## 5. Eval impact
- Test-only metadata normalization coverage.
- No production behavior change; fixture/private eval not run.
- Private eval evidence not used; real100_v2 guardrail remains unchanged.

## 6. Risk / rollback
- Risk: narrow; only adds a regression assertion for existing behavior.
- Rollback: remove the added test if metadata policy changes to accept decimal string page span endpoints.