### PR TITLE
test(metadata): pin whitespace decimal region page span fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -233,6 +233,15 @@ def test_normalize_page_span_ignores_decimal_string_region_pages() -> None:
     ]
 
 
+def test_normalize_page_span_ignores_whitespace_decimal_string_region_pages() -> None:
+    assert normalize_page_span(
+        None, [{"page_number": " \t3.0\n"}, {"page_number": 5}]
+    ) == [
+        5,
+        5,
+    ]
+
+
 def test_normalize_page_span_ignores_nonpositive_region_pages() -> None:
     assert normalize_page_span(None, [{"page_number": 0}, {"page_number": -1}, {"page_number": 3}]) == [
         3,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_page_span` 이 regions fallback 으로 page span 을 만들 때 whitespace-padded decimal string `page_number` 를 정수 page 로 받아들이지 않는다는 계약을 test-only guardrail 로 고정합니다.

Closes #2733

## 2. 영향 파일

- `tests/test_metadata_normalization.py` — `normalize_page_span` regions fallback negative-case 단위 테스트 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 기존 normalization contract 를 테스트로 고정합니다.
- 깨짐 가능 경로: whitespace decimal string 이 실수로 `int` 유사 page 로 취급되는 회귀.
- 배제 근거: targeted metadata normalization test 전체 통과 및 diff whitespace check 통과.

## 4. 테스트

- `pytest -q tests/test_metadata_normalization.py` -> `46 passed in 0.22s` before commit, `46 passed in 0.15s` after commit
- `git diff --check` -> pass
- `make check-branch` -> pass
- overlap preflight -> `OPEN_PR_OVERLAP []`, `DIRTY_WORKTREE_OVERLAP_COUNT 0`, `OVERLAP_PREFLIGHT_OK`
- drift preflight -> `BRANCH_FILES ['tests/test_metadata_normalization.py']`, `MAIN_DRIFT_FILES []`, `MAIN_DRIFT_OVERLAP []`

## 5. Eval 영향

- RAG/eval/load-bearing path 변경 없음.
- Test-only guardrail 이므로 real-data eval 미실행.
- CI fixture smoke eval 은 PR scope 상 skip 예상.

## 6. 하위 호환

- 기존 API/CLI/schema/answer-contract 변경 없음.
- ADR 0003 `schema_version` 영향 없음.

## 7. 범위 외

- `normalize_page_span` production behavior 변경은 의도적으로 하지 않음.
- 다른 metadata matching/dedupe/ambiguity 경로는 별도 concern.
