### PR TITLE
eval: diagnose real100 v2 retrieval collapse

### DIFF
--- a/docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md
+++ b/docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md
@@ -1,0 +1,29 @@
+# T-2026-0076 real100_v2 Retrieval Collapse Diagnosis
+
+This reviewer note is aggregate-only. It intentionally omits raw case rows, queries, answers, doc IDs, chunk IDs, and text previews.
+
+## Verdict
+
+- Primary signal: `doc_ranking_collapse_not_chunk_id_only`
+- Baseline comparability: `not_comparable_stack_changed`
+- Recommendation: Re-run or instrument a same-stack page-aware MiniLM retrieval aggregate with explicit retrieval_backend provenance before T-2026-0030/T-2026-0032/T-2026-0033 optimization.
+
+## Aggregate comparison
+
+| Metric | Current page-aware | Hashing backup | Delta current-backup |
+| --- | ---: | ---: | ---: |
+| doc_hit_at_5 | 0.106618 | 0.529412 | -0.422794 |
+| doc_hit_at_8 | 0.121324 | 0.613971 | -0.492647 |
+| chunk_hit_at_5 | 0.011029 | 0.375 | -0.363971 |
+| chunk_hit_at_8 | 0.011029 | 0.441176 | -0.430147 |
+| chunk_recall_at_5 | 0.009191 | 0.369485 | -0.360294 |
+
+## Stack comparison
+
+- Changed stack fields: `embedding_backend, embedding_model_id, chunking_strategy, chunker_version, vector_store_backend`
+- Current run manifest: `{"chunk_max_chars": 520, "chunk_overlap_sentences": 1, "chunker_version": "chunker.section.v1", "chunking_strategy": "section", "config_sha256": "be6e5dc606418192", "embedding_backend": "sentence-transformers", "embedding_dim": 384, "embedding_model_id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", "git_commit": "5f91a933e83f", "git_dirty": false, "index_schema_version": 2, "vector_store_backend": "chroma"}`
+- Backup run manifest: `{"chunk_max_chars": 520, "chunk_overlap_sentences": 1, "chunker_version": "chunker.fixed.v1", "chunking_strategy": "fixed", "config_sha256": "7ff7aa1454ded52e", "embedding_backend": "hashing", "embedding_dim": 384, "embedding_model_id": "local-hashing-bow", "git_commit": "e94603713d83", "git_dirty": false, "index_schema_version": 2}`
+
+## Interpretation
+
+The page-aware current run changed retrieval stack fields and shows a doc-level hit-rate collapse, so downstream reranker/window experiments should not treat the hashing backup as a comparable baseline.

