### PR TITLE
test(metadata): pin float page span pair fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -219,6 +219,10 @@ def test_normalize_page_span_whitespace_nonpositive_pair_falls_back_to_regions()
     assert normalize_page_span(["\t-1\n", "3"], [{"page_number": 5}]) == [5, 5]
 
 
+def test_normalize_page_span_float_pair_falls_back_to_regions() -> None:
+    assert normalize_page_span([1.9, 3.1], [{"page_number": 5}]) == [5, 5]
+
+
 def test_normalize_page_span_invalid_pair_without_region_pages_is_none() -> None:
     assert normalize_page_span(["bad", "span"], [{"bbox": [1, 2, 3, 4]}]) is None
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_page_span` 이 명시적 2-item `page_span` pair를 받았더라도 float 값 때문에 coercion 이 실패하면 유효한 `regions` page 로 fallback 한다는 계약을 test-only guardrail 로 고정합니다.

Closes #2745

## 2. 영향 파일

- `tests/test_metadata_normalization.py` — float explicit pair → regions fallback 단위 테스트 추가

## 3. 리스크

- 리스크 낮음: production code 변경 없이 기존 fallback contract 를 테스트로 고정합니다.
- 깨짐 가능 경로: float explicit pair 가 regions fallback 을 막아 page span 이 `None` 이 되는 회귀.
- 배제 근거: targeted metadata normalization test 전체 통과 및 diff whitespace check 통과.

## 4. 테스트

- `pytest -q tests/test_metadata_normalization.py` -> `52 passed in 0.22s` before commit, `52 passed in 0.16s` after commit
- `git diff --check` -> pass
- `make check-branch` -> pass
- overlap preflight -> `OPEN_PR_OVERLAP []`, `DIRTY_WORKTREE_OVERLAP_COUNT 0`, `OVERLAP_PREFLIGHT_OK`
- drift preflight -> `BRANCH_FILES ['tests/test_metadata_normalization.py']`, `MAIN_DRIFT_FILES []`, `MAIN_DRIFT_OVERLAP []`

## 5. Eval 영향

- RAG/eval/load-bearing path 변경 없음.
- Test-only guardrail 이므로 real-data eval 미실행.
- CI fixture smoke eval 은 PR scope 상 skip 예상.

## 6. 하위 호환

- 기존 API/CLI/schema/answer-contract 변경 없음.
- ADR 0003 `schema_version` 영향 없음.

## 7. 범위 외

- `normalize_page_span` production behavior 변경은 의도적으로 하지 않음.
- 다른 metadata matching/dedupe/ambiguity 경로는 별도 concern.
