### PR TITLE
test(metadata): pin boolean page span pair fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -223,6 +223,11 @@ def test_normalize_page_span_float_pair_falls_back_to_regions() -> None:
     assert normalize_page_span([1.9, 3.1], [{"page_number": 5}]) == [5, 5]
 
 
+def test_normalize_page_span_boolean_pair_falls_back_to_regions() -> None:
+    assert normalize_page_span([True, 3], [{"page_number": 5}]) == [5, 5]
+    assert normalize_page_span([False, 3], [{"page_number": 5}]) == [5, 5]
+
+
 def test_normalize_page_span_invalid_pair_without_region_pages_is_none() -> None:
     assert normalize_page_span(["bad", "span"], [{"bbox": [1, 2, 3, 4]}]) is None
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`normalize_page_span`에서 boolean explicit `page_span` pair가 invalid로 처리될 때, 유효한 region page number로 fallback하는 현재 의미를 회귀 테스트로 고정했습니다. 신규 테스트는 `[True, 3]` / `[False, 3]` 모두 regions fallback으로 `[5, 5]`를 반환해야 함을 검증합니다.

Closes #2747

## 2. 영향 파일

- `tests/test_metadata_normalization.py` — metadata normalization 회귀 테스트 1개 추가

## 3. 리스크

- 리스크: boolean이 Python `int` subclass라 explicit page pair로 잘못 수용되는 회귀를 놓칠 수 있음.
- 배제 근거: targeted metadata normalization 테스트 전체가 통과했고, 변경은 test-only입니다.

## 4. 테스트

- `pytest -q tests/test_metadata_normalization.py` → 53 passed in 0.23s (before commit)
- `pytest -q tests/test_metadata_normalization.py` → 53 passed in 0.16s (after commit)
- `git diff --check origin/main...HEAD` → pass
- `make check-branch` → pass
- overlap preflight: changed file `tests/test_metadata_normalization.py`; open PR overlap `[]`; dirty worktree overlap count `0`

## 5. Eval 영향

RAG/eval/load-bearing path 변경 없음. Test-only metadata guardrail이라 동작 변경 및 real-data eval 영향 없음. `make real-eval-v2-*` 계열은 실행하지 않았습니다.

## 6. 하위 호환

기존 계약/스키마/CLI flag/doc link 변경 없음. ADR 0003 answer-contract 변경 없음, `schema_version` bump 불필요.

## 7. 범위 외

- production normalization 구현 변경 없음.
- full suite 및 private real-data eval은 test-only 단일 guardrail 범위라 실행하지 않음.