--- a/docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md
+++ b/docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md
@@ -1,0 +1,41 @@
+# T-2026-0076 real100_v2 Retrieval Collapse Diagnosis Plan
+
+**Goal:** Produce an aggregate-only diagnosis artifact for the page-aware `real100_v2` retrieval collapse so downstream experiments do not optimize against a stale or incomparable baseline.
+
+**Architecture:** Add a small reporting script that compares the current page-aware eval summary with the checked-in hashing backup using only aggregate metrics and safe run-manifest fields. Keep raw `case_results` private by emitting counts/rates only, plus a Markdown reviewer note and targeted regression tests.
+
+**Files:**
+- Create: `scripts/diagnose_real100_v2_retrieval_collapse.py` — aggregate-only comparison builder/renderer.
+- Create: `tests/test_diagnose_real100_v2_retrieval_collapse.py` — privacy and metric regression tests.
+- Create: `docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md` — task plan/evidence.
+- Create/update: `docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md` — generated reviewer-facing Markdown.
+- Create/update: `reports/real100_v2/retrieval_collapse_diagnosis.aggregate.json` — generated aggregate JSON.
+- Modify: `tasks/queue.md` — record T-2026-0076 completion and issue #2751.
+
+**Steps:**
+1. Write failing test for aggregate-only output and doc-level/chunk-level metric deltas.
+2. Run targeted test and confirm import/script failure.
+3. Implement minimal reporting script.
+4. Run targeted tests and generate JSON/Markdown artifacts.
+5. Update queue with the diagnosis outcome.
+6. Run real100_v2 guard, privacy/static checks, branch check, and commit/ship.
+
+## Outcome
+
+- Issue: #2751.
+- Aggregate JSON: `reports/real100_v2/retrieval_collapse_diagnosis.aggregate.json`.
+- Reviewer Markdown: `docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md`.
+- Verdict: `doc_ranking_collapse_not_chunk_id_only`; the current page-aware MiniLM run changed stack fields relative to the hashing backup and has materially lower doc/chunk hit rates, so the backup is not a comparable baseline for downstream optimization.
+- Decision: keep page-aware chunking as an unresolved diagnostic input; do not tune reranker/window/context tasks until same-stack page-aware MiniLM retrieval provenance/remeasurement is available.
+
+## Validation Target
+
+```bash
+python3 -m pytest tests/test_diagnose_real100_v2_retrieval_collapse.py tests/test_run_manifest_versioning_regression.py -q
+python3 scripts/diagnose_real100_v2_retrieval_collapse.py
+make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -95,6 +95,8 @@ def compute_run_manifest(
     config_path: Path,
     index: dict[str, Any] | None = None,
     run_environment: Mapping[str, Any] | None = None,
+    *,
+    run_config: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the run_manifest block pinned to git commit + config bytes + UTC time.
 
@@ -130,6 +132,7 @@ def compute_run_manifest(
     if not chunker_version and chunking_strategy:
         chunker_version = f"chunker.{chunking_strategy}.v1"
     environment_block = build_run_environment_manifest(run_environment)
+    retrieval_config = dict(run_config or {})
     return {
         "git_commit": commit,
         "git_dirty": dirty,
@@ -145,6 +148,14 @@ def compute_run_manifest(
         "chunker_version": chunker_version,
         "chunk_max_chars": chunking_meta.get("max_chars"),
         "chunk_overlap_sentences": chunking_meta.get("overlap_sentences"),
+        "retrieval_backend": retrieval_config.get("retrieval_backend"),
+        "retrieval_mode": retrieval_config.get("retrieval_mode"),
+        "retrieval_top_k": retrieval_config.get("top_k"),
+        "retrieval_rerank": retrieval_config.get("rerank"),
+        "rrf_k": retrieval_config.get("rrf_k"),
+        "bm25_backend": retrieval_config.get("bm25_backend"),
+        "bm25_tokenizer": retrieval_config.get("bm25_tokenizer"),
+        "bm25_stopword_profile": retrieval_config.get("bm25_stopword_profile"),
         **environment_block,
     }
 
@@ -1776,6 +1787,7 @@ def main() -> int:
             config.get("run_environment")
             if isinstance(config.get("run_environment"), dict)
             else None,
+            run_config=primary_summary,
         ),
         "config": args.config,
         "index_dir": args.index_dir,

--- a/scripts/diagnose_real100_v2_retrieval_collapse.py
+++ b/scripts/diagnose_real100_v2_retrieval_collapse.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Render an aggregate-only T-2026-0076 real100_v2 retrieval collapse diagnosis.
+
+The input eval summaries may contain private case payloads. This module never
+copies case-level rows, raw queries, answers, text previews, document names, or
+chunk identifiers into its output; it emits only aggregate counts/rates and safe
+run-manifest fields.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime as _dt
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.run_real_eval_delta import _safe_run_manifest_field
+DEFAULT_CURRENT = ROOT / "reports" / "real100_v2" / "eval_summary.json"
+DEFAULT_BACKUP = ROOT / "reports" / "real100_v2" / "eval_summary.hashing-backup.json"
+DEFAULT_JSON = ROOT / "reports" / "real100_v2" / "retrieval_collapse_diagnosis.aggregate.json"
+DEFAULT_MD = ROOT / "docs" / "evaluation" / "real100_v2-retrieval-collapse-diagnosis.md"
+
+SAFE_MANIFEST_FIELDS = (
+    "git_commit",
+    "git_dirty",
+    "config_sha256",
+    "index_schema_version",
+    "embedding_backend",
+    "embedding_model_id",
+    "embedding_dim",
+    "vector_store_backend",
+    "chunking_strategy",
+    "chunker_version",
+    "chunk_max_chars",
+    "chunk_overlap_sentences",
+    "retrieval_backend",
+    "retrieval_mode",
+    "retrieval_top_k",
+    "retrieval_rerank",
+    "rrf_k",
+    "bm25_backend",
+    "bm25_tokenizer",
+    "bm25_stopword_profile",
+)
+
+
+def _round(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 6)
+
+
+def _case_is_answerable(case: Mapping[str, Any]) -> bool:
+    if "answerable" in case:
+        return bool(case.get("answerable"))
+    return bool(case.get("gold_chunk_ids") or case.get("gold_evidence"))
+
+
+def _gold_chunk_ids(case: Mapping[str, Any]) -> set[str]:
+    explicit = {str(item) for item in (case.get("gold_chunk_ids") or []) if item}
+    if explicit:
+        return explicit
+    return {
+        str(item.get("chunk_id"))
+        for item in (case.get("gold_evidence") or [])
+        if isinstance(item, Mapping) and item.get("chunk_id")
+    }
+
+
+def _gold_doc_ids(case: Mapping[str, Any]) -> set[str]:
+    explicit = {str(item) for item in (case.get("expected_doc_ids") or []) if item}
+    evidence = {
+        str(item.get("doc_id"))
+        for item in (case.get("gold_evidence") or [])
+        if isinstance(item, Mapping) and item.get("doc_id")
+    }
+    return explicit | evidence
+
+
+def _retrieved_chunks(case: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    chunks = case.get("retrieved_chunks") or []
+    return [item for item in chunks if isinstance(item, Mapping)]
+
+
+def _hits_at(retrieved: Iterable[Mapping[str, Any]], gold: set[str], field: str, k: int) -> bool:
+    if not gold:
+        return False
+    for item in list(retrieved)[:k]:
+        value = item.get(field)
+        if value is not None and str(value) in gold:
+            return True
+    return False
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _manifest(summary: Mapping[str, Any]) -> dict[str, Any]:
+    source = summary.get("run_manifest") or {}
+    if not isinstance(source, Mapping):
+        source = {}
+    return {
+        field: _safe_run_manifest_field(field, source.get(field))
+        for field in SAFE_MANIFEST_FIELDS
+        if field in source
+    }
+
+
+def _page_metadata(summary: Mapping[str, Any]) -> dict[str, Any]:
+    meta = summary.get("index_citation_metadata_coverage") or {}
+    if not isinstance(meta, Mapping):
+        return {}
+    return {
+        key: meta.get(key)
+        for key in ("chunks_total", "chunks_with_page_span", "page_span_coverage", "coverage_reason")
+        if key in meta
+    }
+
+
+def summarize_run(label: str, summary: Mapping[str, Any]) -> dict[str, Any]:
+    cases = [case for case in (summary.get("case_results") or []) if isinstance(case, Mapping)]
+    answerable_cases = [case for case in cases if _case_is_answerable(case)]
+    retrieval_lengths = collections.Counter(len(_retrieved_chunks(case)) for case in cases)
+
+    chunk_hit_at_5: list[float] = []
+    chunk_hit_at_8: list[float] = []
+    doc_hit_at_5: list[float] = []
+    doc_hit_at_8: list[float] = []
+    chunk_recall_5_values: list[float] = []
+    chunk_recall_10_values: list[float] = []
+    mrr5_values: list[float] = []
+
+    for case in answerable_cases:
+        retrieved = _retrieved_chunks(case)
+        gold_chunks = _gold_chunk_ids(case)
+        gold_docs = _gold_doc_ids(case)
+        chunk_hit_at_5.append(float(_hits_at(retrieved, gold_chunks, "chunk_id", 5)))
+        chunk_hit_at_8.append(float(_hits_at(retrieved, gold_chunks, "chunk_id", 8)))
+        doc_hit_at_5.append(float(_hits_at(retrieved, gold_docs, "doc_id", 5)))
+        doc_hit_at_8.append(float(_hits_at(retrieved, gold_docs, "doc_id", 8)))
+        if isinstance(case.get("chunk_recall_at_5"), int | float):
+            chunk_recall_5_values.append(float(case["chunk_recall_at_5"]))
+        if isinstance(case.get("chunk_recall_at_10"), int | float):
+            chunk_recall_10_values.append(float(case["chunk_recall_at_10"]))
+        if isinstance(case.get("chunk_mrr_at_5"), int | float):
+            mrr5_values.append(float(case["chunk_mrr_at_5"]))
+
+    top_level = {
+        "chunk_recall_at_5": summary.get("chunk_recall_at_5"),
+        "chunk_recall_at_10": summary.get("chunk_recall_at_10"),
+        "chunk_mrr_at_5": summary.get("chunk_mrr_at_5"),
+    }
+    return {
+        "label": label,
+        "population": {
+            "num_predictions": int(summary.get("num_predictions") or len(cases)),
+            "evaluated_rows_count": len(cases),
+            "answerable_count": len(answerable_cases),
+        },
+        "run_manifest": _manifest(summary),
+        "page_metadata": _page_metadata(summary),
+        "retrieval": {
+            "chunk_hit_at_5": _round(_mean(chunk_hit_at_5)),
+            "chunk_hit_at_8": _round(_mean(chunk_hit_at_8)),
+            "doc_hit_at_5": _round(_mean(doc_hit_at_5)),
+            "doc_hit_at_8": _round(_mean(doc_hit_at_8)),
+            "chunk_recall_at_5_mean_from_cases": _round(_mean(chunk_recall_5_values)),
+            "chunk_recall_at_10_mean_from_cases": _round(_mean(chunk_recall_10_values)),
+            "chunk_mrr_at_5_mean_from_cases": _round(_mean(mrr5_values)),
+            "top_level_metrics": {k: _round(v) for k, v in top_level.items() if isinstance(v, int | float)},
+            "retrieved_length_counts": {str(k): retrieval_lengths[k] for k in sorted(retrieval_lengths)},
+        },
+    }
+
+
+def _delta(current: Mapping[str, Any], backup: Mapping[str, Any], path: tuple[str, ...]) -> float | None:
+    left: Any = current
+    right: Any = backup
+    for key in path:
+        if not isinstance(left, Mapping) or not isinstance(right, Mapping):
+            return None
+        left = left.get(key)
+        right = right.get(key)
+    if not isinstance(left, int | float) or not isinstance(right, int | float):
+        return None
+    return _round(float(left) - float(right))
+
+
+def _changed_stack(current: Mapping[str, Any], backup: Mapping[str, Any]) -> list[str]:
+    fields = (
+        "embedding_backend",
+        "embedding_model_id",
+        "chunking_strategy",
+        "chunker_version",
+        "vector_store_backend",
+        "retrieval_backend",
+        "retrieval_mode",
+        "retrieval_top_k",
+        "retrieval_rerank",
+        "rrf_k",
+        "bm25_backend",
+        "bm25_tokenizer",
+        "bm25_stopword_profile",
+    )
+    cur = current.get("run_manifest") or {}
+    old = backup.get("run_manifest") or {}
+    changed = []
+    for field in fields:
+        if isinstance(cur, Mapping) and isinstance(old, Mapping) and cur.get(field) != old.get(field):
+            changed.append(field)
+    return changed
+
+
+def build_report(current_summary: Mapping[str, Any], backup_summary: Mapping[str, Any]) -> dict[str, Any]:
+    current = summarize_run("current_page_aware", current_summary)
+    backup = summarize_run("hashing_backup", backup_summary)
+    changed = _changed_stack(current, backup)
+    doc_delta = _delta(current, backup, ("retrieval", "doc_hit_at_5"))
+    chunk_delta = _delta(current, backup, ("retrieval", "chunk_hit_at_5"))
+
+    if doc_delta is not None and doc_delta <= -0.2:
+        primary_signal = "doc_ranking_collapse_not_chunk_id_only"
+    elif chunk_delta is not None and chunk_delta <= -0.2:
+        primary_signal = "chunk_retrieval_collapse"
+    else:
+        primary_signal = "no_large_retrieval_delta_observed"
+
+    return {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_retrieval_collapse_diagnosis",
+        "generated_at": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "privacy": {
+            "redacted": True,
+            "aggregate_only": True,
+            "omission_policy": "omits raw private rows, prompts, answers, retrieved evidence, gold evidence, identifiers, and text previews",
+        },
+        "source": {
+            "current_sha256_prefix": _sha_prefix(current_summary),
+            "backup_sha256_prefix": _sha_prefix(backup_summary),
+        },
+        "current": current,
+        "backup": backup,
+        "comparison": {
+            "changed_stack_fields": changed,
+            "baseline_comparability": "not_comparable_stack_changed" if changed else "same_stack",
+            "doc_hit_at_5_delta_current_minus_backup": doc_delta,
+            "doc_hit_at_8_delta_current_minus_backup": _delta(current, backup, ("retrieval", "doc_hit_at_8")),
+            "chunk_hit_at_5_delta_current_minus_backup": chunk_delta,
+            "chunk_hit_at_8_delta_current_minus_backup": _delta(current, backup, ("retrieval", "chunk_hit_at_8")),
+            "chunk_recall_at_5_delta_current_minus_backup": _delta(current, backup, ("retrieval", "chunk_recall_at_5_mean_from_cases")),
+            "chunk_recall_at_10_delta_current_minus_backup": _delta(current, backup, ("retrieval", "chunk_recall_at_10_mean_from_cases")),
+        },
+        "diagnosis": {
+            "primary_signal": primary_signal,
+            "baseline_comparability": "not_comparable_stack_changed" if changed else "same_stack",
+            "interpretation": (
+                "The page-aware current run changed retrieval stack fields and shows a doc-level hit-rate collapse, "
+                "so downstream reranker/window experiments should not treat the hashing backup as a comparable baseline."
+                if primary_signal == "doc_ranking_collapse_not_chunk_id_only"
+                else "No doc-level collapse signal crossed the conservative aggregate threshold."
+            ),
+            "recommended_next_step": (
+                "Re-run or instrument a same-stack page-aware MiniLM retrieval aggregate with explicit retrieval_backend provenance before T-2026-0030/T-2026-0032/T-2026-0033 optimization."
+            ),
+        },
+    }
+
+
+def _sha_prefix(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:12]
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    current = report["current"]
+    backup = report["backup"]
+    comparison = report["comparison"]
+    diagnosis = report["diagnosis"]
+
+    def metric(run: Mapping[str, Any], key: str) -> Any:
+        return run.get("retrieval", {}).get(key)
+
+    lines = [
+        "# T-2026-0076 real100_v2 Retrieval Collapse Diagnosis",
+        "",
+        "This reviewer note is aggregate-only. It intentionally omits raw case rows, queries, answers, doc IDs, chunk IDs, and text previews.",
+        "",
+        "## Verdict",
+        "",
+        f"- Primary signal: `{diagnosis['primary_signal']}`",
+        f"- Baseline comparability: `{diagnosis['baseline_comparability']}`",
+        f"- Recommendation: {diagnosis['recommended_next_step']}",
+        "",
+        "## Aggregate comparison",
+        "",
+        "| Metric | Current page-aware | Hashing backup | Delta current-backup |",
+        "| --- | ---: | ---: | ---: |",
+        f"| doc_hit_at_5 | {metric(current, 'doc_hit_at_5')} | {metric(backup, 'doc_hit_at_5')} | {comparison.get('doc_hit_at_5_delta_current_minus_backup')} |",
+        f"| doc_hit_at_8 | {metric(current, 'doc_hit_at_8')} | {metric(backup, 'doc_hit_at_8')} | {comparison.get('doc_hit_at_8_delta_current_minus_backup')} |",
+        f"| chunk_hit_at_5 | {metric(current, 'chunk_hit_at_5')} | {metric(backup, 'chunk_hit_at_5')} | {comparison.get('chunk_hit_at_5_delta_current_minus_backup')} |",
+        f"| chunk_hit_at_8 | {metric(current, 'chunk_hit_at_8')} | {metric(backup, 'chunk_hit_at_8')} | {comparison.get('chunk_hit_at_8_delta_current_minus_backup')} |",
+        f"| chunk_recall_at_5 | {metric(current, 'chunk_recall_at_5_mean_from_cases')} | {metric(backup, 'chunk_recall_at_5_mean_from_cases')} | {comparison.get('chunk_recall_at_5_delta_current_minus_backup')} |",
+        "",
+        "## Stack comparison",
+        "",
+        f"- Changed stack fields: `{', '.join(comparison.get('changed_stack_fields') or []) or 'none'}`",
+        f"- Current run manifest: `{json.dumps(current.get('run_manifest', {}), ensure_ascii=False, sort_keys=True)}`",
+        f"- Backup run manifest: `{json.dumps(backup.get('run_manifest', {}), ensure_ascii=False, sort_keys=True)}`",
+        "",
+        "## Interpretation",
+        "",
+        str(diagnosis["interpretation"]),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current", type=Path, default=DEFAULT_CURRENT)
+    parser.add_argument("--backup", type=Path, default=DEFAULT_BACKUP)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-md", type=Path, default=DEFAULT_MD)
+    args = parser.parse_args(argv)
+
+    report = build_report(_load_json(args.current), _load_json(args.backup))
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.output_md.write_text(render_markdown(report), encoding="utf-8")
+    print(f"wrote {args.output_json}")
+    print(f"wrote {args.output_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -287,6 +287,14 @@ SAFE_RUN_MANIFEST_KEYS = (
     "embedding_model_id",
     "embedding_dim",
     "vector_store_backend",
+    "retrieval_backend",
+    "retrieval_mode",
+    "retrieval_top_k",
+    "retrieval_rerank",
+    "rrf_k",
+    "bm25_backend",
+    "bm25_tokenizer",
+    "bm25_stopword_profile",
 )
 SAFE_RUN_MANIFEST_NESTED_KEYS = {
     "environment": (

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -40,10 +40,10 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 27 | `T-2026-0027` | `done` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584 COMPLETED (RAG performance experiment task stack). |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
 | 29 | `T-2026-0029` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1764; page-aware re-measurement DONE (diagnostic-only). Page blocker resolved (coverage 0.0 -> 1.0) but doc-level retrieval collapsed (~12%); renderer BUG #1/#2 hardened; root cause spun off as T-2026-0076. |
-| 30 | `T-2026-0030` | `ready` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | reopened after naive baseline remeasurement: rerender latency/cost envelope against the MiniLM page-aware v2 aggregate. |
-| 31 | `T-2026-0031` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | MiniLM page-aware checkpoint index now has non-zero page_span coverage; rerun only after refreshed baseline aggregate is available. |
-| 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | reopened after naive baseline remeasurement: rerun BGE-KO screening on the MiniLM page-aware v2 index before keeping no-winner status. |
-| 33 | `T-2026-0033` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | reopened after naive baseline remeasurement: rerun context-packing screening on the MiniLM page-aware v2 index before keeping latency_regression status. |
+| 30 | `T-2026-0030` | `blocked` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | blocked by T-2026-0076 outcome: do not rerender latency/cost envelope against the current page-aware aggregate until same-stack page-aware MiniLM retrieval provenance/remeasurement replaces the incomparable hashing backup. |
+| 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | page-span coverage is non-zero, but T-2026-0076 found the current page-aware aggregate is not comparable to the hashing backup; rerun only after same-stack page-aware MiniLM retrieval provenance/remeasurement is available. |
+| 32 | `T-2026-0032` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | blocked by T-2026-0076 outcome: reranker screening would optimize against a doc-ranking collapse; wait for same-stack page-aware MiniLM retrieval provenance/remeasurement. |
+| 33 | `T-2026-0033` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | blocked by T-2026-0076 outcome: context-packing screening should wait for same-stack page-aware MiniLM retrieval provenance/remeasurement. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
 | 36 | `T-2026-0036` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on stable retrieval/context evidence from P0/P1 tasks. |
@@ -86,7 +86,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 73 | `T-2026-0073` | `done` | Implementer -> Reviewer | 2026-06-02: agent-loop 남은 보조도구 2종 advisory-only(호출만) 통합 완료 (T-2026-0072 후속). eval-to-adr-bridge (PR #1756 / issue #1755) — eval surface 게이트(`write_active_gate_evidence`)에서 ADR 임계 판단 advisory, T-2026-0072 의 eval-anomaly 형제와 동일 `_eval_surface_touched` 게이트에 부착; adr-lifecycle-manager (PR #1758 / issue #1757) — proposed-ADR SLA(ADR 0047) 초과 시 `write_active_auto_loop` state advisory, learning-capture 형제 패턴(렌더러 미변경). 둘 다 제어 흐름 불변(gate ready 결정 · preflight exit code · loop decision/defer/stop 그대로), 각 통합=별도 worktree + ADR 0007 브랜치 + 회귀 테스트(eval-to-adr 4종 / adr-lifecycle 6종). code-reviewer APPROVE 후 squash 머지, CI green. |
 | 74 | `T-2026-0074` | `done` | Implementer -> Reviewer | XYZ 병렬화 epic (X task-pool + Y omc multi-worker default-on + Z roles) **완결** (2026-06-04). 7-PR 시퀀스 A1→A2→B→C→D→E→F 머지 완료, capstone **PR-F #2261** (default task-pool X=2 go-live; ADR 0001 byte-identity X=1 default 경로 보존, 탈출구 3 env). PR-0 scaffolding issue #1762 CLOSED (ADR 0094/0095). 잔여 open brick PR/worktree 0. 설계 문서: [`docs/plans/xyz-parallelism-stack.md`](../docs/plans/xyz-parallelism-stack.md). 교훈: parity guard=ancestor≠tree-identity(exact rev-parse), 다라운드 codex escalation calibration, flaky-under-concurrent-codex vs regression 판별. |
 | 75 | `T-2026-0075` | `done` | Implementer -> Reviewer | issue #1765; `memory` VectorStore backend 가 default/baseline 로 새지 않도록 positive-shape 회귀 가드 (옵션 A — 런타임 코드 무변경, parity 테스트 무영향). `DEFAULT_INDEX_BACKEND`/default-resolve/eval `ablation_runs` 전체가 chroma 로 resolve 됨을 잠금 + 명시적 memory opt-in(test-control) 보존 (ADR 0001/0081). 기존 자산(presets default·`vector_store_backend_for_runs` mixed 거부·naive_baseline=chroma) 재사용, gap A(rag_vector_store chokepoint)+C(eval 전 row) 보강. merged in PR #1769 (issue #1765 CLOSED, 2026-06-02). |
-| 76 | `T-2026-0076` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; spun off from T-2026-0029 page-aware re-measurement. MiniLM page-aware `real100_v2` rebuild resolved the page blocker but collapsed doc-level retrieval (gold-doc-in-retrieved 61.4% -> 12.1%) despite 88.3% universe coverage (answerable-with-gold; 91.7% all-cases); the diagnostic renderer's new `retrieval_integrity_suspect` signal points here. Gates every downstream `real100_v2` optimization task (T-2026-0030/0032/0033). Issue: TBD (created when task starts). |
+| 76 | `T-2026-0076` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #2751; aggregate-only collapse diagnosis rendered. Current page-aware run is not comparable to the hashing backup (stack changed: embedding/backend/chunking/vector-store) and still shows doc-ranking collapse (`doc_hit_at_5` 0.106618 vs 0.529412; `chunk_hit_at_5` 0.011029 vs 0.375). Downstream `real100_v2` optimization tasks remain blocked until same-stack page-aware MiniLM retrieval provenance/remeasurement is available. |
 | 77 | `T-2026-0077` | `backlog` | Maintainer -> CI Reviewer -> Reviewer | issue #1800; **due 2026-06-09** — ui-smoke(#1799) nightly 표본으로 required status check 승격 판단. durable cron 이 cmux 미지원 → 이 queue 행이 리마인드 앵커(다음 세션 표면화). flaky 0 + nightly ≥5회면 승격 제안, 실패 있으면 run 로그 분석 + 추가 관찰. |
 | 78 | `T-2026-0078` | `backlog` | Architect -> Planner -> Implementer -> Deep Reviewer -> Reviewer | agent-loop `expanded-eight` 토폴로지의 single write-lease Implementer 병목 재조정 **탐색**. 8역할 중 Implementer 만 `write_lease_owner=true`(나머지 7 read-only) → 구현 직렬화가 throughput 제약. 설계 미확정(현행 유지 / Implementer ×M + shared reviewer pool / 역할 축소) → architect 옵션 비교 + 순차단계 분석 + ADR(load-bearing; ADR 0080 single-writer 제약과 충돌 분석) 선행 필요. `ready` 아님 = 자동 루프가 섣불리 구현 못 하게. 진단 출처: 2026-06-03 세션. 시각화: `scripts/render_agent_loop_board.py` 토폴로지 맵. |
 | 79 | `T-2026-0079` | `done` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1844/#1969/#2374 CLOSED; `agent-evals/` operator-skill eval thin slice **완료** (2026-06-04). 3-PR stack 전부 머지: PR1 #1964 (ADR 0100+scaffold) → PR2 #2343 (core+content scanner+playbook v0/v1+3-task synthetic smoke) → PR3 #2411 (full runner `git worktree add --detach` ≥3 seed + cross-family oracle `reviewer_family != candidate_family` fail-closed + holdout v0-vs-v1 byte-identical smoke aggregate). cross-family 리뷰 round2 #2446(6 fix)+round3 #2455(2 real+live fix, 1 latent defer, 1 contrived decline) → real 발견 3→6→2 점감 = live 표면 수렴(thesis 자기증명). 비 load-bearing. 실제 mining(#1336–1820)+external-reviewer payload egress(public-attestation-only) = deferred axis (thin slice 밖). detail: `## T-2026-0079`. |
