### PR TITLE
test(metadata): pin non-list page span fallback

### DIFF
--- a/tests/test_metadata_normalization.py
+++ b/tests/test_metadata_normalization.py
@@ -197,6 +197,11 @@ def test_normalize_page_span_wrong_length_pair_without_region_pages_is_none() ->
     assert normalize_page_span([1, 2, 3], []) is None
 
 
+def test_normalize_page_span_non_list_value_falls_back_to_regions() -> None:
+    assert normalize_page_span({"start": 1, "end": 3}, [{"page_number": 6}]) == [6, 6]
+    assert normalize_page_span("1-3", [{"page_number": 6}]) == [6, 6]
+
+
 def test_normalize_page_span_invalid_string_pair_falls_back_to_regions() -> None:
     assert normalize_page_span(["bad", "span"], [{"page_number": 4}]) == [4, 4]
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`page_span` 값이 list pair가 아닌 dict/string일 때 기존 region fallback 의미가 유지됨을 회귀 테스트로 고정했습니다. 런타임 동작 변경 없이 metadata normalization의 기존 fallback 계약만 pin합니다.

Closes #2749

## 2. 영향 파일

- `tests/test_metadata_normalization.py` — non-list `page_span` 값의 regions fallback 회귀 테스트 추가

## 3. 리스크

- 리스크: 테스트 기대값이 실제 normalization 계약과 다르면 잘못된 guard가 될 수 있음.
- 확인: 기존 nearby fallback 테스트들과 동일한 `normalize_page_span(..., regions)` 계약을 사용했고 targeted test 전체가 통과했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_metadata_normalization.py -q` — 54 passed
- `python3 -m py_compile rag_metadata_processing.py parser_page_metadata_contract.py`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

RAG/eval 런타임 동작 변경 없음. 테스트 전용 변경이며 load-bearing path를 수정하지 않았습니다. real-eval 미실행 사유: metadata normalization 동작 자체를 바꾸지 않는 회귀 테스트 추가입니다.

## 6. 하위 호환

하위 호환 영향 없음. schema/CLI/API/answer contract 변경 없음.

## 7. 범위 외

- `normalize_page_span` 런타임 구현 변경
- page span 정책 확장
- private real100_v2 aggregate 재측정