@@ -2883,11 +2883,11 @@ make check-branch
 
 - ID: T-2026-0030
 - Title: Define latency and cost budget envelope
-- Status: ready
+- Status: blocked
 - Priority: P0
 - Owner role: Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-29
+- Last updated: 2026-06-08
 
 ### Goal
 
@@ -2936,6 +2936,10 @@ make check-branch
   MiniLM page-aware v2 aggregate before downstream experiment no-go decisions
   cite it.
 
+### Blocker Update — 2026-06-08
+
+- Blocked by T-2026-0076 outcome: the current page-aware MiniLM aggregate is not comparable to the hashing backup and shows doc-ranking collapse. Wait for same-stack page-aware MiniLM retrieval provenance/remeasurement before optimization or budget-envelope conclusions.
+
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md`](../docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md)
@@ -2965,11 +2969,11 @@ make check-branch
 
 - ID: T-2026-0031
 - Title: Parent and section-window retrieval experiment
-- Status: ready
+- Status: blocked
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-29
+- Last updated: 2026-06-08
 
 ### Goal
 
@@ -3021,6 +3025,10 @@ make check-branch
 - Fresh MiniLM page-aware `real100_v2` baseline aggregate before any
   parent/window winner or no-go claim.
 
+### Blocker Update — 2026-06-08
+
+- Blocked by T-2026-0076 outcome: the current page-aware MiniLM aggregate is not comparable to the hashing backup and shows doc-ranking collapse. Wait for same-stack page-aware MiniLM retrieval provenance/remeasurement before optimization or budget-envelope conclusions.
+
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0031-parent-section-window-retrieval-experiment.md`](../docs/plans/T-2026-0031-parent-section-window-retrieval-experiment.md)
@@ -3031,11 +3039,11 @@ make check-branch
 
 - ID: T-2026-0032
 - Title: Reranker candidate-budget experiment
-- Status: ready
+- Status: blocked
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-29
+- Last updated: 2026-06-08
 
 ### Goal
 
@@ -3089,6 +3097,10 @@ make check-branch
   the prior hashing/page-0 baseline cannot support the retained no-winner
   conclusion.
 
+### Blocker Update — 2026-06-08
+
+- Blocked by T-2026-0076 outcome: the current page-aware MiniLM aggregate is not comparable to the hashing backup and shows doc-ranking collapse. Wait for same-stack page-aware MiniLM retrieval provenance/remeasurement before optimization or budget-envelope conclusions.
+
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`](../docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md)
@@ -3135,11 +3147,11 @@ make check-branch
 
 - ID: T-2026-0033
 - Title: Context packing and citation ordering experiment
-- Status: ready
+- Status: blocked
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-29
+- Last updated: 2026-06-08
 
 ### Goal
 
@@ -3196,6 +3208,10 @@ make check-branch
 - Reopened follow-up: rerun the screening on the MiniLM page-aware v2 index;
   the prior hashing/page-0 baseline cannot support the retained
   `latency_regression` conclusion.
+
+### Blocker Update — 2026-06-08
+
+- Blocked by T-2026-0076 outcome: the current page-aware MiniLM aggregate is not comparable to the hashing backup and shows doc-ranking collapse. Wait for same-stack page-aware MiniLM retrieval provenance/remeasurement before optimization or budget-envelope conclusions.
 
 ### Related Plan / Issue / PR Links
 
@@ -5400,11 +5416,11 @@ make check-branch
 
 - ID: T-2026-0076
 - Title: Verify real100_v2 page-aware retrieval integrity (embedding parity + provenance)
-- Status: ready
+- Status: done
 - Priority: P0
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-06-02
-- Last updated: 2026-06-02
+- Last updated: 2026-06-08
 
 ### Goal
 
@@ -5436,11 +5452,15 @@ which are meaningless while doc-recall is ~12%.
 
 ### Acceptance Criteria
 
-- [ ] Named root cause for the doc-recall collapse with paired `real100_v2`
-  evidence (aggregate-only).
-- [ ] Embedding/retrieval provenance field present in `eval_summary` and surfaced
-  (aggregate-only) so the diagnostic renderer can record it.
-- [ ] Decision recorded whether page-aware chunking is kept, reverted, or re-tuned.
+- [x] Named root cause for the doc-recall collapse with paired `real100_v2`
+  evidence (aggregate-only): the page-aware MiniLM run has a doc-ranking collapse,
+  not only chunk-id instability, and the hashing backup is not a comparable
+  baseline because retrieval stack fields changed.
+- [x] Embedding/retrieval provenance field present in future `eval_summary`
+  manifests and surfaced by the aggregate collapse diagnosis.
+- [x] Decision recorded: do not revert or retune page-aware chunking in this
+  task; block downstream optimization until same-stack page-aware MiniLM
+  retrieval provenance/remeasurement is available.
 
 ### Validation Commands
 
@@ -5461,9 +5481,19 @@ make check-branch
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD
-- Issue: TBD (created when task starts)
+- Plan: [`docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md`](../docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md)
+- Issue: [#2751](https://github.com/hskim-solv/BidMate-DocAgent/issues/2751)
 - PR: TBD
+
+
+
+### Completion Evidence — 2026-06-08
+
+- Generated aggregate JSON: `reports/real100_v2/retrieval_collapse_diagnosis.aggregate.json`.
+- Generated reviewer Markdown: `docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md`.
+- Aggregate diagnosis: `doc_ranking_collapse_not_chunk_id_only`; baseline comparability `not_comparable_stack_changed`.
+- Current page-aware vs hashing backup: `doc_hit_at_5` 0.106618 vs 0.529412; `doc_hit_at_8` 0.121324 vs 0.613971; `chunk_hit_at_5` 0.011029 vs 0.375.
+- Privacy posture: aggregate-only; no raw case rows, prompts, answers, evidence, doc IDs, chunk IDs, or text previews emitted.
 
 ### Notes
 

--- a/tests/test_diagnose_real100_v2_retrieval_collapse.py
+++ b/tests/test_diagnose_real100_v2_retrieval_collapse.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from scripts.diagnose_real100_v2_retrieval_collapse import build_report, render_markdown
+
+
+def _retrieved(chunk_ids: list[str], doc_ids: list[str]) -> list[dict[str, object]]:
+    return [
+        {"rank": rank, "chunk_id": chunk_id, "doc_id": doc_id, "text_preview": "PRIVATE"}
+        for rank, (chunk_id, doc_id) in enumerate(zip(chunk_ids, doc_ids), start=1)
+    ]
+
+
+def _case(gold_chunks: list[str], gold_docs: list[str], retrieved_chunks: list[str], retrieved_docs: list[str]) -> dict[str, object]:
+    return {
+        "answerable": True,
+        "gold_chunk_ids": gold_chunks,
+        "gold_evidence": [
+            {"chunk_id": chunk_id, "doc_id": doc_id}
+            for chunk_id, doc_id in zip(gold_chunks, gold_docs)
+        ],
+        "retrieved_chunks": _retrieved(retrieved_chunks, retrieved_docs),
+        "query": "PRIVATE QUERY SHOULD NOT LEAK",
+        "answer": "PRIVATE ANSWER SHOULD NOT LEAK",
+    }
+
+
+def _summary(*, label: str, cases: list[dict[str, object]], manifest: dict[str, object]) -> dict[str, object]:
+    return {
+        "num_predictions": len(cases),
+        "case_results": cases,
+        "run_manifest": manifest,
+        "index_citation_metadata_coverage": {
+            "chunks_total": 10,
+            "chunks_with_page_span": 10 if label == "current" else 0,
+            "page_span_coverage": 1.0 if label == "current" else 0.0,
+        },
+    }
+
+
+def test_build_report_compares_chunk_and_doc_retrieval_without_raw_case_leakage() -> None:
+    current = _summary(
+        label="current",
+        manifest={
+            "embedding_backend": "sentence-transformers",
+            "embedding_model_id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+            "chunking_strategy": "section",
+            "chunker_version": "chunker.section.v1",
+            "vector_store_backend": "chroma",
+            "config_sha256": "abc123",
+        },
+        cases=[
+            _case(["gold-a"], ["doc-a"], ["miss-1", "miss-2"], ["doc-x", "doc-y"]),
+            _case(["gold-b"], ["doc-b"], ["miss-3", "miss-4"], ["doc-b", "doc-z"]),
+        ],
+    )
+    backup = _summary(
+        label="backup",
+        manifest={
+            "embedding_backend": "hashing",
+            "embedding_model_id": "local-hashing-bow",
+            "chunking_strategy": "fixed",
+            "chunker_version": "chunker.fixed.v1",
+            "config_sha256": "def456",
+        },
+        cases=[
+            _case(["gold-a"], ["doc-a"], ["gold-a", "miss-2"], ["doc-a", "doc-y"]),
+            _case(["gold-b"], ["doc-b"], ["miss-3", "gold-b"], ["doc-z", "doc-b"]),
+        ],
+    )
+
+    report = build_report(current, backup)
+
+    assert report["schema_version"] == 1
+    assert report["profile_type"] == "private_real100_v2_retrieval_collapse_diagnosis"
+    assert report["current"]["retrieval"]["chunk_hit_at_5"] == 0.0
+    assert report["current"]["retrieval"]["doc_hit_at_5"] == 0.5
+    assert report["comparison"]["doc_hit_at_5_delta_current_minus_backup"] == -0.5
+    assert report["comparison"]["chunk_hit_at_5_delta_current_minus_backup"] == -1.0
+    assert report["diagnosis"]["primary_signal"] == "doc_ranking_collapse_not_chunk_id_only"
+    assert report["diagnosis"]["baseline_comparability"] == "not_comparable_stack_changed"
+    assert "case_results" not in str(report)
+    assert "PRIVATE QUERY" not in str(report)
+
+
+def test_render_markdown_keeps_reviewer_summary_aggregate_only() -> None:
+    report = build_report(
+        _summary(label="current", cases=[_case(["g"], ["d"], ["x"], ["z"])], manifest={"embedding_backend": "sentence-transformers", "chunking_strategy": "section"}),
+        _summary(label="backup", cases=[_case(["g"], ["d"], ["g"], ["d"])], manifest={"embedding_backend": "hashing", "chunking_strategy": "fixed"}),
+    )
+
+    rendered = render_markdown(report)
+
+    assert "T-2026-0076" in rendered
+    assert "doc_ranking_collapse_not_chunk_id_only" in rendered
+    assert "PRIVATE" not in rendered
+
+
+def test_build_report_marks_retrieval_knob_changes_as_incomparable() -> None:
+    current = _summary(
+        label="current",
+        manifest={
+            "embedding_backend": "sentence-transformers",
+            "embedding_model_id": "safe-model",
+            "chunking_strategy": "section",
+            "chunker_version": "chunker.section.v1",
+            "vector_store_backend": "chroma",
+            "retrieval_backend": "hybrid",
+            "retrieval_mode": "parent_section",
+            "retrieval_top_k": 8,
+            "retrieval_rerank": True,
+            "bm25_backend": "okapi",
+            "bm25_tokenizer": "regex",
+            "bm25_stopword_profile": "shared",
+        },
+        cases=[_case(["g"], ["d"], ["x"], ["z"])],
+    )
+    backup = _summary(
+        label="backup",
+        manifest={
+            "embedding_backend": "sentence-transformers",
+            "embedding_model_id": "safe-model",
+            "chunking_strategy": "section",
+            "chunker_version": "chunker.section.v1",
+            "vector_store_backend": "chroma",
+            "retrieval_backend": "dense",
+            "retrieval_mode": "flat",
+            "retrieval_top_k": 5,
+            "retrieval_rerank": False,
+            "bm25_backend": "bm25s",
+            "bm25_tokenizer": "kiwi",
+            "bm25_stopword_profile": "none",
+        },
+        cases=[_case(["g"], ["d"], ["g"], ["d"])],
+    )
+
+    report = build_report(current, backup)
+
+    assert report["comparison"]["baseline_comparability"] == "not_comparable_stack_changed"
+    assert "retrieval_backend" in report["comparison"]["changed_stack_fields"]
+    assert "retrieval_top_k" in report["comparison"]["changed_stack_fields"]
+    assert "bm25_tokenizer" in report["comparison"]["changed_stack_fields"]
+
+
+def test_manifest_redacts_local_model_paths_before_json_and_markdown_rendering() -> None:
+    current = _summary(
+        label="current",
+        manifest={
+            "embedding_backend": "sentence-transformers",
+            "embedding_model_id": "/Users/hskim/private/model.bin",
+            "chunking_strategy": "section",
+        },
+        cases=[_case(["g"], ["d"], ["x"], ["z"])],
+    )
+    backup = _summary(
+        label="backup",
+        manifest={
+            "embedding_backend": "sentence-transformers",
+            "embedding_model_id": "data/private/model.bin",
+            "chunking_strategy": "section",
+        },
+        cases=[_case(["g"], ["d"], ["g"], ["d"])],
+    )
+
+    report = build_report(current, backup)
+    rendered = render_markdown(report)
+
+    assert report["current"]["run_manifest"]["embedding_model_id"] == "[redacted-local-path]"
+    assert report["backup"]["run_manifest"]["embedding_model_id"] == "[redacted-local-path]"
+    assert "/Users/hskim" not in str(report)
+    assert "data/private/model.bin" not in str(report)
+    assert "/Users/hskim" not in rendered
+    assert "data/private/model.bin" not in rendered

--- a/tests/test_run_manifest_versioning_regression.py
+++ b/tests/test_run_manifest_versioning_regression.py
@@ -99,5 +99,30 @@ class RunManifestVersioningTest(unittest.TestCase):
         self.assertFalse(manifest["privacy"]["exact_local_paths_committed"])
 
 
+    def test_retrieval_provenance_fields_from_run_config(self) -> None:
+        manifest = compute_run_manifest(
+            CONFIG_PATH,
+            {"chunks": []},
+            run_config={
+                "retrieval_backend": "hybrid",
+                "retrieval_mode": "parent_section",
+                "top_k": 8,
+                "rerank": False,
+                "rrf_k": 60,
+                "bm25_backend": "okapi",
+                "bm25_tokenizer": "regex",
+                "bm25_stopword_profile": "shared",
+            },
+        )
+
+        self.assertEqual(manifest["retrieval_backend"], "hybrid")
+        self.assertEqual(manifest["retrieval_mode"], "parent_section")
+        self.assertEqual(manifest["retrieval_top_k"], 8)
+        self.assertFalse(manifest["retrieval_rerank"])
+        self.assertEqual(manifest["rrf_k"], 60)
+        self.assertEqual(manifest["bm25_backend"], "okapi")
+        self.assertEqual(manifest["bm25_tokenizer"], "regex")
+        self.assertEqual(manifest["bm25_stopword_profile"], "shared")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -424,6 +424,33 @@ class ExtractAggregateTest(unittest.TestCase):
         # The dropped path should not appear anywhere in the serialized output.
         self.assertNotIn("hskim", json.dumps(agg))
 
+
+    def test_run_manifest_preserves_retrieval_provenance_fields(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "run_manifest": {
+                "retrieval_backend": "hybrid",
+                "retrieval_mode": "parent_section",
+                "retrieval_top_k": 8,
+                "retrieval_rerank": False,
+                "rrf_k": 60,
+                "bm25_backend": "okapi",
+                "bm25_tokenizer": "regex",
+                "bm25_stopword_profile": "shared",
+            },
+        }
+
+        manifest = extract_aggregate(summary)["run_manifest"]
+
+        self.assertEqual("hybrid", manifest["retrieval_backend"])
+        self.assertEqual("parent_section", manifest["retrieval_mode"])
+        self.assertEqual(8, manifest["retrieval_top_k"])
+        self.assertFalse(manifest["retrieval_rerank"])
+        self.assertEqual(60, manifest["rrf_k"])
+        self.assertEqual("okapi", manifest["bm25_backend"])
+        self.assertEqual("regex", manifest["bm25_tokenizer"])
+        self.assertEqual("shared", manifest["bm25_stopword_profile"])
+
     def test_run_manifest_redacts_local_embedding_model_path(self) -> None:
         summary = {
             **FULL_SUMMARY,


### PR DESCRIPTION
## 1. Summary
- Adds an aggregate-only T-2026-0076 diagnosis for the `real100_v2` page-aware retrieval collapse.
- Records retrieval provenance fields in future `eval_summary.run_manifest` and preserves them through aggregate sanitization.
- Updates `tasks/queue.md`: T-2026-0076 done; downstream T-2026-0030/0031/0032/0033 blocked pending same-stack page-aware MiniLM retrieval provenance/remeasurement.

## 2. Issue / Scope
Closes #2751.

Scope is diagnostic/provenance/reporting only. No retrieval ranking, reranker, context packing, verifier, answer, ingestion, or baseline behavior changes.

## 3. Tests
- `python3 -m pytest tests/test_diagnose_real100_v2_retrieval_collapse.py tests/test_run_manifest_versioning_regression.py tests/test_run_real_eval_delta.py::ExtractAggregateTest::test_run_manifest_preserves_retrieval_provenance_fields tests/test_eval_metrics.py::RunManifestTest::test_manifest_has_expected_keys -q`
- `make real-eval-v2-guard`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 -m ruff check eval/run_eval.py scripts/diagnose_real100_v2_retrieval_collapse.py scripts/run_real_eval_delta.py tests/test_diagnose_real100_v2_retrieval_collapse.py tests/test_run_manifest_versioning_regression.py tests/test_run_real_eval_delta.py`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0076-real100-v2-retrieval-collapse-diagnosis.md docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md`
- `git diff --check`
- `make check-branch`

## 4. Artifacts / Evidence
- Committed reviewer note: `docs/evaluation/real100_v2-retrieval-collapse-diagnosis.md`.
- Local generated JSON: `reports/real100_v2/retrieval_collapse_diagnosis.aggregate.json` (not committed; ADR 0005 pre-commit boundary keeps ignored `reports/real100_v2` artifacts local unless allowlisted deliberately).
- Diagnosis: `doc_ranking_collapse_not_chunk_id_only`; `baseline_comparability=not_comparable_stack_changed`.
- Aggregate comparison in committed Markdown: current page-aware `doc_hit_at_5=0.106618` vs hashing backup `0.529412`; current `chunk_hit_at_5=0.011029` vs backup `0.375`.

## 5. Eval / Data Boundary
- Private eval surface: `real100_v2` only.
- No legacy `real100`/v1/221/kordoc evidence used.
- Aggregate-only output; no raw case rows, prompts, answers, evidence text, filenames, local paths, doc IDs, chunk IDs, or text previews are committed.
- `claim-audit --from-git` intentionally returns exit 1 for this private-real-eval surface requiring Benchmark Auditor + Privacy Auditor review.

## 6. Risks / Follow-up
- Full private rerun not performed; this PR is diagnostic/provenance/reporting only.
- Downstream optimization tasks must not treat the hashing backup as a comparable MiniLM page-aware baseline.
